### PR TITLE
Typed DB results and use IDs instead of names to access columns

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -27,8 +27,8 @@ noinst_HEADERS = \
   account.hpp \
   character.hpp \
   damagelists.hpp \
-  database.hpp \
-  faction.hpp \
+  database.hpp database.tpp \
+  faction.hpp faction.tpp \
   fighter.hpp \
   prizes.hpp \
   region.hpp \

--- a/database/account.cpp
+++ b/database/account.cpp
@@ -32,9 +32,9 @@ Account::Account (Database& d, const std::string& n)
 Account::Account (Database& d, const Database::Result<AccountResult>& res)
   : db(d), dirty(false)
 {
-  name = res.Get<std::string> ("name");
-  kills = res.Get<int64_t> ("kills");
-  fame = res.Get<int64_t> ("fame");
+  name = res.Get<AccountResult::name> ();
+  kills = res.Get<AccountResult::kills> ();
+  fame = res.Get<AccountResult::fame> ();
 
   VLOG (1) << "Created account instance for " << name << " from database";
 }

--- a/database/account.cpp
+++ b/database/account.cpp
@@ -29,10 +29,9 @@ Account::Account (Database& d, const std::string& n)
   VLOG (1) << "Created instance for empty account of Xaya name " << name;
 }
 
-Account::Account (Database& d, const Database::Result& res)
+Account::Account (Database& d, const Database::Result<AccountResult>& res)
   : db(d), dirty(false)
 {
-  CHECK_EQ (res.GetName (), "accounts");
   name = res.Get<std::string> ("name");
   kills = res.Get<int64_t> ("kills");
   fame = res.Get<int64_t> ("fame");
@@ -63,7 +62,7 @@ Account::~Account ()
 }
 
 AccountsTable::Handle
-AccountsTable::GetFromResult (const Database::Result& res)
+AccountsTable::GetFromResult (const Database::Result<AccountResult>& res)
 {
   return Handle (new Account (db, res));
 }
@@ -73,7 +72,7 @@ AccountsTable::GetByName (const std::string& name)
 {
   auto stmt = db.Prepare ("SELECT * FROM `accounts` WHERE `name` = ?1");
   stmt.Bind (1, name);
-  auto res = stmt.Query ("accounts");
+  auto res = stmt.Query<AccountResult> ();
 
   if (!res.Step ())
     return Handle (new Account (db, name));
@@ -83,11 +82,11 @@ AccountsTable::GetByName (const std::string& name)
   return r;
 }
 
-Database::Result
+Database::Result<AccountResult>
 AccountsTable::QueryNonTrivial ()
 {
   auto stmt = db.Prepare ("SELECT * FROM `accounts` ORDER BY `name`");
-  return stmt.Query ("accounts");
+  return stmt.Query<AccountResult> ();
 }
 
 } // namespace pxd

--- a/database/account.hpp
+++ b/database/account.hpp
@@ -30,7 +30,7 @@ namespace pxd
 /**
  * Database result type for rows from the accounts table.
  */
-class AccountResult
+class AccountResult : public Database::ResultType
 {};
 
 /**

--- a/database/account.hpp
+++ b/database/account.hpp
@@ -30,8 +30,12 @@ namespace pxd
 /**
  * Database result type for rows from the accounts table.
  */
-class AccountResult : public Database::ResultType
-{};
+struct AccountResult : public Database::ResultType
+{
+  RESULT_COLUMN (std::string, name, 1);
+  RESULT_COLUMN (int64_t, kills, 2);
+  RESULT_COLUMN (int64_t, fame, 3);
+};
 
 /**
  * Wrapper class around the state of one Xaya account (name) in the database.

--- a/database/account.hpp
+++ b/database/account.hpp
@@ -28,6 +28,12 @@ namespace pxd
 {
 
 /**
+ * Database result type for rows from the accounts table.
+ */
+class AccountResult
+{};
+
+/**
  * Wrapper class around the state of one Xaya account (name) in the database.
  * Instantiations of this class should be made through the AccountsTable.
  */
@@ -63,7 +69,7 @@ private:
    * Constructs an instance based on the given DB result set.  The result
    * set should be constructed by an AccountsTable.
    */
-  explicit Account (Database& d, const Database::Result& res);
+  explicit Account (Database& d, const Database::Result<AccountResult>& res);
 
   friend class AccountsTable;
 
@@ -143,7 +149,7 @@ public:
   /**
    * Returns a handle for the instance based on a Database::Result.
    */
-  Handle GetFromResult (const Database::Result& res);
+  Handle GetFromResult (const Database::Result<AccountResult>& res);
 
   /**
    * Returns the account with the given name.
@@ -155,7 +161,7 @@ public:
    * data stored.  Returns a result set that can be used together with
    * GetFromResult.
    */
