### PR TITLE
Track pending prospecting moves

### DIFF
--- a/src/logic.hpp
+++ b/src/logic.hpp
@@ -123,6 +123,16 @@ public:
   PXLogic (const PXLogic&) = delete;
   void operator= (const PXLogic&) = delete;
 
+  /**
+   * Gives access to the underlying BaseMap instance (so that it can be reused
+   * for other parts of the game like pending processing).
+   */
+  const BaseMap&
+  GetBaseMap ()
+  {
+    return map;
+  }
+
 };
 
 } // namespace pxd

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -182,7 +182,7 @@ PendingMoves::AddPendingMove (const Json::Value& mv)
 
   const Params params(GetChain ());
 
-  PendingStateUpdater updater(dbObj, state, params);
+  PendingStateUpdater updater(dbObj, state, params, rules.GetBaseMap ());
   updater.ProcessMove (mv);
 }
 

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -191,6 +191,10 @@ void
 PendingStateUpdater::PerformCharacterUpdate (Character& c,
                                              const Json::Value& upd)
 {
+  Database::IdT regionId;
+  if (ParseCharacterProspecting (c, upd, regionId))
+    state.AddCharacterProspecting (c, regionId);
+
   std::vector<HexCoord> wp;
   if (ParseCharacterWaypoints (c, upd, wp))
     {

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -26,6 +26,7 @@
 #include "database/database.hpp"
 #include "database/faction.hpp"
 #include "hexagonal/coord.hpp"
+#include "mapdata/basemap.hpp"
 
 #include <xayagame/sqlitegame.hpp>
 
@@ -146,8 +147,9 @@ protected:
 
 public:
 
-  explicit PendingStateUpdater (Database& d, PendingState& s, const Params& p)
-    : BaseMoveProcessor(d, p), state(s)
+  explicit PendingStateUpdater (Database& d, PendingState& s,
+                                const Params& p, const BaseMap& m)
+    : BaseMoveProcessor(d, p, m), state(s)
   {}
 
   /**

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -64,6 +64,12 @@ private:
     std::unique_ptr<std::vector<HexCoord>> wp;
 
     /**
+     * The ID of the region this character is starting to prospect.  Set to
+     * RegionMap::OUT_OF_MAP if no prospection is coming.
+     */
+    Database::IdT prospectingRegionId = RegionMap::OUT_OF_MAP;
+
+    /**
      * Returns the JSON representation of the pending state.
      */
     Json::Value ToJson () const;
@@ -96,6 +102,13 @@ private:
   /** Pending creations of new characters (by account name).  */
   std::map<std::string, std::vector<NewCharacter>> newCharacters;
 
+  /**
+   * Returns the pending character state for the given instance, creating one
+   * if we do not have it yet.  The reference follows iterator-invalidation
+   * rules for "characters".
+   */
+  CharacterState& GetCharacterState (const Character& c);
+
 public:
 
   PendingState () = default;
@@ -111,9 +124,21 @@ public:
 
   /**
    * Updates the state for waypoints found for a character in a pending move.
+   *
+   * If the character is already pending to start prospecting, then this
+   * will do nothing as a prospecting character cannot move.
    */
   void AddCharacterWaypoints (const Character& ch,
                               const std::vector<HexCoord>& wp);
+
+  /**
+   * Updates the state of a character to include a pending prospecting
+   * for the given region.
+   *
+   * A character that prospects can't move, so this will unset the pending
+   * waypoints for it (if any).
+   */
+  void AddCharacterProspecting (const Character& ch, Database::IdT regionId);
 
   /**
    * Updates the state for a new pending character creation.

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -147,6 +147,73 @@ TEST_F (PendingStateTests, Waypoints)
   )");
 }
 
+TEST_F (PendingStateTests, Prospecting)
+{
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 1);
+
+  state.AddCharacterProspecting (*c, 12345);
+  state.AddCharacterProspecting (*c, 12345);
+  EXPECT_DEATH (state.AddCharacterProspecting (*c, 999), "another region");
+
+  c.reset ();
+
+  ExpectStateJson (R"(
+    {
+      "characters":
+        [
+          {
+            "id": 1,
+            "prospecting": 12345
+          }
+        ]
+    }
+  )");
+}
+
+TEST_F (PendingStateTests, ProspectingAndWaypoints)
+{
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 1);
+
+  state.AddCharacterProspecting (*c, 12345);
+  state.AddCharacterWaypoints (*c, {});
+
+  c.reset ();
+  ExpectStateJson (R"(
+    {
+      "characters":
+        [
+          {
+            "id": 1,
+            "prospecting": 12345,
+            "waypoints": null
+          }
+        ]
+    }
+  )");
+
+  c = characters.GetById (1);
+
+  state.Clear ();
+  state.AddCharacterWaypoints (*c, {});
+  state.AddCharacterProspecting (*c, 12345);
+
+  c.reset ();
+  ExpectStateJson (R"(
+    {
+      "characters":
+        [
+          {
+            "id": 1,
+            "prospecting": 12345,
+            "waypoints": null
+          }
+        ]
+    }
+  )");
+}
+
 TEST_F (PendingStateTests, CharacterCreation)
 {
   state.AddCharacterCreation ("foo", Faction::RED);

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -181,6 +181,7 @@ class PendingStateUpdaterTests : public PendingStateTests
 protected:
 
   const Params params;
+  const BaseMap map;
 
 private:
 
@@ -189,7 +190,7 @@ private:
 protected:
 
   PendingStateUpdaterTests ()
-    : params(xaya::Chain::MAIN), updater(db, state, params)
+    : params(xaya::Chain::MAIN), updater(db, state, params, map)
   {}
 
   /**

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -410,6 +410,38 @@ TEST_F (PendingStateUpdaterTests, Waypoints)
   )");
 }
 
+TEST_F (PendingStateUpdaterTests, Prospecting)
+{
+  const HexCoord pos(456, -789);
+  auto h = characters.CreateNew ("domob", Faction::RED);
+  ASSERT_EQ (h->GetId (), 1);
+  h->SetPosition (pos);
+  h.reset ();
+
+  h = characters.CreateNew ("domob", Faction::GREEN);
+  ASSERT_EQ (h->GetId (), 2);
+  h->SetBusy (10);
+  h->MutableProto ().mutable_prospection ();
+  h.reset ();
+
+  Process ("domob", R"({
+    "c":
+      {
+        "1": {"prospect": {}},
+        "2": {"prospect": {}}
+      }
+  })");
+
+  ExpectStateJson (R"(
+    {
+      "characters":
+        [
+          {"id": 1, "prospecting": 345820}
+        ]
+    }
+  )");
+}
+
 TEST_F (PendingStateUpdaterTests, CreationAndUpdateTogether)
 {
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);


### PR DESCRIPTION
This extends #19 so that also prospecting commands are tracked as pending moves for characters.  In the pending state, we add `"prospecting": regionid` in case a character will start prospecting.

Note that prospecting characters cannot move, so prospecting commands overrule waypoints in the pending state.