### PR TITLE
Add RPCs to retrieve parts of the game state

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -14,7 +14,8 @@ REGTESTS = \
   multiupdate.py \
   nullstate.py \
   pending.py \
-  prospecting.py
+  prospecting.py \
+  splitstaterpcs.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)
 TESTS = $(REGTESTS)

--- a/gametest/nullstate.py
+++ b/gametest/nullstate.py
@@ -28,7 +28,7 @@ class NullstateTest (PXTest):
   def run (self):
     self.generate (10)
 
-    self.assertEqual (self.getCustomState ("data", "getnullstate"), None)
+    self.assertEqual (self.getRpc ("getnullstate"), None)
 
     res = self.rpc.game.getnullstate ()
     self.assertEqual (res["state"], "up-to-date")

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -50,9 +50,9 @@ class PendingTest (PXTest):
     self.moveCharactersTo ({
       "domob": position,
     })
-    # getGameState ensures that we sync up at least for the confirmed state
+    # getnullstate ensures that we sync up at least for the confirmed state
     # before we look at the pending state.
-    self.getGameState ()
+    self.getRpc ("getnullstate")
     self.assertEqual (self.getPendingState (), {
       "characters": [],
       "newcharacters": [],
@@ -118,7 +118,7 @@ class PendingTest (PXTest):
 
     self.mainLogger.info ("Confirming the moves...")
     self.generate (1)
-    self.getGameState ()
+    self.getRpc ("getnullstate")
     self.assertEqual (self.getPendingState (), {
       "characters": [],
       "newcharacters": [],

--- a/gametest/prospecting.py
+++ b/gametest/prospecting.py
@@ -293,16 +293,15 @@ class ProspectingTest (PXTest):
       chars[nm].sendMove ({"prospect": {}})
     self.generate (11)
 
-    state = self.getGameState ()
     prizesInRegions = {
       "gold": 0,
       "silver": 0,
       "bronze": 0,
     }
-    for r in state["regions"]:
+    for r in self.getRpc ("getregions"):
       if ("prospection" in r) and "prize" in r["prospection"]:
         prizesInRegions[r["prospection"]["prize"]] += 1
-    for nm, val in state["prizes"].iteritems ():
+    for nm, val in self.getRpc ("getprizestats").iteritems ():
       self.assertEqual (prizesInRegions[nm], val["found"])
     self.log.info ("Found prizes:\n%s" % prizesInRegions)
     self.assertEqual (prizesInRegions["bronze"], 0)

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -136,6 +136,14 @@ class PXTest (XayaGameTest):
     binary = os.path.join (top_builddir, "src", "tauriond")
     super (PXTest, self).__init__ (GAMEID, binary)
 
+  def getRpc (self, method, *args, **kwargs):
+    """
+    Calls the given "read-type" RPC method on the game daemon and returns
+    the "data" field (holding the main data).
+    """
+
+    return self.getCustomState ("data", method, *args, **kwargs)
+
   def moveWithPayment (self, name, move, devAmount):
     """
     Sends a move (name_update for the given name) and also includes the
@@ -174,11 +182,8 @@ class PXTest (XayaGameTest):
     then the second will have the key "owner 2", the third "owner 3" and so on.
     """
 
-    state = self.getGameState ()
-    assert "characters" in state
-
     res = {}
-    for c in state["characters"]:
+    for c in self.getRpc ("getcharacters"):
       assert "owner" in c
       nm = c["owner"]
       idx = 2
@@ -228,11 +233,8 @@ class PXTest (XayaGameTest):
     Returns all accounts with non-trivial data in the current game state.
     """
 
-    state = self.getGameState ()
-    assert "accounts" in state
-
     res = {}
-    for a in state["accounts"]:
+    for a in self.getRpc ("getaccounts"):
       handle = Account (a)
       nm = handle.getName ()
       assert nm not in res
@@ -247,10 +249,7 @@ class PXTest (XayaGameTest):
     explicitly present.
     """
 
-    state = self.getGameState ()
-    assert "regions" in state
-
-    for r in state["regions"]:
+    for r in self.getRpc ("getregions"):
       if r["id"] == regionId:
         return Region (r)
 

--- a/gametest/splitstaterpcs.py
+++ b/gametest/splitstaterpcs.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from pxtest import PXTest
+
+"""
+Tests how the full game state corresponds to the "split state" RPCs
+like getaccounts or getregions.
+"""
+
+
+class SplitStateRpcsTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    # Set up a non-trivial situation, where we have characters, prospected
+    # regions and kills/fame.
+    self.createCharacter ("prospector", "r")
+    self.createCharacter ("killed", "g")
+    self.generate (1)
+    self.moveCharactersTo ({
+      "prospector": {"x": 0, "y": 0},
+      "killed": {"x": 0, "y": 0},
+    })
+    self.setCharactersHP ({
+      "killed": {"a": 1, "s": 0},
+    })
+    self.getCharacters ()["prospector"].sendMove ({"prospect": {}})
+    self.generate (20)
+
+    # Test that the full game state corresponds to the split RPCs.
+    state = self.getGameState ()
+    accounts = self.getRpc ("getaccounts")
+    characters = self.getRpc ("getcharacters")
+    regions = self.getRpc ("getregions")
+    prizes = self.getRpc ("getprizestats")
+    assert len (accounts) > 0
+    assert len (characters) > 0
+    assert len (regions) > 0
+    assert len (prizes) > 0
+    self.assertEqual (accounts, state["accounts"])
+    self.assertEqual (characters, state["characters"])
+    self.assertEqual (regions, state["regions"])
+    self.assertEqual (prizes, state["prizes"])
+
+
+if __name__ == "__main__":
+  SplitStateRpcsTest ().main ()

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -302,25 +302,34 @@ GameStateJson::PrizeStats ()
 }
 
 Json::Value
+GameStateJson::Accounts ()
+{
+  AccountsTable tbl(db);
+  return ResultsAsArray (tbl, tbl.QueryNonTrivial ());
+}
+
+Json::Value
+GameStateJson::Characters ()
+{
+  CharacterTable tbl(db);
+  return ResultsAsArray (tbl, tbl.QueryAll ());
+}
+
+Json::Value
+GameStateJson::Regions ()
+{
+  RegionsTable tbl(db);
+  return ResultsAsArray (tbl, tbl.QueryNonTrivial ());
+}
+
+Json::Value
 GameStateJson::FullState ()
 {
   Json::Value res(Json::objectValue);
 
-  {
-    CharacterTable tbl(db);
-    res["characters"] = ResultsAsArray (tbl, tbl.QueryAll ());
-  }
-
-  {
-    AccountsTable tbl(db);
-    res["accounts"] = ResultsAsArray (tbl, tbl.QueryNonTrivial ());
-  }
-
-  {
-    RegionsTable tbl(db);
-    res["regions"] = ResultsAsArray (tbl, tbl.QueryNonTrivial ());
-  }
-
+  res["accounts"] = Accounts ();
+  res["characters"] = Characters ();
+  res["regions"] = Regions ();
   res["prizes"] = PrizeStats ();
 
   return res;

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -75,6 +75,21 @@ public:
     Json::Value Convert (const T& val) const;
 
   /**
+   * Returns the JSON data representing all accounts in the game state.
+   */
+  Json::Value Accounts ();
+
+  /**
+   * Returns the JSON data representing all characters in the game state.
+   */
+  Json::Value Characters ();
+
+  /**
+   * Returns the JSON data representing all regions in the game state.
+   */
+  Json::Value Regions ();
+
+  /**
    * Returns the JSON data representing the available and found prizes
    * for prospecting.
    */

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -20,7 +20,6 @@
 
 #include "combat.hpp"
 #include "dynobstacles.hpp"
-#include "gamestatejson.hpp"
 #include "movement.hpp"
 #include "moveprocessor.hpp"
 #include "prospecting.hpp"
@@ -181,9 +180,23 @@ PXLogic::GetStateAsJson (sqlite3* db)
 {
   SQLiteGameDatabase dbObj(*this);
   const Params params(GetChain ());
+  GameStateJson gsj(dbObj, params, map);
 
-  GameStateJson converter(dbObj, params, map);
-  return converter.FullState ();
+  return gsj.FullState ();
+}
+
+Json::Value
+PXLogic::GetCustomStateData (xaya::Game& game, const JsonStateFromDatabase& cb)
+{
+  return SQLiteGame::GetCustomStateData (game, "data",
+      [this, &cb] (sqlite3* db)
+        {
+          SQLiteGameDatabase dbObj(*this);
+          const Params params(GetChain ());
+          GameStateJson gsj(dbObj, params, map);
+
+          return cb (gsj);
+        });
 }
 
 } // namespace pxd

--- a/src/logic.hpp
+++ b/src/logic.hpp
@@ -20,6 +20,7 @@
 #define PXD_LOGIC_HPP
 
 #include "fame.hpp"
+#include "gamestatejson.hpp"
 #include "params.hpp"
 
 #include "database/database.hpp"
@@ -33,6 +34,7 @@
 
 #include <sqlite3.h>
 
+#include <functional>
 #include <string>
 
 namespace pxd
@@ -118,6 +120,9 @@ protected:
 
 public:
 
+  /** Type for a callback that retrieves JSON data from the database.  */
+  using JsonStateFromDatabase = std::function<Json::Value (GameStateJson& gsj)>;
+
   PXLogic () = default;
 
   PXLogic (const PXLogic&) = delete;
@@ -132,6 +137,14 @@ public:
   {
     return map;
   }
+
+  /**
+   * Returns custom game-state data as JSON.  The provided callback is invoked
+   * with a GameStateJson instance to retrieve the "main" state data that is
+   * returned in the JSON "data" field.
+   */
+  Json::Value GetCustomStateData (xaya::Game& game,
+                                  const JsonStateFromDatabase& cb);
 
 };
 

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -102,8 +102,8 @@ Json::Value
 PXRpcServer::getnullstate ()
 {
   LOG (INFO) << "RPC method called: getnullstate";
-  return logic.GetCustomStateData (game, "data",
-    [] (sqlite3* db)
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
       {
         return Json::Value ();
       });
@@ -128,6 +128,50 @@ PXRpcServer::waitforchange (const std::string& knownBlock)
 {
   LOG (INFO) << "RPC method called: waitforchange " << knownBlock;
   return xaya::GameRpcServer::DefaultWaitForChange (game, knownBlock);
+}
+
+Json::Value
+PXRpcServer::getaccounts ()
+{
+  LOG (INFO) << "RPC method called: getaccounts";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.Accounts ();
+      });
+}
+
+Json::Value
+PXRpcServer::getcharacters ()
+{
+  LOG (INFO) << "RPC method called: getcharacters";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.Characters ();
+      });
+}
+
+Json::Value
+PXRpcServer::getregions ()
+{
+  LOG (INFO) << "RPC method called: getregions";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.Regions ();
+      });
+}
+
+Json::Value
+PXRpcServer::getprizestats ()
+{
+  LOG (INFO) << "RPC method called: getprizestats";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.PrizeStats ();
+      });
 }
 
 Json::Value

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -61,6 +61,11 @@ public:
   std::string waitforchange (const std::string& knownBlock) override;
   Json::Value waitforpendingchange (int oldVersion) override;
 
+  Json::Value getaccounts () override;
+  Json::Value getcharacters () override;
+  Json::Value getregions () override;
+  Json::Value getprizestats () override;
+
   Json::Value findpath (int l1range, const Json::Value& source,
                         const Json::Value& target, int wpdist) override;
   Json::Value getregionat (const Json::Value& coord) override;

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -30,6 +30,27 @@
   },
 
   {
+    "name": "getaccounts",
+    "params": {},
+    "returns": {}
+  },
+  {
+    "name": "getcharacters",
+    "params": {},
+    "returns": {}
+  },
+  {
+    "name": "getregions",
+    "params": {},
+    "returns": {}
+  },
+  {
+    "name": "getprizestats",
+    "params": {},
+    "returns": {}
+  },
+
+  {
     "name": "findpath",
     "params":
       {


### PR DESCRIPTION
This adds four new RPCs to `tauriond`: `getaccounts`, `getcharacters`, `getregions` and `getprizestats`.  They return parts of the full game state, namely the JSON fields of the full game state individually.

This allows more fine-grained control over which data is needed by a frontend, possibly improving performance and saving load on the GSP as well.