-  Database::Result QueryNonTrivial ();
+  Database::Result<AccountResult> QueryNonTrivial ();
 
 };
 

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -34,10 +34,9 @@ Character::Character (Database& d, const std::string& o, const Faction f)
   Validate ();
 }
 
-Character::Character (Database& d, const Database::Result& res)
+Character::Character (Database& d, const Database::Result<CharacterResult>& res)
   : db(d), dirtyFields(false), dirtyProto(false)
 {
-  CHECK_EQ (res.GetName (), "characters");
   id = res.Get<int64_t> ("id");
   owner = res.Get<std::string> ("owner");
   faction = GetFactionFromColumn (res, "faction");
@@ -146,7 +145,7 @@ CharacterTable::CreateNew (const std::string& owner, const Faction faction)
 }
 
 CharacterTable::Handle
-CharacterTable::GetFromResult (const Database::Result& res)
+CharacterTable::GetFromResult (const Database::Result<CharacterResult>& res)
 {
   return Handle (new Character (db, res));
 }
@@ -156,7 +155,7 @@ CharacterTable::GetById (const Database::IdT id)
 {
   auto stmt = db.Prepare ("SELECT * FROM `characters` WHERE `id` = ?1");
   stmt.Bind (1, id);
-  auto res = stmt.Query ("characters");
+  auto res = stmt.Query<CharacterResult> ();
   if (!res.Step ())
     return nullptr;
 
@@ -165,48 +164,48 @@ CharacterTable::GetById (const Database::IdT id)
   return c;
 }
 
-Database::Result
+Database::Result<CharacterResult>
 CharacterTable::QueryAll ()
 {
   auto stmt = db.Prepare ("SELECT * FROM `characters` ORDER BY `id`");
-  return stmt.Query ("characters");
+  return stmt.Query<CharacterResult> ();
 }
 
-Database::Result
+Database::Result<CharacterResult>
 CharacterTable::QueryForOwner (const std::string& owner)
 {
   auto stmt = db.Prepare (R"(
     SELECT * FROM `characters` WHERE `owner` = ?1 ORDER BY `id`
   )");
   stmt.Bind (1, owner);
-  return stmt.Query ("characters");
+  return stmt.Query<CharacterResult> ();
 }
 
-Database::Result
+Database::Result<CharacterResult>
 CharacterTable::QueryMoving ()
 {
   auto stmt = db.Prepare (R"(
     SELECT * FROM `characters` WHERE `ismoving` ORDER BY `id`
   )");
-  return stmt.Query ("characters");
+  return stmt.Query<CharacterResult> ();
 }
 
-Database::Result
+Database::Result<CharacterResult>
 CharacterTable::QueryWithTarget ()
 {
   auto stmt = db.Prepare (R"(
     SELECT * FROM `characters` WHERE `hastarget` ORDER BY `id`
   )");
-  return stmt.Query ("characters");
+  return stmt.Query<CharacterResult> ();
 }
 
-Database::Result
+Database::Result<CharacterResult>
 CharacterTable::QueryBusyDone ()
 {
   auto stmt = db.Prepare (R"(
     SELECT * FROM `characters` WHERE `busy` = 1 ORDER BY `id`
   )");
-  return stmt.Query ("characters");
+  return stmt.Query<CharacterResult> ();
 }
 
 void
