### PR TITLE
Optimise protocol buffers in database reads

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -30,6 +30,7 @@ noinst_HEADERS = \
   database.hpp database.tpp \
   faction.hpp faction.tpp \
   fighter.hpp \
+  lazyproto.hpp lazyproto.tpp \
   prizes.hpp \
   region.hpp \
   schema.hpp \
@@ -70,6 +71,7 @@ tests_SOURCES = \
   database_tests.cpp \
   faction_tests.cpp \
   fighter_tests.cpp \
+  lazyproto_tests.cpp \
   prizes_tests.cpp \
   region_tests.cpp \
   schema_tests.cpp \

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -29,6 +29,7 @@
 #include "proto/combat.pb.h"
 #include "proto/movement.pb.h"
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -285,6 +286,9 @@ public:
   /** Movable handle to a character instance.  */
   using Handle = std::unique_ptr<Character>;
 
+  /** Callback function for processing positions and factions of characters.  */
+  using PositionFcn = std::function<void (const HexCoord& pos, Faction f)>;
+
   explicit CharacterTable (Database& d)
     : db(d)
   {}
@@ -343,6 +347,13 @@ public:
    * processed and finished next.
    */
   Database::Result<CharacterResult> QueryBusyDone ();
+
+  /**
+   * Processes all positions of characters on the map.  This is used to
+   * construct the dynamic obstacle map, avoiding the need to query all data
+   * for each character and construct a full Character handle.
+   */
+  void ProcessAllPositions (const PositionFcn& cb);
 
   /**
    * Deletes the character with the given ID.

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -46,8 +46,9 @@ struct CharacterResult : public ResultWithFaction
   RESULT_COLUMN (int64_t, y, 4);
   RESULT_COLUMN (pxd::proto::VolatileMovement, volatilemv, 5);
   RESULT_COLUMN (pxd::proto::HP, hp, 6);
-  RESULT_COLUMN (int64_t, busy, 7);
-  RESULT_COLUMN (pxd::proto::Character, proto, 8);
+  RESULT_COLUMN (pxd::proto::RegenData, regendata, 7);
+  RESULT_COLUMN (int64_t, busy, 8);
+  RESULT_COLUMN (pxd::proto::Character, proto, 9);
 };
 
 /**
@@ -85,6 +86,13 @@ private:
 
   /** Current HP proto.  */
   LazyProto<proto::HP> hp;
+
+  /**
+   * Data about HP regeneration.  This is accessed often but not updated
+   * frequently.  If modified, then we do a full update as per the proto
+   * update.  But parsing it should be cheap.
+   */
+  LazyProto<proto::RegenData> regenData;
 
   /** The number of blocks (or zero) the character is still busy.  */
   int busy;
@@ -211,6 +219,18 @@ public:
   MutableHP ()
   {
     return hp.Mutable ();
+  }
+
+  const proto::RegenData&
+  GetRegenData () const
+  {
+    return regenData.Get ();
+  }
+
+  proto::RegenData&
+  MutableRegenData ()
+  {
+    return regenData.Mutable ();
   }
 
   unsigned

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -49,6 +49,7 @@ struct CharacterResult : public ResultWithFaction
   RESULT_COLUMN (pxd::proto::RegenData, regendata, 7);
   RESULT_COLUMN (int64_t, busy, 8);
   RESULT_COLUMN (pxd::proto::Character, proto, 9);
+  RESULT_COLUMN (bool, canregen, 10);
 };
 
 /**
@@ -99,6 +100,12 @@ private:
 
   /** All other data in the protocol buffer.  */
   LazyProto<proto::Character> data;
+
+  /**
+   * Stores the canregen flag from the database.  We only update it if
+   * the RegenData or HP have been modified.
+   */
+  bool oldCanRegen;
 
   /**
    * Set to true if this is a new character, so we know that we have to
@@ -319,6 +326,11 @@ public:
    * to be updated for move stepping).
    */
   Database::Result<CharacterResult> QueryMoving ();
