### PR TITLE
Stop giving out prizes after competition end

### DIFF
--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -53,7 +53,7 @@ namespace
  */
 void
 ProcessBusy (Database& db, xaya::Random& rnd,
-             const Params& params, const BaseMap& map)
+             const int64_t timestamp, const Params& params, const BaseMap& map)
 {
   CharacterTable characters(db);
   RegionsTable regions(db);
@@ -66,7 +66,7 @@ ProcessBusy (Database& db, xaya::Random& rnd,
       switch (c->GetProto ().busy_case ())
         {
         case proto::Character::kProspection:
-          FinishProspecting (*c, db, regions, rnd, params, map);
+          FinishProspecting (*c, db, regions, rnd, timestamp, params, map);
           break;
 
         default:
@@ -102,10 +102,16 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
                       const Params& params, const BaseMap& map,
                       const Json::Value& blockData)
 {
+  const auto& block = blockData["block"];
+  CHECK (block.isObject ());
+  const auto& timestampVal = block["timestamp"];
+  CHECK (timestampVal.isInt64 ());
+  const int64_t timestamp = timestampVal.asInt64 ();
+
   fame.GetDamageLists ().RemoveOld (params.DamageListBlocks ());
 
   AllHpUpdates (db, fame, rnd, map);
-  ProcessBusy (db, rnd, params, map);
+  ProcessBusy (db, rnd, timestamp, params, map);
 
   DynObstacles dyn(db);
   MoveProcessor mvProc(db, dyn, rnd, params, map);

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -81,6 +81,7 @@ protected:
 
     Json::Value meta(Json::objectValue);
     meta["height"] = 42;
+    meta["timestamp"] = 1500000000;
     blockData["block"] = meta;
 
     std::istringstream in(movesStr);

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -72,6 +72,13 @@ Params::ProspectingBlocks () const
   return 10;
 }
 
+int64_t
+Params::CompetitionEndTime () const
+{
+  /* 2019-10-15, 14:00 UTC */
+  return 1571148000;
+}
+
 namespace
 {
 

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -113,6 +113,11 @@ public:
   unsigned ProspectingBlocks () const;
 
   /**
+   * UNIX timestamp of the end time when prospecting prizes are given out.
+   */
+  int64_t CompetitionEndTime () const;
+
+  /**
    * Returns the ordered list of available prizes for prospecting in the
    * demo competition.
    */

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -41,7 +41,8 @@ InitialisePrizes (Database& db, const Params& params)
 void
 FinishProspecting (Character& c, Database& db, RegionsTable& regions,
                    xaya::Random& rnd,
-                   const Params& params, const BaseMap& map)
+                   const int64_t timestamp, const Params& params,
+                   const BaseMap& map)
 {
   const auto& pos = c.GetPosition ();
   const auto regionId = map.Regions ().GetRegionId (pos);
@@ -63,6 +64,12 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
   CHECK (!mpb.has_prospection ());
   auto* prosp = mpb.mutable_prospection ();
   prosp->set_name (c.GetOwner ());
+
+  if (timestamp > params.CompetitionEndTime ())
+    {
+      LOG (INFO) << "Competition is over, no prizes can be found";
+      return;
+    }
 
   /* Check the prizes in order to see if we won any.  */
   CHECK (!prosp->has_prize ());

--- a/src/prospecting.hpp
+++ b/src/prospecting.hpp
@@ -38,11 +38,14 @@ namespace pxd
 void InitialisePrizes (Database& db, const Params& params);
 
 /**
- * Finishes a done prospecting operation by the given character.
+ * Finishes a done prospecting operation by the given character.  If the
+ * competition is still active (not yet past the end time), then also
+ * prizes can be won.
  */
 void FinishProspecting (Character& c, Database& db, RegionsTable& regions,
                         xaya::Random& rnd,
-                        const Params& params, const BaseMap& map);
+                        int64_t timestamp, const Params& params,
+                        const BaseMap& map);
 
 } // namespace pxd
 


### PR DESCRIPTION
This introduces the official end time of the tech demo competition (at UNIX timestamp 1571148000) and stops giving out prizes in blocks that are beyond that timestamp.

Note that this causes a hard fork of the game logic:  Because we stop giving out prizes, we also try fewer random numbers, and thus alter the entire sequence of random numbers.  In any case, the fork only applies at the competition end, so it won't matter for the competition itself.

This implements #25.