@@ -226,10 +225,13 @@ CharacterTable::DecrementBusy ()
 {
   VLOG (1) << "Decrementing busy counter for all characters...";
 
+  class CountResult
+  {};
+
   auto stmt = db.Prepare (R"(
     SELECT COUNT(*) AS `cnt` FROM `characters` WHERE `busy` = 1
   )");
-  auto res = stmt.Query ();
+  auto res = stmt.Query<CountResult> ();
   CHECK (res.Step ());
   CHECK_EQ (res.Get<int64_t> ("cnt"), 0)
       << "DecrementBusy called but there are characters with busy=1";

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -225,7 +225,7 @@ CharacterTable::DecrementBusy ()
 {
   VLOG (1) << "Decrementing busy counter for all characters...";
 
-  class CountResult
+  class CountResult : public Database::ResultType
   {};
 
   auto stmt = db.Prepare (R"(

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -35,6 +35,12 @@ namespace pxd
 {
 
 /**
+ * Database result type for rows from the characters table.
+ */
+class CharacterResult : public ResultWithFaction
+{};
+
+/**
  * Wrapper class for the state of one character.  This connects the actual game
  * logic (reading the state and doing modifications to it) from the database.
  * All interpretation of database results and upates to the database are done
@@ -99,7 +105,8 @@ private:
    * represents the data from the result row but can then be modified.  The
    * result should come from a query made through CharacterTable.
    */
-  explicit Character (Database& d, const Database::Result& res);
+  explicit Character (Database& d,
+                      const Database::Result<CharacterResult>& res);
 
   /**
    * Binds parameters in a statement to the mutable non-proto fields.  This is
@@ -261,7 +268,7 @@ public:
   /**
    * Returns a handle for the instance based on a Database::Result.
    */
-  Handle GetFromResult (const Database::Result& res);
+  Handle GetFromResult (const Database::Result<CharacterResult>& res);
 
   /**
    * Returns the character with the given ID or a null handle if there is
@@ -273,30 +280,30 @@ public:
    * Queries for all characters in the database table.  The characters are
    * ordered by ID to make the result deterministic.
    */
-  Database::Result QueryAll ();
+  Database::Result<CharacterResult> QueryAll ();
 
   /**
    * Queries for all characters with a given owner, ordered by ID.
    */
-  Database::Result QueryForOwner (const std::string& owner);
+  Database::Result<CharacterResult> QueryForOwner (const std::string& owner);
 
   /**
    * Queries for all characters that are currently moving (and thus may need
    * to be updated for move stepping).
    */
-  Database::Result QueryMoving ();
+  Database::Result<CharacterResult> QueryMoving ();
 
   /**
    * Queries for all characters that have a combat target and thus need
    * to be processed for damage.
    */
-  Database::Result QueryWithTarget ();
+  Database::Result<CharacterResult> QueryWithTarget ();
 
   /**
    * Queries all characters that have busy=1, i.e. need their operation
    * processed and finished next.
    */
-  Database::Result QueryBusyDone ();
+  Database::Result<CharacterResult> QueryBusyDone ();
 
   /**
    * Deletes the character with the given ID.

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -37,8 +37,17 @@ namespace pxd
 /**
  * Database result type for rows from the characters table.
  */
-class CharacterResult : public ResultWithFaction
-{};
+struct CharacterResult : public ResultWithFaction
+{
+  RESULT_COLUMN (int64_t, id, 1);
+  RESULT_COLUMN (std::string, owner, 2);
+  RESULT_COLUMN (int64_t, x, 3);
+  RESULT_COLUMN (int64_t, y, 4);
+  RESULT_COLUMN (pxd::proto::VolatileMovement, volatilemv, 5);
+  RESULT_COLUMN (pxd::proto::HP, hp, 6);
+  RESULT_COLUMN (int64_t, busy, 7);
+  RESULT_COLUMN (pxd::proto::Character, proto, 8);
+};
 
 /**
  * Wrapper class for the state of one character.  This connects the actual game

--- a/database/damagelists.cpp
+++ b/database/damagelists.cpp
@@ -88,7 +88,7 @@ DamageLists::GetAttackers (const Database::IdT victim) const
   )");
   stmt.Bind (1, victim);
 
-  class AttackerResult
+  class AttackerResult : public Database::ResultType
   {};
 
   auto res = stmt.Query<AttackerResult> ();

--- a/database/damagelists.cpp
+++ b/database/damagelists.cpp
@@ -78,6 +78,16 @@ DamageLists::RemoveCharacter (const Database::IdT id)
   stmt.Execute ();
 }
 
+namespace
+{
+
+struct AttackerResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, attacker, 1);
+};
+
+} // anonymous namespace
+
 DamageLists::Attackers
 DamageLists::GetAttackers (const Database::IdT victim) const
 {
@@ -88,14 +98,12 @@ DamageLists::GetAttackers (const Database::IdT victim) const
   )");
   stmt.Bind (1, victim);
 
-  class AttackerResult : public Database::ResultType
-  {};
-
   auto res = stmt.Query<AttackerResult> ();
   Attackers attackers;
   while (res.Step ())
     {
-      const auto insert = attackers.insert (res.Get<int64_t> ("attacker"));
+      const Database::IdT att = res.Get<AttackerResult::attacker> ();
+      const auto insert = attackers.insert (att);
       CHECK (insert.second);
     }
 

--- a/database/damagelists.cpp
+++ b/database/damagelists.cpp
@@ -88,7 +88,10 @@ DamageLists::GetAttackers (const Database::IdT victim) const
   )");
   stmt.Bind (1, victim);
 
-  auto res = stmt.Query ();
+  class AttackerResult
+  {};
+
+  auto res = stmt.Query<AttackerResult> ();
   Attackers attackers;
   while (res.Step ())
     {

--- a/database/database.hpp
+++ b/database/database.hpp
@@ -29,6 +29,7 @@
 
 #include <map>
 #include <string>
+#include <type_traits>
 
 namespace pxd
 {
@@ -63,6 +64,7 @@ public:
 
   template <typename T>
     class Result;
+  class ResultType;
   class Statement;
 
   Database (const Database&) = delete;
@@ -170,6 +172,22 @@ public:
 };
 
 /**
+ * Type specifying a kind of database result (e.g. is this a row of the
+ * characters table?).  This class (or rather, subclasses of it) are used as
+ * template parameter for Result<T>, and they should define appropriate
+ * static methods.  It should not be instantiated.
+ */
+class Database::ResultType
+{
+
+public:
+
+  ResultType () = delete;
+  ResultType (const ResultType&) = delete;
+
+};
+
+/**
  * Wrapper around sqlite3_stmt, but taking care of reading results of a
  * query rather than binding values.  Results are "typed", where the type
  * indicates what kind of row this is (e.g. from the character table or
@@ -180,6 +198,9 @@ template <typename T>
 {
 
 private:
+
+  static_assert (std::is_base_of<ResultType, T>::value,
+                 "Result type has an invalid type");
 
   /** The database this corresponds to.  */
   Database* db;

--- a/database/database.tpp
+++ b/database/database.tpp
@@ -1,0 +1,114 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Template implementation code for database.hpp.  */
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+template <typename T>
+  Database::Result<T>
+  Database::Statement::Query ()
+{
+  CHECK (!run) << "Database statement has already been run";
+  run = true;
+  return Result<T> (*db, stmt);
+}
+
+template <typename T>
+  void
+  Database::Result<T>::BuildColumnMap ()
+{
+  CHECK (columnInd.empty ());
+  const int num = sqlite3_column_count (stmt);
+  for (int i = 0; i < num; ++i)
+    {
+      const std::string name = sqlite3_column_name (stmt, i);
+      columnInd.emplace (name, i);
+    }
+  CHECK_EQ (columnInd.size (), num);
+}
+
+template <typename T>
+  int
+  Database::Result<T>::ColumnIndex (const std::string& name) const
+{
+  CHECK (initialised);
+  const auto mit = columnInd.find (name);
+  CHECK (mit != columnInd.end ())
+      << "Column name not in result set: " << name;
+  return mit->second;
+}
+
+template <typename T>
+  bool
+  Database::Result<T>::Step ()
+{
+  const int rc = sqlite3_step (stmt);
+  if (rc == SQLITE_DONE)
+    return false;
+
+  CHECK_EQ (rc, SQLITE_ROW);
+
+  if (!initialised)
+    {
+      BuildColumnMap ();
+      initialised = true;
+    }
+
+  return true;
+}
+
+namespace internal
+{
+
+/**
+ * Extracts a typed object from the SQLite statement.  This is used internally
+ * to implement Result<T>::Get<C> accordingly.  The actual logic is in
+ * certain specialisations below.
+ */
+template <typename C>
+  C GetColumnValue (sqlite3_stmt* stmt, int index);
+
+} // namespace internal
+
+template <typename T>
+template <typename C>
+  C
+  Database::Result<T>::Get (const std::string& name) const
+{
+  return internal::GetColumnValue<C> (stmt, ColumnIndex (name));
+}
+
+template <typename T>
+  void
+  Database::Result<T>::GetProto (const std::string& name,
+                                 google::protobuf::Message& res) const
+{
+  const int ind = ColumnIndex (name);
+
+  const int len = sqlite3_column_bytes (stmt, ind);
+  const void* bytes = sqlite3_column_blob (stmt, ind);
+
+  const std::string str(static_cast<const char*> (bytes), len);
+  CHECK (res.ParseFromString (str));
+}
+
+} // namespace pxd

--- a/database/database_tests.cpp
+++ b/database/database_tests.cpp
@@ -47,8 +47,13 @@ struct RowData
 /**
  * Database result type for our test table.
  */
-class TestResult : public Database::ResultType
-{};
+struct TestResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, id, 1);
+  RESULT_COLUMN (bool, flag, 2);
+  RESULT_COLUMN (std::string, name, 3);
+  RESULT_COLUMN (pxd::proto::HexCoord, proto, 4);
+};
 
 class DatabaseTests : public DBTestFixture
 {
@@ -83,12 +88,12 @@ protected:
         LOG (INFO) << "Verifying golden data with ID " << val.id << "...";
 
         ASSERT_TRUE (res.Step ());
-        EXPECT_EQ (res.Get<int64_t> ("id"), val.id);
-        EXPECT_EQ (res.Get<bool> ("flag"), val.flag);
-        EXPECT_EQ (res.Get<std::string> ("name"), val.name);
+        EXPECT_EQ (res.Get<TestResult::id> (), val.id);
+        EXPECT_EQ (res.Get<TestResult::flag> (), val.flag);
+        EXPECT_EQ (res.Get<TestResult::name> (), val.name);
 
         proto::HexCoord c;
-        res.GetProto ("proto", c);
+        res.GetProto<TestResult::proto> (c);
         EXPECT_EQ (c.x (), val.coordX);
         EXPECT_EQ (c.y (), val.coordY);
       }
@@ -150,12 +155,12 @@ TEST_F (DatabaseTests, StatementReset)
   auto res = stmt.Query<TestResult> ();
 
   ASSERT_TRUE (res.Step ());
-  EXPECT_EQ (res.Get<int64_t> ("id"), 42);
-  EXPECT_EQ (res.Get<bool> ("flag"), true);
+  EXPECT_EQ (res.Get<TestResult::id> (), 42);
+  EXPECT_EQ (res.Get<TestResult::flag> (), true);
 
   ASSERT_TRUE (res.Step ());
-  EXPECT_EQ (res.Get<int64_t> ("id"), 50);
-  EXPECT_EQ (res.Get<bool> ("flag"), false);
+  EXPECT_EQ (res.Get<TestResult::id> (), 50);
+  EXPECT_EQ (res.Get<TestResult::flag> (), false);
 
   ASSERT_FALSE (res.Step ());
 }