+
+  /**
+   * Queries for all characters that may need to have HP regenerated.
+   */
+  Database::Result<CharacterResult> QueryForRegen ();
 
   /**
    * Queries for all characters that have a combat target and thus need

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -68,6 +68,7 @@ TEST_F (CharacterTests, Creation)
   c->SetPosition (pos);
   const auto id1 = c->GetId ();
   c->MutableHP ().set_armour (10);
+  c->MutableRegenData ().set_shield_regeneration_mhp (1234);
   SetBusy (*c, 42);
   c.reset ();
 
@@ -85,6 +86,7 @@ TEST_F (CharacterTests, Creation)
   EXPECT_EQ (c->GetFaction (), Faction::RED);
   EXPECT_EQ (c->GetPosition (), pos);
   EXPECT_EQ (c->GetHP ().armour (), 10);
+  EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 1234);
   EXPECT_EQ (c->GetBusy (), 42);
   EXPECT_FALSE (c->GetProto ().has_movement ());
 
@@ -93,6 +95,7 @@ TEST_F (CharacterTests, Creation)
   ASSERT_EQ (c->GetId (), id2);
   EXPECT_EQ (c->GetOwner (), "domob");
   EXPECT_EQ (c->GetFaction (), Faction::GREEN);
+  EXPECT_FALSE (c->GetRegenData ().has_shield_regeneration_mhp ());
   EXPECT_EQ (c->GetBusy (), 0);
   EXPECT_TRUE (c->GetProto ().has_movement ());
 
@@ -120,6 +123,7 @@ TEST_F (CharacterTests, ModificationWithProto)
   c->SetPosition (pos);
   c->MutableVolatileMv ().set_partial_step (10);
   c->MutableHP ().set_shield (5);
+  c->MutableRegenData ().set_shield_regeneration_mhp (1234);
   SetBusy (*c, 42);
   c->MutableProto ().mutable_target ();
   c.reset ();
@@ -132,6 +136,7 @@ TEST_F (CharacterTests, ModificationWithProto)
   EXPECT_EQ (c->GetPosition (), pos);
   EXPECT_EQ (c->GetVolatileMv ().partial_step (), 10);
   EXPECT_EQ (c->GetHP ().shield (), 5);
+  EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 1234);
   EXPECT_EQ (c->GetBusy (), 42);
   EXPECT_TRUE (c->GetProto ().has_target ());
   ASSERT_FALSE (res.Step ());

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -322,6 +322,24 @@ TEST_F (CharacterTableTests, QueryBusyDone)
   ASSERT_FALSE (res.Step ());
 }
 
+TEST_F (CharacterTableTests, ProcessAllPositions)
+{
+  tbl.CreateNew ("red", Faction::RED)->SetPosition (HexCoord (1, 5));
+  tbl.CreateNew ("red", Faction::RED)->SetPosition (HexCoord (-1, -5));
+  tbl.CreateNew ("blue", Faction::BLUE)->SetPosition (HexCoord (0, 0));
+
+  using Entry = std::pair<Faction, HexCoord>;
+  std::vector<Entry> entries;
+  tbl.ProcessAllPositions ([&entries] (const HexCoord& pos, const Faction f)
+    {
+      entries.emplace_back (f, pos);
+    });
+
+  EXPECT_THAT (entries, ElementsAre (Entry (Faction::RED, HexCoord (1, 5)),
+                                     Entry (Faction::RED, HexCoord (-1, -5)),
+                                     Entry (Faction::BLUE, HexCoord (0, 0))));
+}
+
 TEST_F (CharacterTableTests, DeleteById)
 {
   const auto id1 = tbl.CreateNew ("domob", Faction::RED)->GetId ();

--- a/database/database.cpp
+++ b/database/database.cpp
@@ -115,20 +115,6 @@ Database::Statement::BindNull (const unsigned ind)
   CHECK_EQ (sqlite3_bind_null (stmt, ind), SQLITE_OK);
 }
 
-void
-Database::Statement::BindProto (const unsigned ind,
-                                const google::protobuf::Message& msg)
-{
-  CHECK (!run);
-
-  std::string str;
-  CHECK (msg.SerializeToString (&str));
-
-  CHECK_EQ (sqlite3_bind_blob (stmt, ind, &str[0], str.size (),
-                               SQLITE_TRANSIENT),
-            SQLITE_OK);
-}
-
 /* ************************************************************************** */
 
 namespace internal

--- a/database/database.hpp
+++ b/database/database.hpp
@@ -19,6 +19,8 @@
 #ifndef DATABASE_DATABASE_HPP
 #define DATABASE_DATABASE_HPP
 
+#include "lazyproto.hpp"
+
 #include <xayagame/sqlitegame.hpp>
 
 #include <google/protobuf/message.h>
@@ -146,7 +148,8 @@ public:
   /**
    * Binds a protocol buffer to a BLOB parameter.
    */
-  void BindProto (unsigned ind, const google::protobuf::Message& msg);
+  template <typename Proto>
+    void BindProto (unsigned ind, const LazyProto<Proto>& msg);
 
   /**
    * Resets the statement so it can be used again with fresh bindings
@@ -285,7 +288,7 @@ public:
    * Extracts a protocol buffer from the column of the given type.
    */
   template <typename Col>
-    void GetProto (typename Col::Type& res) const;
+    LazyProto<typename Col::Type> GetProto () const;
 
   /**
    * Returns the underlying database handle.

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -49,6 +49,13 @@ Fighter::GetPosition () const
   return character->GetPosition ();
 }
 
+const proto::RegenData&
+Fighter::GetRegenData () const
+{
+  CHECK (character != nullptr);
+  return character->GetRegenData ();
+}
+
 const proto::CombatData&
 Fighter::GetCombatData () const
 {

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -148,6 +148,14 @@ FighterTable::ProcessAll (const Callback& cb)
 }
 
 void
+FighterTable::ProcessForRegen (const Callback& cb)
+{
+  auto res = characters.QueryForRegen ();
+  while (res.Step ())
+    cb (Fighter (characters.GetFromResult (res)));
+}
+
+void
 FighterTable::ProcessWithTarget (const Callback& cb)
 {
   auto res = characters.QueryWithTarget ();

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -78,6 +78,11 @@ public:
   const HexCoord& GetPosition () const;
 
   /**
+   * Returns the HP regeneration data for this fighter.
+   */
+  const proto::RegenData& GetRegenData () const;
+
+  /**
    * Returns the combat data proto for this fighter.
    */
   const proto::CombatData& GetCombatData () const;

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -164,6 +164,11 @@ public:
   void ProcessAll (const Callback& cb);
 
   /**
+   * Retrieves and processes all fighters that need HP regeneration.
+   */
+  void ProcessForRegen (const Callback& cb);
+
+  /**
    * Retrieves and processes all fighers that have a target, i.e. for whom
    * we need to deal damage.
    */

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -88,6 +88,11 @@ public:
   const proto::CombatData& GetCombatData () const;
 
   /**
+   * Returns the fighter's attack range or zero if there are no attacks.
+   */
+  HexCoord::IntT GetAttackRange () const;
+
+  /**
    * Returns the target.  This must only be called if there is one.
    */
   const proto::TargetId& GetTarget () const;
