### PR TITLE
Add getnullstate RPC method

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -12,6 +12,7 @@ REGTESTS = \
   godmode.py \
   movement.py \
   multiupdate.py \
+  nullstate.py \
   pending.py \
   prospecting.py
 

--- a/gametest/nullstate.py
+++ b/gametest/nullstate.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests that getnullstate works (very roughly).
+"""
+
+from pxtest import PXTest, offsetCoord
+
+
+class NullstateTest (PXTest):
+
+  def run (self):
+    self.generate (10)
+
+    self.assertEqual (self.getCustomState ("data", "getnullstate"), None)
+
+    res = self.rpc.game.getnullstate ()
+    self.assertEqual (res["state"], "up-to-date")
+    self.assertEqual (res["chain"], "regtest")
+    self.assertEqual (res["height"], self.rpc.xaya.getblockcount ())
+    self.assertEqual (res["blockhash"], self.rpc.xaya.getbestblockhash ())
+
+
+if __name__ == "__main__":
+  NullstateTest ().main ()

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -99,6 +99,17 @@ PXRpcServer::getcurrentstate ()
 }
 
 Json::Value
+PXRpcServer::getnullstate ()
+{
+  LOG (INFO) << "RPC method called: getnullstate";
+  return logic.GetCustomStateData (game, "data",
+    [] (sqlite3* db)
+      {
+        return Json::Value ();
+      });
+}
+
+Json::Value
 PXRpcServer::getpendingstate ()
 {
   LOG (INFO) << "RPC method called: getpendingstate";

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -56,6 +56,7 @@ public:
 
   void stop () override;
   Json::Value getcurrentstate () override;
+  Json::Value getnullstate () override;
   Json::Value getpendingstate () override;
   std::string waitforchange (const std::string& knownBlock) override;
   Json::Value waitforpendingchange (int oldVersion) override;

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -9,6 +9,11 @@
     "returns": {}
   },
   {
+    "name": "getnullstate",
+    "params": {},
+    "returns": {}
+  },
+  {
     "name": "getpendingstate",
     "params": {},
     "returns": {}


### PR DESCRIPTION
The new `getnullstate` RPC method just returns JSON null as payload data, but in addition also the current syncing state and other default stuff from libxayagame.  This makes it useful for checking if the GSP is synced up, without the need to retrieve any other (potentially expensive) data from it.