@@ -181,7 +186,7 @@ TEST_F (DatabaseTests, ProtoIsOverwritten)
      just merged with the data we read.  */
   proto::HexCoord protoRes;
   protoRes.set_y (42);
-  res.GetProto ("proto", protoRes);
+  res.GetProto<TestResult::proto> (protoRes);
   EXPECT_EQ (protoRes.x (), coord.x ());
   EXPECT_FALSE (protoRes.has_y ());
 

--- a/database/database_tests.cpp
+++ b/database/database_tests.cpp
@@ -47,7 +47,7 @@ struct RowData
 /**
  * Database result type for our test table.
  */
-class TestResult
+class TestResult : public Database::ResultType
 {};
 
 class DatabaseTests : public DBTestFixture

--- a/database/database_tests.cpp
+++ b/database/database_tests.cpp
@@ -44,6 +44,12 @@ struct RowData
   int coordY;
 };
 
+/**
+ * Database result type for our test table.
+ */
+class TestResult
+{};
+
 class DatabaseTests : public DBTestFixture
 {
 
@@ -71,7 +77,7 @@ protected:
     auto stmt = db.Prepare (R"(
       SELECT * FROM `test` ORDER BY `id` ASC
     )");
-    auto res = stmt.Query ();
+    auto res = stmt.Query<TestResult> ();
     for (const auto& val : golden)
       {
         LOG (INFO) << "Verifying golden data with ID " << val.id << "...";
@@ -141,7 +147,7 @@ TEST_F (DatabaseTests, StatementReset)
   stmt.Execute ();
 
   stmt = db.Prepare ("SELECT `id`, `flag` FROM `test` ORDER BY `id`");
-  auto res = stmt.Query ();
+  auto res = stmt.Query<TestResult> ();
 
   ASSERT_TRUE (res.Step ());
   EXPECT_EQ (res.Get<int64_t> ("id"), 42);
@@ -167,7 +173,7 @@ TEST_F (DatabaseTests, ProtoIsOverwritten)
   stmt.Execute ();
 
   stmt = db.Prepare ("SELECT `proto` FROM `test`");
-  auto res = stmt.Query ();
+  auto res = stmt.Query<TestResult> ();
 
   ASSERT_TRUE (res.Step ());
 
@@ -185,9 +191,8 @@ TEST_F (DatabaseTests, ProtoIsOverwritten)
 TEST_F (DatabaseTests, ResultProperties)
 {
   auto stmt = db.Prepare ("SELECT * FROM `test`");
-  auto res = stmt.Query ("foo");
+  auto res = stmt.Query<TestResult> ();
   EXPECT_EQ (&res.GetDatabase (), &db);
-  EXPECT_EQ (res.GetName (), "foo");
 }
 
 } // anonymous namespace

--- a/database/faction.cpp
+++ b/database/faction.cpp
@@ -56,15 +56,6 @@ FactionFromString (const std::string& str)
   return Faction::INVALID;
 }
 