@@ -158,10 +163,10 @@ public:
   Fighter GetForTarget (const proto::TargetId& id);
 
   /**
-   * Retrieves all fighters from the database and runs the callback
-   * on each one.
+   * Retrieves all fighters from the database that have an attack and runs
+   * the callback on each one.
    */
-  void ProcessAll (const Callback& cb);
+  void ProcessWithAttacks (const Callback& cb);
 
   /**
    * Retrieves and processes all fighters that need HP regeneration.
@@ -175,6 +180,12 @@ public:
   void ProcessWithTarget (const Callback& cb);
 
 };
+
+/**
+ * Computes the attack range of a fighter with the given combat data.
+ * Returns zero if there are no attacks at all.
+ */
+HexCoord::IntT FindAttackRange (const proto::CombatData& cd);
 
 } // namespace pxd
 

--- a/database/lazyproto.hpp
+++ b/database/lazyproto.hpp
@@ -1,0 +1,132 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_LAZYPROTO_HPP
+#define DATABASE_LAZYPROTO_HPP
+
+#include <string>
+
+namespace pxd
+{
+
+/**
+ * A class that wraps a protocol buffer and implements "lazy deserialisation".
+ * Initially, it just keeps the raw data in a string, and only deserialises the
+ * protocol buffer when actually needed.  This can help speed up database
+ * accesses for cases where we don't actually need some proto data for certain
+ * operations.
+ *
+ * The class also keeps track of when the protocol buffer was modified, so
+ * we know if we need to update it in the database.
+ */
+template <typename Proto>
+  class LazyProto
+{
+
+private:
+
+  /**
+   * Possible "states" of a lazy proto.
+   */
+  enum class State : uint8_t
+  {
+
+    /** There is no data yet (this instance is uninitialised).  */
+    UNINITIALISED,
+
+    /** We have not yet accessed/parsed the byte data.  */
+    UNPARSED,
+
+    /**
+     * We have parsed the byte data but not modified the proto object.
+     * In other words, the serialised data is still in sync with the
+     * proto message.
+     */
+    UNMODIFIED,
+
+    /** The proto message has been modified.  */
+    MODIFIED,
+
+  };
+
+  /** The raw bytes of the protocol buffer.  */
+  mutable std::string data;
+
+  /** The parsed protocol buffer.  */
+  mutable Proto msg;
+
+  /** Current state of this lazy proto.  */
+  mutable State state = State::UNINITIALISED;
+
+  /**
+   * Ensures that the protocol buffer is parsed.
+   */
+  void EnsureParsed () const;
+
+  friend class LazyProtoTests;
+
+public:
+
+  LazyProto () = default;
+
+  /**
+   * Constructs a lazy proto instance based on the given byte data.
+   */
+  explicit LazyProto (std::string&& d);
+
+  /* A LazyProto can be moved but not copied.  */
+  LazyProto (LazyProto&&) = default;
+  LazyProto& operator= (LazyProto&&) = default;
+
+  LazyProto (const LazyProto&) = delete;
+  void operator= (const LazyProto&) = delete;
+
+  /**
+   * Initialises the protocol buffer value as "empty" (i.e. default-constructed
+   * protocol buffer message, empty data string).
+   */
+  void SetToDefault ();
+
+  /**
+   * Accesses the message read-only.
+   */
+  const Proto& Get () const;
+
+  /**
+   * Accesses and modifies the proto message.
+   */
+  Proto& Mutable ();
+
+  /**
+   * Returns true if the protocol buffer was modified from the original
+   * data (e.g. so we know that it needs updating in the database).
+   */
+  bool IsDirty () const;
+
+  /**
+   * Returns a serialised form of the potentially modified protocol buffer.
+   */
+  const std::string& GetSerialised () const;
+
+};
+
+} // namespace pxd
+
+#include "lazyproto.tpp"
+
+#endif // DATABASE_LAZYPROTO_HPP

