### PR TITLE
Optimise construction of DynTiles

### DIFF
--- a/mapdata/Makefile.am
+++ b/mapdata/Makefile.am
@@ -59,6 +59,7 @@ benchmarks_LDADD = \
   $(top_builddir)/hexagonal/libhexagonal.la \
   $(GLOG_LIBS) $(BENCHMARK_LIBS)
 benchmarks_SOURCES = \
+  dyntiles_bench.cpp \
   regionmap_bench.cpp
 
 procmap_CXXFLAGS = \

--- a/mapdata/dyntiles_bench.cpp
+++ b/mapdata/dyntiles_bench.cpp
@@ -1,0 +1,178 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "dyntiles.hpp"
+
+#include "tiledata.hpp"
+
+#include "hexagonal/coord.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <glog/logging.h>
+
+#include <cstdlib>
+#include <vector>
+
+namespace pxd
+{
+namespace
+{
+
+/**
+ * Returns a hex coordinate on the map chosen (mostly) randomly.
+ */
+HexCoord
+RandomCoord ()
+{
+  using namespace tiledata;
+
+  const int y = minY + std::rand () % (maxY - minY + 1);
+  const int yInd = y - minY;
+  const int x = minX[yInd] + std::rand () % (maxX[yInd] - minX[yInd] + 1);
+
+  return HexCoord (x, y);
+}
+
+/**
+ * Constructs a vector of n "random" coordinates.
+ */
+std::vector<HexCoord>
+RandomCoords (const unsigned n)
+{
+  std::vector<HexCoord> res;
+  res.reserve (n);
+
+  for (unsigned i = 0; i < n; ++i)
+    res.push_back (RandomCoord ());
+
+  return res;
+}
+
+/**
+ * Benchmarks the construction of an empty DynTiles<bool> instance with
+ * no further access.
+ */
+void
+DynTilesBoolConstruction (benchmark::State& state)
+{
+  for (auto _ : state)
+    {
+      DynTiles<bool> dyn(false);
+    }
+}
+BENCHMARK (DynTilesBoolConstruction)
+  ->Unit (benchmark::kMicrosecond);
+
+/**
+ * Benchmarks updates in a DynTiles<bool> instance.  Takes one argument,
+ * the number of random coordinates to update.  Each coordinate is changed
+ * from the default false to true and then back to false in a later step.
+ */
+void
+DynTilesBoolDoubleUpdate (benchmark::State& state)
+{
+  const unsigned n = state.range (0);
+  std::srand (42);
+  const auto coords = RandomCoords (n);
+
+  for (auto _ : state)
+    {
+      state.PauseTiming ();
+      DynTiles<bool> dyn(false);
+      state.ResumeTiming ();
+
+      for (const auto& c : coords)
+        dyn.Access (c) = true;
+      for (const auto& c : coords)
+        dyn.Access (c) = false;
+    }
+}
+BENCHMARK (DynTilesBoolDoubleUpdate)
+  ->Unit (benchmark::kMillisecond)
+  ->Arg (100000)
+  ->Arg (1000000);
+
+/**
+ * Benchmarks reads of uninitialised (default) values from a DynTiles<bool>
+ * instance.  Takes two arguments:  The number of random coordinates to look
+ * at, and the number of reads for each of them.
+ */
+void
+DynTilesBoolReadDefault (benchmark::State& state)
+{
+  const unsigned n = state.range (0);
+  const unsigned rounds = state.range (1);
+
+  std::srand (42);
+  const auto coords = RandomCoords (n);
+
+  for (auto _ : state)
+    {
+      state.PauseTiming ();
+      DynTiles<bool> dyn(false);
+      state.ResumeTiming ();
+
+      for (unsigned t = 0; t < rounds; ++t)
+        for (const auto& c : coords)
+          CHECK (!dyn.Access (c));
+    }
+}
+BENCHMARK (DynTilesBoolReadDefault)
+  ->Unit (benchmark::kMillisecond)
+  ->Args ({1000, 100})
+  ->Args ({1000, 1000})
+  ->Args ({10000, 100})
+  ->Args ({10000, 1000});
+
+/**
+ * Benchmarks reads of initialised (non-default) values from a DynTiles<bool>
+ * instance.  Takes two arguments:  The number of random coordinates to look
+ * at, and the number of reads for each of them.
+ */
+void
+DynTilesBoolReadInitialised (benchmark::State& state)
+{
+  const unsigned n = state.range (0);
+  const unsigned rounds = state.range (1);
+
+  std::srand (42);
+  const auto coords = RandomCoords (n);
+
+  for (auto _ : state)
+    {
+      state.PauseTiming ();
+      DynTiles<bool> dyn(false);
+      for (const auto& c : coords)
+        dyn.Access (c) = true;
+      state.ResumeTiming ();
+
+      for (unsigned t = 0; t < rounds; ++t)
+        for (const auto& c : coords)
+          CHECK (dyn.Access (c));
+    }
+}
+BENCHMARK (DynTilesBoolReadInitialised)
+  ->Unit (benchmark::kMillisecond)
+  ->Args ({1000, 100})
+  ->Args ({1000, 1000})
+  ->Args ({10000, 100})
+  ->Args ({10000, 1000});
+
+} // anonymous namespace
+} // namespace pxd

--- a/mapdata/procmap.cpp
+++ b/mapdata/procmap.cpp
@@ -218,7 +218,9 @@ public:
     out << "}; // offsetForY" << std::endl;
     out << "CHECK_YARRAY_LEN (offsetForY);" << std::endl;
 
-    out << "const size_t numTiles = " << numTiles << ";" << std::endl;
+    out << "static_assert (numTiles == " << numTiles << R"(,
+      "mismatch for numTiles between hardcoded value and map data");
+    )" << std::endl;
   }
 
   friend bool

--- a/mapdata/tiledata.hpp
+++ b/mapdata/tiledata.hpp
@@ -47,8 +47,13 @@ extern const int maxX[];
  */
 extern const size_t offsetForY[];
 
-/** Total number of tiles.  */
-extern const size_t numTiles;
+/**
+ * Total number of tiles.  Unlike the other data, this is specified here so
+ * that it can be constexpr and used e.g. as template parameters for
+ * std::array.  It is only checked against the actual data from the raw
+ * map files using static_assert.
+ */
+constexpr size_t numTiles = 66080641;
 
 namespace obstacles
 {


### PR DESCRIPTION
This optimises the construction of `DynTiles`, which was is taking almost all the time (just filling memory with zeros) syncing Taurion with empty map.  Instead of always using a full `std::vector<bool>` for all map tiles, we use a vector of bitsets and only initialise those "buckets" that are actually updated from all-default values.

This reduces the construction time according to the benchmark massively from 2086us to 1.38us, while only increasing times of other operations moderately by 30-50% in the benchmark cases.  (And in any case, these times are irrelevant unless we have millions of players on the map and the bottlenecks will be elsewhere.)

With this, the typical full processing time per block while syncing (with a mostly empty map) for me reduces from 12ms to 150us.  The profile of syncing time afterwards looks a lot more balanced; still `DynObstacles` takes almost all time, but mostly in querying the database for vehicles rather than just filling memory with zeros.