-Faction
-GetFactionFromColumn (const Database::Result& res, const std::string& col)
-{
-  const auto val = res.Get<int64_t> (col);
-  CHECK (val >= 1 && val <= 3)
-      << "Invalid faction value from database: " << val;
-  return static_cast<Faction> (val);
-}
-
 void
 BindFactionParameter (Database::Statement& stmt, const unsigned ind,
                       const Faction f)

--- a/database/faction.hpp
+++ b/database/faction.hpp
@@ -60,8 +60,10 @@ Faction FactionFromString (const std::string& str);
 /**
  * A database result that includes a "faction" column.
  */
-class ResultWithFaction : public Database::ResultType
-{};
+struct ResultWithFaction : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, faction, 50);
+};
 
 /**
  * Retrieves a faction from a database column.  This function verifies that
@@ -72,8 +74,7 @@ class ResultWithFaction : public Database::ResultType
  * They should all be derived from ResultWithFaction, though.
  */
 template <typename T>
-  Faction GetFactionFromColumn (const Database::Result<T>& res,
-                                const std::string& col);
+  Faction GetFactionFromColumn (const Database::Result<T>& res);
 
 /**
  * Binds a faction value to a statement parameter.

--- a/database/faction.hpp
+++ b/database/faction.hpp
@@ -58,12 +58,22 @@ std::string FactionToString (Faction f);
 Faction FactionFromString (const std::string& str);
 
 /**
+ * A database result that includes a "faction" column.
+ */
+class ResultWithFaction
+{};
+
+/**
  * Retrieves a faction from a database column.  This function verifies that
  * the database value represents a valid faction.  Otherwise it crashes the
  * process (data corruption).
+ *
+ * This is templated, so that it can accept different database result types.
+ * They should all be derived from ResultWithFaction, though.
  */