--- a/database/lazyproto.tpp
+++ b/database/lazyproto.tpp
@@ -1,0 +1,104 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Template implementation code for lazyproto.hpp.  */
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+template <typename Proto>
+  LazyProto<Proto>::LazyProto (std::string&& d)
+    : data(std::move (d)), state(State::UNPARSED)
+{}
+
+template <typename Proto>
+  inline void
+  LazyProto<Proto>::EnsureParsed () const
+{
+  switch (state)
+    {
+    case State::UNPARSED:
+      CHECK (msg.ParseFromString (data));
+      state = State::UNMODIFIED;
+      return;
+
+    case State::UNMODIFIED:
+    case State::MODIFIED:
+      return;
+
+    default:
+      LOG (FATAL) << "Unexpected state: " << static_cast<int> (state);
+    }
+}
+
+template <typename Proto>
+  void
+  LazyProto<Proto>::SetToDefault ()
+{
+  data.clear ();
+  msg.Clear ();
+  state = State::UNMODIFIED;
+}
+
+template <typename Proto>
+  inline const Proto&
+  LazyProto<Proto>::Get () const
+{
+  EnsureParsed ();
+  return msg;
+}
+
+template <typename Proto>
+  inline Proto&
+  LazyProto<Proto>::Mutable ()
+{
+  EnsureParsed ();
+  state = State::MODIFIED;
+  return msg;
+}
+
+template <typename Proto>
+  inline bool
+  LazyProto<Proto>::IsDirty () const
+{
+  CHECK (state != State::UNINITIALISED);
+  return state == State::MODIFIED;
+}
+
+template <typename Proto>
+  const std::string&
+  LazyProto<Proto>::GetSerialised () const
+{
+  switch (state)
+    {
+    case State::UNPARSED:
+    case State::UNMODIFIED:
+      return data;
+
+    case State::MODIFIED:
+      CHECK (msg.SerializeToString (&data));
+      return data;
+
+    default:
+      LOG (FATAL) << "Unexpected state: " << static_cast<int> (state);
+    }
+}
+
+} // namespace pxd

