### PR TITLE
Multichar command

### DIFF
--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -121,6 +121,16 @@ class CharactersTest (PXTest):
       "domob 2": {"faction": "g"},
     })
 
+    self.mainLogger.info ("Updates with ID lists...")
+    id1 = self.getCharacters ()["domob"].getId ()
+    id2 = self.getCharacters ()["domob 2"].getId ()
+    self.sendMove ("domob", {
+      "c": {"%d,%d" % (id1, id2): {"send": "idlist"}},
+    })
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["idlist"].getId (), id1)
+    self.assertEqual (self.getCharacters ()["idlist 2"].getId (), id2)
+
     self.testReorg ()
 
   def testReorg (self):

--- a/src/jsonutils.hpp
+++ b/src/jsonutils.hpp
@@ -27,6 +27,7 @@
 #include <json/json.h>
 
 #include <string>
+#include <vector>
 
 namespace pxd
 {
@@ -63,6 +64,17 @@ bool AmountFromJson (const Json::Value& val, Amount& amount);
  * false if something is wrong.
  */
 bool IdFromString (const std::string& str, Database::IdT& id);
+
+/**
+ * Parses a string that encodes one or more IDs (separated by commas), e.g.
+ * from a character-update JSON command.  Returns true and fills in the vector
+ * of parsed IDs on success, and returns false if the string is not valid.
+ *
+ * The empty string is valid, and corresponds to an empty array that will be
+ * returned for it.  A string like " " or " 1 " is invalid.
+ */
+bool IdArrayFromString (const std::string& str,
+                        std::vector<Database::IdT>& ids);
 
 /**
  * Converts an integer value to the proper JSON representation.


### PR DESCRIPTION
Extend move processing for character updates (`c` move field) to support ID lists instead of single IDs.  If an ID list is given, we update all characters from that list to the same value.  This can be useful for moving groups of characters, for instance.

For instance, a move like this can be used to set the same way points (or perform any other action) for three characters at once:

    {"c":{"1,5,42":{"wp":[...]}}}

When processing IDs and ID lists, first invalid entries are ignored (e.g. whitespace or otherwise invalid IDs/lists, or if the value is not a JSON object).  Then all IDs are extracted.  If any ID is duplicated, the whole character update command is ignored.  Otherwise, the IDs are sorted ascending by numeric value, and the updates processed in that order.

This implements #31.