-Faction GetFactionFromColumn (const Database::Result& res,
-                              const std::string& col);
+template <typename T>
+  Faction GetFactionFromColumn (const Database::Result<T>& res,
+                                const std::string& col);
 
 /**
  * Binds a faction value to a statement parameter.
@@ -71,5 +81,7 @@ Faction GetFactionFromColumn (const Database::Result& res,
 void BindFactionParameter (Database::Statement& stmt, unsigned ind, Faction f);
 
 } // namespace pxd
+
+#include "faction.tpp"
 
 #endif // DATABASE_FACTION_HPP

--- a/database/faction.hpp
+++ b/database/faction.hpp
@@ -60,7 +60,7 @@ Faction FactionFromString (const std::string& str);
 /**
  * A database result that includes a "faction" column.
  */
-class ResultWithFaction
+class ResultWithFaction : public Database::ResultType
 {};
 
 /**

--- a/database/faction.tpp
+++ b/database/faction.tpp
@@ -27,12 +27,12 @@ namespace pxd
 
 template <typename T>
   Faction
-  GetFactionFromColumn (const Database::Result<T>& res, const std::string& col)
+  GetFactionFromColumn (const Database::Result<T>& res)
 {
   static_assert (std::is_base_of<ResultWithFaction, T>::value,
                  "GetFactionFromColumn needs a ResultWithFaction");
   
-  const auto val = res.template Get<int64_t> (col);
+  const auto val = res.template Get<typename T::faction> ();
   CHECK (val >= 1 && val <= 3)
       << "Invalid faction value from database: " << val;
 

--- a/database/faction_tests.cpp
+++ b/database/faction_tests.cpp
@@ -90,7 +90,7 @@ TEST_F (FactionDatabaseTests, RoundTrip)
 
       stmt = db.Prepare ("SELECT `faction` FROM `test` WHERE `name` = ?1");
       stmt.Bind (1, t.second);
-      auto res = stmt.Query ();
+      auto res = stmt.Query<ResultWithFaction> ();
 
       ASSERT_TRUE (res.Step ());
       EXPECT_EQ (GetFactionFromColumn (res, "faction"), t.first);
@@ -106,7 +106,7 @@ TEST_F (FactionDatabaseTests, Invalid)
   stmt.Execute ();
 
   stmt = db.Prepare ("SELECT `faction` FROM `test`");
-  auto res = stmt.Query ();
+  auto res = stmt.Query<ResultWithFaction> ();
 
   ASSERT_TRUE (res.Step ());
   EXPECT_DEATH (GetFactionFromColumn (res, "faction"), "Invalid faction value");

--- a/database/faction_tests.cpp
+++ b/database/faction_tests.cpp
@@ -93,7 +93,7 @@ TEST_F (FactionDatabaseTests, RoundTrip)
       auto res = stmt.Query<ResultWithFaction> ();
 
       ASSERT_TRUE (res.Step ());
-      EXPECT_EQ (GetFactionFromColumn (res, "faction"), t.first);
+      EXPECT_EQ (GetFactionFromColumn (res), t.first);
       EXPECT_FALSE (res.Step ());
     }
 }
@@ -109,7 +109,7 @@ TEST_F (FactionDatabaseTests, Invalid)
   auto res = stmt.Query<ResultWithFaction> ();
 
   ASSERT_TRUE (res.Step ());
-  EXPECT_DEATH (GetFactionFromColumn (res, "faction"), "Invalid faction value");
+  EXPECT_DEATH (GetFactionFromColumn (res), "Invalid faction value");
 }
 
 } // anonymous namespace

--- a/database/prizes.cpp
+++ b/database/prizes.cpp
@@ -31,7 +31,7 @@ Prizes::GetFound (const std::string& name)
   )");
   stmt.Bind (1, name);
 
-  class PrizesResult
+  class PrizesResult : public Database::ResultType
   {};
 
   auto res = stmt.Query<PrizesResult> ();

--- a/database/prizes.cpp
+++ b/database/prizes.cpp
@@ -23,6 +23,16 @@
 namespace pxd
 {
 
+namespace
+{
+
+struct PrizesResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, found, 1);
+};
+
+} // anonymous namespace
+
 unsigned
 Prizes::GetFound (const std::string& name)
 {
@@ -31,12 +41,9 @@ Prizes::GetFound (const std::string& name)
   )");
   stmt.Bind (1, name);
 
-  class PrizesResult : public Database::ResultType
-  {};
-
   auto res = stmt.Query<PrizesResult> ();
   CHECK (res.Step ()) << "Prize not found in database: " << name;
-  const unsigned found = res.Get<int64_t> ("found");
+  const unsigned found = res.Get<PrizesResult::found> ();
   CHECK (!res.Step ());
 
   return found;

--- a/database/region.cpp
+++ b/database/region.cpp
@@ -27,10 +27,9 @@ Region::Region (Database& d, const RegionMap::IdT i)
   VLOG (1) << "Created instance for empty region with ID " << id;
 }
 
-Region::Region (Database& d, const Database::Result& res)
+Region::Region (Database& d, const Database::Result<RegionResult>& res)
   : db(d), dirty(false)
 {
-  CHECK_EQ (res.GetName (), "regions");
   id = res.Get<int64_t> ("id");
   res.GetProto ("proto", data);
 
@@ -58,7 +57,7 @@ Region::~Region ()
 }
 
 RegionsTable::Handle
-RegionsTable::GetFromResult (const Database::Result& res)
+RegionsTable::GetFromResult (const Database::Result<RegionResult>& res)
 {
   return Handle (new Region (db, res));
 }
@@ -68,7 +67,7 @@ RegionsTable::GetById (const RegionMap::IdT id)
 {
   auto stmt = db.Prepare ("SELECT * FROM `regions` WHERE `id` = ?1");
   stmt.Bind (1, id);
-  auto res = stmt.Query ("regions");
+  auto res = stmt.Query<RegionResult> ();
 
   if (!res.Step ())
     return Handle (new Region (db, id));
@@ -78,11 +77,11 @@ RegionsTable::GetById (const RegionMap::IdT id)
   return r;
 }
 
-Database::Result
+Database::Result<RegionResult>
 RegionsTable::QueryNonTrivial ()
 {
   auto stmt = db.Prepare ("SELECT * FROM `regions` ORDER BY `id`");
-  return stmt.Query ("regions");
+  return stmt.Query<RegionResult> ();
 }
 
 } // namespace pxd

--- a/database/region.cpp
+++ b/database/region.cpp
@@ -30,8 +30,8 @@ Region::Region (Database& d, const RegionMap::IdT i)
 Region::Region (Database& d, const Database::Result<RegionResult>& res)
   : db(d), dirty(false)
 {
-  id = res.Get<int64_t> ("id");
-  res.GetProto ("proto", data);
+  id = res.Get<RegionResult::id> ();
+  res.GetProto<RegionResult::proto> (data);
 
   VLOG (1) << "Created region data for ID " << id << " from database result";
 }

--- a/database/region.hpp
+++ b/database/region.hpp
@@ -28,6 +28,12 @@ namespace pxd
 {
 
 /**
+ * Database result for a row from the regions table.
+ */
+class RegionResult
+{};
+
+/**
  * Wrapper class around the state of one region in the database.  This
  * abstracts the database accesses themselves away from the other code.
  *
@@ -62,7 +68,7 @@ private:
    * Constructs an instance based on the given DB result set.  The result
    * set should be constructed by a RegionsTable.
    */
