### PR TITLE
Define extra prizes for the competition and update spawn locations

### DIFF
--- a/contrib/competition/findOdds.m
+++ b/contrib/competition/findOdds.m
@@ -1,0 +1,51 @@
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# GNU Octave script that computes the probability p we need in a binomial
+# distribution if we want 90% chance of at least n "successes" with 150k trials.
+# This defines the odds we put for the extra prizes in the Taurion competition.
+
+clear ("all");
+pkg load statistics;
+
+n = 150e3;
+targetChance = 0.9;
+
+prizes = {
+  {"shr", 60},
+  {"spirit clash", 730},
+  {"dio", 50},
+  {"1up", 20},
+  {"battle racers", 3},
+  {"divi", 20},
+  {"dft", 50},
+  {"9la necklace", 30},
+  {"9la miner", 10},
+  {"9la yellow", 10},
+  {"9la horned", 10},
+  {"snails", 20},
+};
+
+for i = 1 : length (prizes)
+  % binocdf(x, n, p) gives the chance of having <= x prizes found
+  % with n trials and probability p.  We want to get the chance of >= x,
+  % so we need 1 - binocdf(x-1, n, p).
+  getChanceDiff = @(p) (1 - binocdf (prizes{i}{2} - 1, n, p)) - targetChance;
+
+  p = fzero (getChanceDiff, [0, 1]);
+  invChance = 1 / p;
+  printf ("%20s: 1 / %.0f\n", prizes{i}{1}, invChance);
+endfor

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -81,6 +81,22 @@ const std::vector<Params::PrizeData> PRIZES =
     {"gold", 5, 150000},
     {"silver", 50, 4000},
     {"bronze", 2000, 100},
+
+    /* The odds for the extra pizes are chosen so that we expect a 90%
+       probability to find all of them with 150k trials.  This can be computed
+       with the script in contrib/competition/findOdds.m.  */
+    {"shr", 60, 2139},
+    {"spirit clash", 730, 196},
+    {"dio", 50, 2532},
+    {"1up", 20, 5791},
+    {"battle racers", 3, 28184},
+    {"divi", 20, 5791},
+    {"dft", 50, 2532},
+    {"9la necklace", 30, 4033},
+    {"9la miner", 10, 10559},
+    {"9la yellow", 10, 10559},
+    {"9la horned", 10, 10559},
+    {"snails", 20, 5791},
   };
 
 /** Prospecting prizes for regtest (easier to find / exhaust).  */

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -132,13 +132,13 @@ Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
   switch (f)
     {
     case Faction::RED:
-      return HexCoord (-1100, 1042);
+      return HexCoord (1993, -2636);
 
     case Faction::GREEN:
-      return HexCoord (-1042, 1265);
+      return HexCoord (-3430, 1793);
 
     case Faction::BLUE:
-      return HexCoord (-1377, 1263);
+      return HexCoord (-553, 2417);
 
     default:
       LOG (FATAL) << "Invalid faction: " << static_cast<int> (f);

--- a/src/spawn_tests.cpp
+++ b/src/spawn_tests.cpp
@@ -136,9 +136,9 @@ protected:
 
 TEST_F (SpawnLocationTests, SpawnLocation)
 {
-  /* Faction blue has a spawn area without obstacles.  This simplifies things
+  /* Faction red has a spawn area without obstacles.  This simplifies things
      a lot for this test, as we do not have to consider displaced spawns.  */
-  constexpr Faction f = Faction::BLUE;
+  constexpr Faction f = Faction::RED;
 
   HexCoord::IntT spawnRadius;
   const HexCoord spawnCentre = params.SpawnArea (f, spawnRadius);
@@ -173,10 +173,10 @@ TEST_F (SpawnLocationTests, SpawnLocation)
 
 TEST_F (SpawnLocationTests, WithObstacles)
 {
-  /* Faction red has a significant amount of obstacles in the spawning area,
+  /* Faction blue has a significant amount of obstacles in the spawning area,
      including on the ring boundary.  Thus we can use it to test that map
      obstacles are fine.  */
-  constexpr Faction f = Faction::RED;
+  constexpr Faction f = Faction::BLUE;
 
   HexCoord::IntT spawnRadius;
   const HexCoord spawnCentre = params.SpawnArea (f, spawnRadius);
@@ -204,10 +204,10 @@ TEST_F (SpawnLocationTests, WithObstacles)
 
 TEST_F (SpawnLocationTests, DynObstacles)
 {
-  /* Faction blue has no obstacles on the basemap in the spawn area, so by
+  /* Faction red has no obstacles on the basemap in the spawn area, so by
      choosing this faction, we will be able to really fill up the entire
      area of the spawn with vehicles.  */
-  constexpr Faction f = Faction::BLUE;
+  constexpr Faction f = Faction::RED;
 
   HexCoord::IntT spawnRadius;
   const HexCoord spawnCentre = params.SpawnArea (f, spawnRadius);


### PR DESCRIPTION
In preparation for the demo competition, this makes the spawn locations further apart (so there is less initial conflict) and adds the extra prizes for mainnet.