### PR TITLE
Allow creating multiple characters at once

### DIFF
--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding=utf8
 
-from pxtest import PXTest
+from pxtest import PXTest, CHARACTER_COST
 
 """
 Runs tests about the basic handling of characters (creating them, transferring
@@ -86,6 +86,23 @@ class CharactersTest (PXTest):
       "andy": {"owner": "andy"},
       "": {"owner": ""},
       u"äöü": {"owner": u"äöü"},
+    })
+
+    self.mainLogger.info ("Multiple creations in one transaction...")
+    data = [
+      {"faction": "r"},
+      {"faction": "g"},
+      {"faction": "b"},
+    ]
+    self.moveWithPayment ("domob", {"nc": data}, 2.5 * CHARACTER_COST)
+    self.generate (1)
+    self.expectPartial ({
+      "adam": {"owner": "adam"},
+      "andy": {"owner": "andy"},
+      "": {"owner": ""},
+      u"äöü": {"owner": u"äöü"},
+      "domob": {"faction": "r"},
+      "domob 2": {"faction": "g"},
     })
 
     self.testReorg ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -125,7 +125,7 @@ class PXTest (XayaGameTest):
       "faction": faction,
     }
 
-    return self.moveWithPayment (owner, {"nc": data}, CHARACTER_COST)
+    return self.moveWithPayment (owner, {"nc": [data]}, CHARACTER_COST)
 
   def getCharacters (self):
     """


### PR DESCRIPTION
This modifies the "create character" move so that the `nc` value should be an array of objects instead of a single object.  If there are multiple entries, then all of them are processed, so that a single transaction / name_update can create multiple characters (if enough developer payment is attached).