-  explicit Region (Database& d, const Database::Result& res);
+  explicit Region (Database& d, const Database::Result<RegionResult>& res);
 
   friend class RegionsTable;
 
@@ -129,7 +135,7 @@ public:
   /**
    * Returns a handle for the instance based on a Database::Result.
    */
-  Handle GetFromResult (const Database::Result& res);
+  Handle GetFromResult (const Database::Result<RegionResult>& res);
 
   /**
    * Returns the region with the given ID.
@@ -141,7 +147,7 @@ public:
    * data stored.  Returns a result set that can be used together with
    * GetFromResult.
    */
-  Database::Result QueryNonTrivial ();
+  Database::Result<RegionResult> QueryNonTrivial ();
 
 };
 

--- a/database/region.hpp
+++ b/database/region.hpp
@@ -30,8 +30,11 @@ namespace pxd
 /**
  * Database result for a row from the regions table.
  */
-class RegionResult : public Database::ResultType
-{};
+struct RegionResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, id, 1);
+  RESULT_COLUMN (pxd::proto::RegionData, proto, 2);
+};
 
 /**
  * Wrapper class around the state of one region in the database.  This

--- a/database/region.hpp
+++ b/database/region.hpp
@@ -30,7 +30,7 @@ namespace pxd
 /**
  * Database result for a row from the regions table.
  */