--- a/database/lazyproto_tests.cpp
+++ b/database/lazyproto_tests.cpp
@@ -1,0 +1,140 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "lazyproto.hpp"
+
+#include "hexagonal/coord.hpp"
+#include "proto/geometry.pb.h"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+
+class LazyProtoTests : public testing::Test
+{
+
+protected:
+
+  LazyProto<proto::HexCoord> lazy;
+
+  /**
+   * Sets our LazyProto instance based on the given coordinate.
+   */
+  void
+  SetToCoord (const HexCoord& c)
+  {
+    proto::HexCoord pb;
+    pb.set_x (c.GetX ());
+    pb.set_y (c.GetY ());
+
+    std::string bytes;
+    CHECK (pb.SerializeToString (&bytes));
+
+    lazy = LazyProto<proto::HexCoord> (std::move (bytes));
+  }
+
+  /**
+   * Checks if the protocol buffer has been parsed.
+   */
+  bool
+  IsProtoParsed () const
+  {
+    return lazy.msg.has_x () || lazy.msg.has_y ();
+  }
+
+  /**
+   * Checks that the protocol buffer is not serialised on demand for
+   * GetSerialised, but that a serialised string is known already and returned.
+   * We do this by modifying the proto message and checking that the serialised
+   * string does not change.
+   */
+  bool
+  IsSerialisationCached ()
+  {
+    const std::string before = lazy.GetSerialised ();
+    lazy.msg.set_x (-12345);
+    const std::string after = lazy.GetSerialised ();
+
+    return before == after;
+  }
+
+};
+
+namespace
+{
+
+TEST_F (LazyProtoTests, SetToDefault)
+{
+  lazy.SetToDefault ();
+  EXPECT_EQ (lazy.GetSerialised (), "");
+  EXPECT_FALSE (lazy.Get ().has_x ());
+  EXPECT_FALSE (lazy.Get ().has_y ());
+
+  EXPECT_FALSE (lazy.IsDirty ());
+  EXPECT_TRUE (IsSerialisationCached ());
+}
+
+TEST_F (LazyProtoTests, ProtoNotParsed)
+{
+  SetToCoord (HexCoord (42, -5));
+  const std::string bytes = lazy.GetSerialised ();
+
+  EXPECT_FALSE (lazy.IsDirty ());
+  EXPECT_FALSE (IsProtoParsed ());
+  EXPECT_TRUE (IsSerialisationCached ());
+
+  proto::HexCoord pb;
+  ASSERT_TRUE (pb.ParseFromString (bytes));
+  EXPECT_EQ (pb.x (), 42);
+  EXPECT_EQ (pb.y (), -5);
+}
+
+TEST_F (LazyProtoTests, ProtoNotModified)
+{
+  SetToCoord (HexCoord (42, -5));
+
+  EXPECT_EQ (lazy.Get ().x (), 42);
+  EXPECT_EQ (lazy.Get ().y (), -5);
+
+  EXPECT_FALSE (lazy.IsDirty ());
+  EXPECT_TRUE (IsProtoParsed ());
+  EXPECT_TRUE (IsSerialisationCached ());
+}
+
+TEST_F (LazyProtoTests, ProtoModified)
+{
+  SetToCoord (HexCoord (42, -5));
+  lazy.Mutable ().set_x (-10);
+  const std::string bytes = lazy.GetSerialised ();
+
+  EXPECT_EQ (lazy.Get ().x (), -10);
+  EXPECT_EQ (lazy.Get ().y (), -5);
+
+  EXPECT_TRUE (lazy.IsDirty ());
+  EXPECT_TRUE (IsProtoParsed ());
+  EXPECT_FALSE (IsSerialisationCached ());
+
+  proto::HexCoord pb;
+  ASSERT_TRUE (pb.ParseFromString (bytes));
+  EXPECT_EQ (pb.x (), -10);
+  EXPECT_EQ (pb.y (), -5);
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/database/region.cpp
+++ b/database/region.cpp
@@ -22,23 +22,24 @@ namespace pxd
 {
 
 Region::Region (Database& d, const RegionMap::IdT i)
-  : db(d), id(i), dirty(false)
+  : db(d), id(i)
 {
   VLOG (1) << "Created instance for empty region with ID " << id;
+  data.SetToDefault ();
 }
 
 Region::Region (Database& d, const Database::Result<RegionResult>& res)
-  : db(d), dirty(false)
+  : db(d)
 {
   id = res.Get<RegionResult::id> ();
-  res.GetProto<RegionResult::proto> (data);
+  data = res.GetProto<RegionResult::proto> ();
 
   VLOG (1) << "Created region data for ID " << id << " from database result";
 }
 
 Region::~Region ()
 {
-  if (!dirty)
+  if (!data.IsDirty ())
     {
       VLOG (1) << "Region " << id << " is not dirty, no update";
       return;

--- a/database/region.hpp
+++ b/database/region.hpp
@@ -20,6 +20,7 @@
 #define DATABASE_REGION_HPP
 
 #include "database.hpp"
+#include "lazyproto.hpp"
 
 #include "mapdata/regionmap.hpp"
 #include "proto/region.pb.h"
@@ -54,13 +55,7 @@ private:
   RegionMap::IdT id;
 
   /** Generic data stored in the proto BLOB.  */
-  proto::RegionData data;
-
-  /**
-   * Set to true if any modification has been made and we need to write
-   * the changes back to the database in the destructor.
-   */
-  bool dirty;
+  LazyProto<proto::RegionData> data;
 
   /**
    * Constructs an instance with "default / empty" data for the given ID.
@@ -98,14 +93,13 @@ public:
   const proto::RegionData&
   GetProto () const
   {
-    return data;
+    return data.Get ();
   }
 
   proto::RegionData&
   MutableProto ()
   {
-    dirty = true;
-    return data;
+    return data.Mutable ();
   }
 
 };

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -62,6 +62,12 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- moving when we do move updates.
   `ismoving` INTEGER NOT NULL,
 
+  -- The range of the longest attack this character has or NULL if there
+  -- is no attack at all.  This is used to speed up target finding without
+  -- the need to look through the character's attacks (and parse the
+  -- full proto) every time.
+  `attackrange` INTEGER NULL,
+
   -- Flag indicating whether a character may need HP regeneration.  This is
   -- set here (based on the RegenData and current HP) so that we can only
   -- retrieve and process characters that need regeneration.
@@ -82,6 +88,8 @@ CREATE INDEX IF NOT EXISTS `characters_owner` ON `characters` (`owner`);
 CREATE INDEX IF NOT EXISTS `characters_pos` ON `characters` (`x`, `y`);
 CREATE INDEX IF NOT EXISTS `characters_busy` ON `characters` (`busy`);
 CREATE INDEX IF NOT EXISTS `characters_ismoving` ON `characters` (`ismoving`);
+CREATE INDEX IF NOT EXISTS `characters_attackrange`
+  ON `characters` (`attackrange`);
 CREATE INDEX IF NOT EXISTS `characters_canregen` ON `characters` (`canregen`);
 CREATE INDEX IF NOT EXISTS `characters_hastarget` ON `characters` (`hastarget`);
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -62,6 +62,11 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- moving when we do move updates.
   `ismoving` INTEGER NOT NULL,
 
+  -- Flag indicating whether a character may need HP regeneration.  This is
+  -- set here (based on the RegenData and current HP) so that we can only
+  -- retrieve and process characters that need regeneration.
+  `canregen` INTEGER NOT NULL,
+
   -- Flag indicating whether or not the character has a combat target.
   -- This is used so we can later efficiently retrieve only those characters
   -- that need to be processed for combat damage.
@@ -77,6 +82,7 @@ CREATE INDEX IF NOT EXISTS `characters_owner` ON `characters` (`owner`);
 CREATE INDEX IF NOT EXISTS `characters_pos` ON `characters` (`x`, `y`);
 CREATE INDEX IF NOT EXISTS `characters_busy` ON `characters` (`busy`);
 CREATE INDEX IF NOT EXISTS `characters_ismoving` ON `characters` (`ismoving`);
+CREATE INDEX IF NOT EXISTS `characters_canregen` ON `characters` (`canregen`);
 CREATE INDEX IF NOT EXISTS `characters_hastarget` ON `characters` (`hastarget`);
 
 -- =============================================================================

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -47,6 +47,11 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- costs and undo data size.
   `hp` BLOB NOT NULL,
 
+  -- Data about HP regeneration encoded as RegenData proto.  This is accessed
+  -- often and independently from the core proto, and thus split out for
+  -- performance reasons.  It is not updated often, mostly read.
+  `regendata` BLOB NOT NULL,
+
   -- If non-zero, then the number represents for how many more blocks the
   -- character is "locked" at being busy (e.g. prospecting).
   `busy` INTEGER NOT NULL,

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -81,6 +81,7 @@ message Character
      - position on the map
      - volatile movement proto (partial step, blocked for counter)
      - current HP proto
+     - HP regeneration data proto
      - number of blocks the character is still "busy"
   */
 

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -91,20 +91,31 @@ message HP
 }
 
 /**
+ * Data relevant for HP regeneration.  This is split out from the main
+ * combat data, because it needs to be accessed for every fighter all the
+ * time to figure out if they need regeneration.
+ */
+message RegenData
+{
+
+  /** Maximum HP of the fighter.  */
+  optional HP max_hp = 1;
+
+  /** Regeneration rate of shield HP in "milli HP per block".  */
+  optional uint32 shield_regeneration_mhp = 2;
+
+}
+
+/**
  * All data related to combat that a fighter entity (character or building) has.
  * This only includes basic properties of the fighter and not more dynamic
- * data like the current target or the current HP.
+ * data like the current target or the current HP, nor specific data that
+ * is frequently accessed like HP regeneration.
  */
 message CombatData
 {
 
   /** The offensive attacks the figher has.  */
   repeated Attack attacks = 1;
-
-  /** Maximum HP of the fighter.  */
-  optional HP max_hp = 2;
-
-  /** Regeneration rate of shield HP in "milli HP per block".  */
-  optional uint32 shield_regeneration_mhp = 3;
 
 }

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -275,7 +275,7 @@ RegenerateHP (Database& db)
   CharacterTable characters(db);
   FighterTable fighters(characters);
 
-  fighters.ProcessAll ([] (Fighter f)
+  fighters.ProcessForRegen ([] (Fighter f)
     {
       RegenerateFighterHP (std::move (f));
     });

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -239,26 +239,26 @@ namespace
 void
 RegenerateFighterHP (Fighter f)
 {
-  const auto& cd = f.GetCombatData ();
+  const auto& regen = f.GetRegenData ();
   const auto& hp = f.GetHP ();
 
   /* Make sure to return early if there is no regeneration at all.  This
      ensures that we are not doing unnecessary database updates triggered
      through MutableHP().  */
-  if (cd.shield_regeneration_mhp () == 0
-        || hp.shield () == cd.max_hp ().shield ())
+  if (regen.shield_regeneration_mhp () == 0
+        || hp.shield () == regen.max_hp ().shield ())
     return;
 
   unsigned shield = hp.shield ();
   unsigned mhp = hp.shield_mhp ();
 
-  mhp += cd.shield_regeneration_mhp ();
+  mhp += regen.shield_regeneration_mhp ();
   shield += mhp / 1000;
   mhp %= 1000;
 
-  if (shield >= cd.max_hp ().shield ())
+  if (shield >= regen.max_hp ().shield ())
     {
-      shield = cd.max_hp ().shield ();
+      shield = regen.max_hp ().shield ();
       mhp = 0;
     }
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -40,19 +40,13 @@ SelectTarget (TargetFinder& targets, xaya::Random& rnd, Fighter f)
 {
   const HexCoord pos = f.GetPosition ();
 
-  const auto& data = f.GetCombatData ();
-  HexCoord::IntT range = 0;
-  for (const auto& attack : data.attacks ())
-    {
-      CHECK_GT (attack.range (), 0);
-      range = std::max<HexCoord::IntT> (range, attack.range ());
-    }
+  const HexCoord::IntT range = f.GetAttackRange ();
   if (range == 0)
     {
-      CHECK_EQ (data.attacks_size (), 0);
       VLOG (1) << "Fighter at " << pos << " has no attacks";
       return;
     }
+  CHECK_GT (range, 0);
 
   HexCoord::IntT closestRange;
   std::vector<proto::TargetId> closestTargets;
@@ -100,7 +94,7 @@ FindCombatTargets (Database& db, xaya::Random& rnd)
   FighterTable fighters(characters);
   TargetFinder targets(db);
 
-  fighters.ProcessAll ([&] (Fighter f)
+  fighters.ProcessWithAttacks ([&] (Fighter f)
     {
       SelectTarget (targets, rnd, std::move (f));
     });

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -60,14 +60,14 @@ InsertCharacters (Database& db, const unsigned numIdle,
     {
       auto c = tbl.CreateNew ("domob", Faction::GREEN);
       const auto id = c->GetId ();
-      auto* cd = c->MutableProto ().mutable_combat_data ();
-      cd->set_shield_regeneration_mhp (1000);
-      cd->mutable_max_hp ()->set_armour (targetHP);
+      auto& regen = c->MutableRegenData ();
+      regen.set_shield_regeneration_mhp (1000);
+      regen.mutable_max_hp ()->set_armour (targetHP);
       c->MutableHP ().set_armour (targetHP);
       c.reset ();
 
       c = tbl.CreateNew ("domob", Faction::RED);
-      cd = c->MutableProto ().mutable_combat_data ();
+      auto* cd = c->MutableProto ().mutable_combat_data ();
       for (unsigned j = 0; j < numAttacks; ++j)
         {
           auto* attack = cd->add_attacks ();

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -527,8 +527,8 @@ TEST_F (RegenerateHpTests, Works)
 {
   auto c = characters.CreateNew ("domob", Faction::RED);
   const auto id = c->GetId ();
-  auto* cd = c->MutableProto ().mutable_combat_data ();
-  cd->mutable_max_hp ()->set_shield (100);
+  auto* regen = &c->MutableRegenData ();
+  regen->mutable_max_hp ()->set_shield (100);
   c.reset ();
 
   struct TestCase
@@ -555,8 +555,8 @@ TEST_F (RegenerateHpTests, Works)
       c = characters.GetById (id);
       c->MutableHP ().set_shield (t.shieldBefore);
       c->MutableHP ().set_shield_mhp (t.mhpShieldBefore);
-      cd = c->MutableProto ().mutable_combat_data ();
-      cd->set_shield_regeneration_mhp (t.mhpRegen);
+      regen = &c->MutableRegenData ();
+      regen->set_shield_regeneration_mhp (t.mhpRegen);
       c.reset ();
 
       RegenerateHP (db);

--- a/src/dynobstacles.cpp
+++ b/src/dynobstacles.cpp
@@ -27,12 +27,10 @@ DynObstacles::DynObstacles (Database& db)
   : red(false), green(false), blue(false)
 {
   CharacterTable tbl(db);
-  auto res = tbl.QueryAll ();
-  while (res.Step ())
+  tbl.ProcessAllPositions ([this] (const HexCoord& pos, const Faction f)
     {
-      auto c = tbl.GetFromResult (res);
-      AddVehicle (c->GetPosition (), c->GetFaction ());
-    }
+      AddVehicle (pos, f);
+    });
 }
 
 DynTiles<bool>&

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -155,10 +155,11 @@ GetCombatJsonObject (const Character& c, const DamageLists& dl)
   if (!attacks.empty ())
     res["attacks"] = attacks;
 
+  const auto& regen = c.GetRegenData ();
   Json::Value hp(Json::objectValue);
-  hp["max"] = HpProtoToJson (pb.combat_data ().max_hp ());
+  hp["max"] = HpProtoToJson (regen.max_hp ());
   hp["current"] = HpProtoToJson (c.GetHP ());
-  hp["regeneration"] = pb.combat_data ().shield_regeneration_mhp () / 1000.0;
+  hp["regeneration"] = regen.shield_regeneration_mhp () / 1000.0;
   res["hp"] = hp;
 
   Json::Value attackers(Json::arrayValue);

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -292,10 +292,10 @@ TEST_F (CharacterJsonTests, HP)
   c->MutableHP ().set_armour (42);
   c->MutableHP ().set_shield (5);
   c->MutableHP ().set_shield_mhp (1);
-  auto* cd = c->MutableProto ().mutable_combat_data ();
-  cd->mutable_max_hp ()->set_armour (100);
-  cd->mutable_max_hp ()->set_shield (10);
-  cd->set_shield_regeneration_mhp (1001);
+  auto& regen = c->MutableRegenData ();
+  regen.mutable_max_hp ()->set_armour (100);
+  regen.mutable_max_hp ()->set_shield (10);
+  regen.set_shield_regeneration_mhp (1001);
   c.reset ();
 
   ExpectStateJson (R"({

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -280,9 +280,9 @@ TEST_F (PXLogicTests, DamageKillsRegeneration)
      but would regenerate HP if that were done before applying damage.  */
   c = characters.GetById (idTarget);
   ASSERT_TRUE (c != nullptr);
-  auto* cd = c->MutableProto ().mutable_combat_data ();
-  cd->set_shield_regeneration_mhp (2000);
-  cd->mutable_max_hp ()->set_shield (100);
+  auto& regen = c->MutableRegenData ();
+  regen.set_shield_regeneration_mhp (2000);
+  regen.mutable_max_hp ()->set_shield (100);
   c->MutableHP ().set_shield (1);
   c->MutableHP ().set_armour (0);
   c.reset ();
@@ -303,8 +303,9 @@ TEST_F (PXLogicTests, DamageLists)
 
   c = characters.CreateNew ("domob", Faction::GREEN);
   const auto idTarget = c->GetId ();
-  auto* cd = c->MutableProto ().mutable_combat_data ();
-  cd->mutable_max_hp ()->set_shield (100);
+  c->MutableProto ().mutable_combat_data ();
+  auto& regen = c->MutableRegenData ();
+  regen.mutable_max_hp ()->set_shield (100);
   c->MutableHP ().set_shield (100);
   c.reset ();
 
@@ -346,8 +347,8 @@ TEST_F (PXLogicTests, FameUpdate)
       auto c = characters.CreateNew ("domob", f);
       ids.push_back (c->GetId ());
       AddUnityAttack (*c, 1);
-      auto* cd = c->MutableProto ().mutable_combat_data ();
-      cd->mutable_max_hp ()->set_shield (1);
+      auto& regen = c->MutableRegenData ();
+      regen.mutable_max_hp ()->set_shield (1);
       c->MutableHP ().set_shield (1);
     }
 
@@ -431,8 +432,9 @@ TEST_F (PXLogicTests, ProspectingUserKilled)
   c = characters.CreateNew ("domob", Faction::GREEN);
   ASSERT_EQ (c->GetId (), 2);
   c->SetPosition (pos);
-  auto* cd = c->MutableProto ().mutable_combat_data ();
-  cd->mutable_max_hp ()->set_shield (100);
+  c->MutableProto ().mutable_combat_data ();
+  auto& regen = c->MutableRegenData ();
+  regen.mutable_max_hp ()->set_shield (100);
   c->MutableHP ().set_shield (1);
   c->MutableHP ().set_armour (0);
   c.reset ();

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -465,8 +465,7 @@ MaybeGodSetHp (CharacterTable& tbl, const Json::Value& cmd)
 
       LOG (INFO) << "Setting HP points for " << id << "...";
       auto& hp = c->MutableHP ();
-      auto& maxHP = *c->MutableProto ().mutable_combat_data ()
-                      ->mutable_max_hp ();
+      auto& maxHP = *c->MutableRegenData ().mutable_max_hp ();
 
       Json::Value val = (*i)["a"];
       if (val.isUInt64 ())

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -769,9 +769,9 @@ TEST_F (GodModeTests, SetHp)
   ASSERT_EQ (id, 1);
   c->MutableHP ().set_armour (50);
   c->MutableHP ().set_shield (20);
-  auto* cd = c->MutableProto ().mutable_combat_data ();
-  cd->mutable_max_hp ()->set_armour (50);
-  cd->mutable_max_hp ()->set_shield (20);
+  auto& regen = c->MutableRegenData ();
+  regen.mutable_max_hp ()->set_armour (50);
+  regen.mutable_max_hp ()->set_shield (20);
   c.reset ();
 
   ProcessAdmin (R"([{"cmd": {
@@ -788,8 +788,8 @@ TEST_F (GodModeTests, SetHp)
   c = tbl.GetById (id);
   EXPECT_EQ (c->GetHP ().armour (), 32);
   EXPECT_EQ (c->GetHP ().shield (), 15);
-  EXPECT_EQ (c->GetProto ().combat_data ().max_hp ().armour (), 50);
-  EXPECT_EQ (c->GetProto ().combat_data ().max_hp ().shield (), 20);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().armour (), 50);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 20);
   c.reset ();
 
   ProcessAdmin (R"([{"cmd": {
@@ -805,8 +805,8 @@ TEST_F (GodModeTests, SetHp)
   c = tbl.GetById (id);
   EXPECT_EQ (c->GetHP ().armour (), 32);
   EXPECT_EQ (c->GetHP ().shield (), 15);
-  EXPECT_EQ (c->GetProto ().combat_data ().max_hp ().armour (), 100);
-  EXPECT_EQ (c->GetProto ().combat_data ().max_hp ().shield (), 90);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().armour (), 100);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 90);
   c.reset ();
 }
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -153,7 +153,7 @@ Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
 }
 
 void
-Params::InitCharacterStats (proto::Character& pb) const
+Params::InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const
 {
   pb.set_speed (3000);
 
@@ -167,10 +167,10 @@ Params::InitCharacterStats (proto::Character& pb) const
   attack->set_min_damage (5);
   attack->set_max_damage (30);
 
-  auto* maxHP = cd->mutable_max_hp ();
+  auto* maxHP = regen.mutable_max_hp ();
   maxHP->set_armour (100);
   maxHP->set_shield (30);
-  cd->set_shield_regeneration_mhp (500);
+  regen.set_shield_regeneration_mhp (500);
 }
 
 bool

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -132,7 +132,7 @@ public:
    * Initialises the stats for a newly created character.  This fills in the
    * combat data and other fields in the protocol buffer as needed.
    */
-  void InitCharacterStats (proto::Character& pb) const;
+  void InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const;
 
   /**
    * Returns true if god-mode commands are allowed (on regtest).

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -124,9 +124,10 @@ SpawnCharacter (const std::string& owner, const Faction f,
   c->SetPosition (pos);
   dyn.AddVehicle (pos, f);
 
+  auto& regen = c->MutableRegenData ();
   auto& pb = c->MutableProto ();
-  params.InitCharacterStats (pb);
-  c->MutableHP () = pb.combat_data ().max_hp ();
+  params.InitCharacterStats (regen, pb);
+  c->MutableHP () = regen.max_hp ();
 
   return c;
 }


### PR DESCRIPTION
This is a bunch of changes that, overall, optimise database reads and in general procotol-buffer parsing for them.  Previously, there were three operations that looped through all characters on the map, and parsed the "main proto" for each of them:  `DynObstacles` initialisation, HP regeneration and combat-target finding.

With these changes applied, none of them parses the proto anymore.  Instead, we only need to deserialise it for characters that actually move, have a combat target already (i.e. actively deal damage in combat), or perform an explicit action.  HP regeneration is only done for characters that really need it (with indexing the table on a flag), and completely without access to the main proto.