### PR TITLE
Make slow assertions optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,18 @@ AX_CHECK_COMPILE_FLAG([-Wno-deprecated], [CXXFLAGS+=" -Wno-deprecated"])
 # See https://hpc.nih.gov/development/glog.html.
 CXXFLAGS+=" -DGLOG_NO_ABBREVIATED_SEVERITIES"
 
+# The code includes some sanity checks / assertions that noticably slow down
+# general block-processing performance.  Thus enabling them is optional,
+# and should be used only for testing purposes.
+AC_ARG_ENABLE([slow-asserts],
+  AS_HELP_STRING([--enable-slow-asserts],
+                 [Enable slow consistency checks for testing]))
+AS_IF([test "x$enable_slow_asserts" = "xyes"], [
+  CXXFLAGS+=" -DENABLE_SLOW_ASSERTS"
+], [
+  enable_slow_asserts="no"
+])
+
 PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES([XAYAGAME], [libxayautil libxayagame])
@@ -52,4 +64,5 @@ AC_CONFIG_FILES([
 AC_OUTPUT
 
 echo
+echo "Slow assertions: ${enable_slow_asserts}"
 echo "CXXFLAGS: ${CXXFLAGS}"

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -162,6 +162,12 @@ private:
    */
   void Validate () const;
 
+  /**
+   * Computes the "canregen" field based on our protos.  This forces parsing
+   * of the main data proto, so it should only be called when needed.
+   */
+  bool ComputeCanRegen () const;
+
   friend class CharacterTable;
 
 public:

--- a/hexagonal/rangemap.tpp
+++ b/hexagonal/rangemap.tpp
@@ -43,17 +43,22 @@ template <typename T>
   inline int
   RangeMap<T>::GetIndex (const HexCoord& c) const
 {
+#ifdef ENABLE_SLOW_ASSERTS
   CHECK (IsInRange (c))
       << "Out-of-range access: "
       << c << " is out of range " << range << " around " << centre;
+#endif // ENABLE_SLOW_ASSERTS
 
   const int row = range + c.GetX () - centre.GetX ();
+  const int col = range + c.GetY () - centre.GetY ();
+
+#ifdef ENABLE_SLOW_ASSERTS
   CHECK_GE (row, 0);
   CHECK_LT (row, 2 * range + 1);
 
-  const int col = range + c.GetY () - centre.GetY ();
   CHECK_GE (col, 0);
   CHECK_LT (col, 2 * range + 1);
+#endif // ENABLE_SLOW_ASSERTS
 
   return row + col * (2 * range + 1);
 }
@@ -63,8 +68,12 @@ template <typename T>
   RangeMap<T>::Access (const HexCoord& c)
 {
   const int ind = GetIndex (c);
+
+#ifdef ENABLE_SLOW_ASSERTS
   CHECK_GE (ind, 0);
   CHECK_LT (ind, data.size ());
+#endif // ENABLE_SLOW_ASSERTS
+
   return data[ind];
 }
 
@@ -73,8 +82,12 @@ template <typename T>
   RangeMap<T>::Get (const HexCoord& c) const
 {
   const int ind = GetIndex (c);
+
+#ifdef ENABLE_SLOW_ASSERTS
   CHECK_GE (ind, 0);
   CHECK_LT (ind, data.size ());
+#endif // ENABLE_SLOW_ASSERTS
+
   return data[ind];
 }
 

--- a/mapdata/basemap.tpp
+++ b/mapdata/basemap.tpp
@@ -38,7 +38,10 @@ static constexpr int BITS = 8;
 inline int
 YArrayIndex (const int y)
 {
+#ifdef ENABLE_SLOW_ASSERTS
   CHECK (y >= tiledata::minY && y <= tiledata::maxY);
+#endif // ENABLE_SLOW_ASSERTS
+
   return y - tiledata::minY;
 }
 

--- a/mapdata/dyntiles.tpp
+++ b/mapdata/dyntiles.tpp
@@ -41,10 +41,13 @@ GetIndex (const HexCoord& c)
 
   using namespace tiledata;
 
-  CHECK (y >= minY && y <= maxY);
   const auto yInd = y - minY;
 
+#ifdef ENABLE_SLOW_ASSERTS
+  CHECK (y >= minY && y <= maxY);
   CHECK (x >= minX[yInd] && x <= maxX[yInd]);
+#endif // ENABLE_SLOW_ASSERTS
+
   return offsetForY[yInd] + x - minX[yInd];
 }
 
@@ -57,7 +60,10 @@ GetBuckets (const size_t fullIndex, size_t& bucket, size_t& within)
 {
   bucket = fullIndex / BUCKET_SIZE;
   within = fullIndex % BUCKET_SIZE;
+
+#ifdef ENABLE_SLOW_ASSERTS
   CHECK_EQ (BUCKET_SIZE * bucket + within, fullIndex);
+#endif // ENABLE_SLOW_ASSERTS
 }
 
 template <typename T>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,6 +110,12 @@ main (int argc, char** argv)
       return EXIT_FAILURE;
     }
 
+#ifdef ENABLE_SLOW_ASSERTS
+  LOG (WARNING)
+      << "Slow assertions are enabled.  This is fine for testing, but will"
+         " slow down syncing";
+#endif // ENABLE_SLOW_ASSERTS
+
   xaya::GameDaemonConfiguration config;
   config.XayaRpcUrl = FLAGS_xaya_rpc_url;
   if (FLAGS_game_rpc_port != 0)


### PR DESCRIPTION
This introduces a configure option (`--enable-slow-asserts`), which can be used to not compile some assertions in the code for production builds.  In particular, with this, we can remove `CHECK`s from the most critical code paths in path finding, and also add back some more consistency checks for characters (because they will only be run when compiled for testing, with slow asserts).