-class RegionResult
+class RegionResult : public Database::ResultType
 {};
 
 /**

--- a/database/target.cpp
+++ b/database/target.cpp
@@ -44,7 +44,7 @@ TargetFinder::ProcessL1Targets (const HexCoord& centre,
 
   BindFactionParameter (stmt, 5, faction);
 
-  class TargetsResult
+  class TargetsResult : public Database::ResultType
   {};
 
   auto res = stmt.Query<TargetsResult> ();

--- a/database/target.cpp
+++ b/database/target.cpp
@@ -44,7 +44,10 @@ TargetFinder::ProcessL1Targets (const HexCoord& centre,
 
   BindFactionParameter (stmt, 5, faction);
 
-  auto res = stmt.Query ("targets");
+  class TargetsResult
+  {};
+
+  auto res = stmt.Query<TargetsResult> ();
   while (res.Step ())
     {
       const HexCoord coord (res.Get<int64_t> ("x"), res.Get<int64_t> ("y"));

--- a/database/target.cpp
+++ b/database/target.cpp
@@ -21,6 +21,18 @@
 namespace pxd
 {
 
+namespace
+{
+
+struct TargetResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, id, 1);
+  RESULT_COLUMN (int64_t, x, 2);
+  RESULT_COLUMN (int64_t, y, 3);
+};
+
+} // anonymous namespace
+
 void
 TargetFinder::ProcessL1Targets (const HexCoord& centre,
                                 const HexCoord::IntT l1range,
@@ -44,18 +56,16 @@ TargetFinder::ProcessL1Targets (const HexCoord& centre,
 
   BindFactionParameter (stmt, 5, faction);
 
-  class TargetsResult : public Database::ResultType
-  {};
-
-  auto res = stmt.Query<TargetsResult> ();
+  auto res = stmt.Query<TargetResult> ();
   while (res.Step ())
     {
-      const HexCoord coord (res.Get<int64_t> ("x"), res.Get<int64_t> ("y"));
+      const HexCoord coord (res.Get<TargetResult::x> (),
+                            res.Get<TargetResult::y> ());
       if (HexCoord::DistanceL1 (centre, coord) > l1range)
         continue;
 
       proto::TargetId targetId;
-      targetId.set_id (res.Get<int64_t> ("id"));
+      targetId.set_id (res.Get<TargetResult::id> ());
       targetId.set_type (proto::TargetId::TYPE_CHARACTER);
 
       cb (coord, targetId);

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -261,9 +261,9 @@ template <>
   return res;
 }
 
-template <typename T>
+template <typename T, typename R>
   Json::Value
-  GameStateJson::ResultsAsArray (T& tbl, Database::Result res) const
+  GameStateJson::ResultsAsArray (T& tbl, Database::Result<R> res) const
 {
   Json::Value arr(Json::arrayValue);
 

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -54,8 +54,8 @@ private:
    * Extracts all results from the Database::Result instance, converts them
    * to JSON, and returns a JSON array.
    */
-  template <typename T>
-    Json::Value ResultsAsArray (T& tbl, Database::Result res) const;
+  template <typename T, typename R>
+    Json::Value ResultsAsArray (T& tbl, Database::Result<R> res) const;
 
 public:
 


### PR DESCRIPTION
This is a major refactoring of the way how columns are read from database results.  We make `Database::Result` a template, whose type parameter indicates what "kind" of result it is (e.g. a row from the characters table or a row from accounts).  This replaces the previous optional runtime checking with "query names", and replaces them by a compile-time verification of the type of results.

We also change the way in which columns are read.  Instead of accessing them by name and specifying the expected type, each of the newly introduced result types specifies what columns there are and what types they have.  Thus when accessing them, there is no need to specify a type.

Furthermore, columns are now no longer looked up by name whenever they are accessed; instead, we look them up by a numeric ID.  This improves performance of lookups.  The character benchmark shows that querying lots of characters from a result set got about 25% faster, while single lookups did not degrade in performance.  Syncing a selected range of ~250 blocks on the tech demo competition also got faster by about 8%.