### PR TITLE
Only check "to" tiles for obstacles

### DIFF
--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -53,9 +53,6 @@ class FindPathTest (PXTest):
 
     # Paths that yield no connection.
     self.expectError (1, "no connection",
-                      findpath, source=obstacle, target=passable,
-                      l1range=10, wpdist=1)
-    self.expectError (1, "no connection",
                       findpath, source=passable, target=obstacle,
                       l1range=10, wpdist=1)
     self.expectError (1, "no connection",

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -174,6 +174,7 @@ class MovementTest (PXTest):
     self.generate (5)
     pos, mv = self.getMovement ("domob")
     assert pos["x"] < 50
+    assert pos["x"] > 30
     assert "blockedturns" not in mv
 
     # Block the path again and let movement stop completely.

--- a/hexagonal/pathfinder.hpp
+++ b/hexagonal/pathfinder.hpp
@@ -23,6 +23,7 @@
 #include "rangemap.hpp"
 
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <memory>
 
@@ -69,6 +70,13 @@ private:
    * it means that no distances are known at all.
    */
   std::unique_ptr<RangeMap<DistanceT>> distances;
+
+  /**
+   * The edge weight used for computing distances.  This is used also for
+   * stepping along the path later on, and thus remembered from the Compute
+   * call.
+   */
+  std::function<DistanceT (const HexCoord& from, const HexCoord& to)> edges;
 
   /**
    * The number of tiles processed (in the sense that we finalised a distance

--- a/hexagonal/pathfinder.tpp
+++ b/hexagonal/pathfinder.tpp
@@ -73,6 +73,8 @@ template <typename Fcn>
       << "PathFinder allows only one Compute call for now";
   CHECK_EQ (computedTiles, 0);
 
+  edges = edgeWeight;
+
   /* Check that the source is actually accessible from any of its neighbours.
      If it is not, then we would just spend the computations for the full
      l1Range for nothing.  Doing this check here makes sure that we can
@@ -149,6 +151,7 @@ template <typename Fcn>
       /* Insert the current element as a finalised distance.  */
       curDist = cur.dist;
       ++computedTiles;
+      VLOG (2) << "Found new distance: " << cur.coord << " as " << cur.dist;
 
       /* If this was the source, we are done.  */
       if (cur.coord == source)

--- a/mapdata/basemap.tpp
+++ b/mapdata/basemap.tpp
@@ -75,7 +75,7 @@ BaseMap::IsPassable (const HexCoord& c) const
 inline PathFinder::DistanceT
 BaseMap::GetEdgeWeight (const HexCoord& from, const HexCoord& to) const
 {
-  if (IsPassable (from) && IsPassable (to))
+  if (IsPassable (to))
     return 1000;
 
   return PathFinder::NO_CONNECTION;

--- a/mapdata/basemap_tests.cpp
+++ b/mapdata/basemap_tests.cpp
@@ -89,7 +89,7 @@ TEST_F (BaseMapTests, EdgeWeights)
   const HexCoord inside(-4064, 0);
   ASSERT_FALSE (map.IsOnMap (outside));
   ASSERT_TRUE (map.IsOnMap (inside));
-  EXPECT_EQ (map.GetEdgeWeight (outside, inside), PathFinder::NO_CONNECTION);
+  EXPECT_EQ (map.GetEdgeWeight (inside, outside), PathFinder::NO_CONNECTION);
 }
 
 } // anonymous namespace

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -238,8 +238,7 @@ template <typename Fcn>
 
   const auto res = baseEdges (from, to);
 
-  if (res == PathFinder::NO_CONNECTION
-        || !dyn.IsPassable (from, f) || !dyn.IsPassable (to, f))
+  if (res == PathFinder::NO_CONNECTION || !dyn.IsPassable (to, f))
     return PathFinder::NO_CONNECTION;
 
   return res;

--- a/src/movement_tests.cpp
+++ b/src/movement_tests.cpp
@@ -152,16 +152,9 @@ TEST_F (MovementEdgeWeightTests, DynamicObstacle)
   const auto baseEdges = EdgeWeights (42);
   dyn.AddVehicle (HexCoord (0, 0), Faction::RED);
 
-  EXPECT_EQ (MovementEdgeWeight (HexCoord (0, 0), HexCoord (1, 0),
-                                 baseEdges, dyn, Faction::RED),
-             PathFinder::NO_CONNECTION);
   EXPECT_EQ (MovementEdgeWeight (HexCoord (1, 0), HexCoord (0, 0),
                                  baseEdges, dyn, Faction::RED),
              PathFinder::NO_CONNECTION);
-
-  EXPECT_EQ (MovementEdgeWeight (HexCoord (0, 0), HexCoord (1, 0),
-                                 baseEdges, dyn, Faction::GREEN),
-             42);
   EXPECT_EQ (MovementEdgeWeight (HexCoord (1, 0), HexCoord (0, 0),
                                  baseEdges, dyn, Faction::GREEN),
              42);


### PR DESCRIPTION
When checking edges during path finding, only consider them impassable if the "to" tile is an obstacle.  This avoids half the calls for basemap and dyntiles `IsPassable`.  It does not matter in practice, except for situations where someone would already be on top of an obstacle (which should not happen anyway unless there is another bug).

Note that the stepping code previously had a bug, which assumed symmetric edge weights / obstacles.  Now we check the individual edges again during stepping, which means that it works correctly as it should even for unsymmetric edge-weight distances.