### PR TITLE
Bump character cost to 50 CHI

### DIFF
--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -44,7 +44,7 @@ class CharactersTest (PXTest):
       c.expectPartial (expected[nm])
 
   def run (self):
-    self.generate (101);
+    self.collectPremine ()
 
     self.mainLogger.info ("Creating first character...")
     self.createCharacter ("adam", "r")
@@ -136,7 +136,7 @@ class CharactersTest (PXTest):
     blk = self.rpc.xaya.getblockhash (1)
     self.rpc.xaya.invalidateblock (blk)
 
-    self.generate (101)
+    self.collectPremine ()
     self.createCharacter ("domob", "b")
     self.generate (1)
     self.expectPartial ({

--- a/gametest/combat_damage.py
+++ b/gametest/combat_damage.py
@@ -43,7 +43,7 @@ class CombatDamageTest (PXTest):
     return hp["current"], hp["max"]
 
   def run (self):
-    self.generate (110);
+    self.collectPremine ()
 
     numAttackers = 5
 

--- a/gametest/combat_targets.py
+++ b/gametest/combat_targets.py
@@ -52,7 +52,7 @@ class CombatTargetTest (PXTest):
     raise AssertionError ("Character with id %d not found" % charId)
 
   def run (self):
-    self.generate (101);
+    self.collectPremine ()
 
     self.mainLogger.info ("Creating test characters...")
     self.createCharacter ("a", "r")

--- a/gametest/damage_lists.py
+++ b/gametest/damage_lists.py
@@ -51,7 +51,7 @@ class DamageListsTest (PXTest):
     self.assertEqual (self.getAttackers (name), set (expectedIds))
 
   def run (self):
-    self.generate (110);
+    self.collectPremine ()
 
     self.mainLogger.info ("Creating test characters...")
     self.createCharacter ("target", "b")

--- a/gametest/fame.py
+++ b/gametest/fame.py
@@ -26,7 +26,7 @@ Tests the fame and kills update of accounts.
 class FameTest (PXTest):
 
   def run (self):
-    self.generate (110);
+    self.collectPremine ()
 
     self.mainLogger.info ("Characters killing each other at the same time...")
     self.createCharacter ("foo", "r")

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -26,7 +26,7 @@ Tests the god-mode commands.
 class GodModeTest (PXTest):
 
   def run (self):
-    self.generate (101);
+    self.collectPremine ()
 
     self.createCharacter ("domob", "r")
     self.generate (1)

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -87,7 +87,7 @@ class MovementTest (PXTest):
     assert mv is None
 
   def run (self):
-    self.generate (101);
+    self.collectPremine ()
 
     self.mainLogger.info ("Creating test character...")
     self.createCharacter ("domob", "r")

--- a/gametest/multiupdate.py
+++ b/gametest/multiupdate.py
@@ -26,7 +26,7 @@ Tests that Taurion works fine with multiple name updates in a single block.
 class MultiUpdateTest (PXTest):
 
   def run (self):
-    self.generate (101);
+    self.collectPremine ()
 
     self.mainLogger.info ("Creating test character...")
     self.createCharacter ("domob", "r")

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -37,7 +37,7 @@ def sleepSome ():
 class PendingTest (PXTest):
 
   def run (self):
-    self.generate (101);
+    self.collectPremine ()
 
     # Some well-defined position that we use, which also reflects the
     # region that will be prospected.

--- a/gametest/prospecting.py
+++ b/gametest/prospecting.py
@@ -39,7 +39,15 @@ class ProspectingTest (PXTest):
     self.assertEqual (data, {"name": name})
 
   def run (self):
-    self.generate (110);
+    self.collectPremine ()
+
+    # Somehow the test fails with the reorgs if we start off with just
+    # a single output of coins.  Thus split it up.
+    sendTo = {}
+    for _ in range (100):
+      sendTo[self.rpc.xaya.getnewaddress ()] = 1000
+    self.rpc.xaya.sendmany ("", sendTo)
+    self.generate (1)
 
     self.mainLogger.info ("Setting up test characters...")
     self.createCharacter ("target", "r")
@@ -203,6 +211,7 @@ class ProspectingTest (PXTest):
         stillNeedSilver = False
 
       self.rpc.xaya.invalidateblock (blk)
+      self.assertEqual (self.rpc.xaya.name_pending ("p/prize trier"), [])
 
     # Restore the last randomised attempt.  Else we might end up with
     # a long invalid chain, which can confuse the reorg test.

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -22,7 +22,7 @@ import os.path
 
 GAMEID = "tn"
 DEVADDR = "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p"
-CHARACTER_COST = 5
+CHARACTER_COST = 50
 
 
 def offsetCoord (c, offs, inverse):

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -45,7 +45,7 @@ Params::DeveloperAddress () const
 Amount
 Params::CharacterCost () const
 {
-  return 5 * COIN;
+  return 50 * COIN;
 }
 
 HexCoord::IntT


### PR DESCRIPTION
This updates the cost of a character to 50 CHI in preparation for the tech demo competition.  This will hopefully help to deter flooding by bots.  Since we give out free entry packs to non-bot players, this doesn't matter (and even for real people wishing to play without a free pack, that's still not a lot of money unless they want to have thousands of characters).

Also includes an update to the test framework to use the premine coins rather than mining blocks to get required funds, which is more robust and allows the tests to work with the higher costs now.