### PR TITLE
Allow reducing movement speed voluntarily

### DIFF
--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -160,16 +160,18 @@ class MovementTest (PXTest):
     wp = self.offsetWaypoints ([{"x": 100, "y": 0}])
     c.sendMove ({"wp": wp, "speed": 1000})
     self.generate (10)
-    pos, _ = self.getMovement ("domob")
+    pos, mv = self.getMovement ("domob")
     self.assertEqual (pos, {"x": 10, "y": 0})
+    self.assertEqual (mv["chosenspeed"], 1000)
 
     # Adjust the speed to be higher than the natural speed of 3000,
     # and expect movement with the natural speed.
     c = self.getCharacters ()["domob"]
     c.sendMove ({"speed": 10000})
     self.generate (10)
-    pos, _ = self.getMovement ("domob")
+    pos, mv = self.getMovement ("domob")
     self.assertEqual (pos, {"x": 40, "y": 0})
+    self.assertEqual (mv["chosenspeed"], 10000)
 
     # Sending another movement in-between without speed will revert it to
     # the default one.
@@ -180,8 +182,9 @@ class MovementTest (PXTest):
     self.assertEqual (pos, {"x": 50, "y": 0})
     self.setWaypoints ("domob", [{"x": 0, "y": 0}])
     self.generate (10)
-    pos, _ = self.getMovement ("domob")
+    pos, mv = self.getMovement ("domob")
     self.assertEqual (pos, {"x": 20, "y": 0})
+    assert "chosenspeed" not in mv
 
     # Letting the movement finish and then sending a new movement will also
     # revert to intrinsic speed.
@@ -195,8 +198,9 @@ class MovementTest (PXTest):
     self.assertEqual (pos, {"x": 100, "y": 0})
     self.setWaypoints ("domob", [{"x": 0, "y": 0}])
     self.generate (10)
-    pos, _ = self.getMovement ("domob")
+    pos, mv = self.getMovement ("domob")
     self.assertEqual (pos, {"x": 70, "y": 0})
+    assert "chosenspeed" not in mv
 
     # Stop the character to avoid confusing later tests.
     self.setWaypoints ("domob", [])

--- a/proto/movement.proto
+++ b/proto/movement.proto
@@ -59,6 +59,13 @@ message Movement
    */
   repeated HexCoord steps = 2;
 
+  /**
+   * If set, then the character chooses to travel at the minimum of this value
+   * and its actual speed.  This can be used to reduce travel speed for faster
+   * vehicles to stay around slower ones in a convoy.
+   */
+  optional uint32 chosen_speed = 3;
+
 }
 
 /**

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -96,6 +96,9 @@ GetMovementJsonObject (const Character& c)
     {
       const auto& mvProto = pb.movement ();
 
+      if (mvProto.has_chosen_speed ())
+        res["chosenspeed"] = mvProto.chosen_speed ();
+
       Json::Value wp(Json::arrayValue);
       for (const auto& entry : mvProto.waypoints ())
         wp.append (CoordToJson (CoordFromProto (entry)));

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -128,6 +128,25 @@ TEST_F (CharacterJsonTests, Basic)
   })");
 }
 
+TEST_F (CharacterJsonTests, ChosenSpeed)
+{
+  auto c = tbl.CreateNew ("domob", Faction::RED);
+  c->MutableProto ().mutable_movement ()->set_chosen_speed (1234);
+  c.reset ();
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "movement":
+            {
+              "chosenspeed": 1234
+            }
+        }
+      ]
+  })");
+}
+
 TEST_F (CharacterJsonTests, Waypoints)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -489,6 +489,7 @@ TEST_F (PXLogicTests, FinishingProspecting)
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos);
   c->MutableProto ().mutable_combat_data ();
+  c->MutableProto ().set_speed (1000);
   c.reset ();
 
   /* Start prospecting with that character.  */

--- a/src/movement_tests.cpp
+++ b/src/movement_tests.cpp
@@ -281,6 +281,28 @@ TEST_F (MovementTests, FastSpeed)
     });
 }
 
+TEST_F (MovementTests, SlowChosenSpeed)
+{
+  SetWaypoints ({HexCoord (10, 0)});
+  GetTest ()->MutableProto ().mutable_movement ()->set_chosen_speed (1);
+  ExpectSteps (5, EdgeWeights (1),
+    {
+      {5, HexCoord (5, 0)},
+      {5, HexCoord (10, 0)},
+    });
+}
+
+TEST_F (MovementTests, FastChosenSpeed)
+{
+  SetWaypoints ({HexCoord (10, 0)});
+  GetTest ()->MutableProto ().mutable_movement ()->set_chosen_speed (5);
+  ExpectSteps (1, EdgeWeights (1),
+    {
+      {5, HexCoord (5, 0)},
+      {5, HexCoord (10, 0)},
+    });
+}
+
 TEST_F (MovementTests, DuplicateWaypoints)
 {
   SetWaypoints (
@@ -423,7 +445,11 @@ TEST_F (AllMovementTests, LongSteps)
      block.  In particular, this only works if updating the dynamic obstacle
      map for the vehicle being moved works correctly.  */
 
-  GetTest ()->MutableVolatileMv ().set_partial_step (1000000);
+  auto c = GetTest ();
+  c->MutableProto ().set_speed (1);
+  c->MutableVolatileMv ().set_partial_step (1000000);
+  c.reset ();
+
   SetWaypoints ({
     HexCoord (5, 0),
     HexCoord (5, 0),

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -378,11 +378,21 @@ MoveProcessor::MaybeSetCharacterWaypoints (Character& c, const Json::Value& upd)
 
   StopCharacter (c);
 
-  if (!wp.empty ())
+  if (wp.empty ())
+    return;
+
+  /* If the character has no movement speed, then we also do not set any
+     waypoints at all for it.  */
+  if (c.GetProto ().speed () == 0)
     {
-      auto* mv = c.MutableProto ().mutable_movement ();
-      SetRepeatedCoords (wp, *mv->mutable_waypoints ());
+      LOG (WARNING)
+          << "Ignoring waypoints for character " << c.GetId ()
+          << " with zero speed";
+      return;
     }
+
+  auto* mv = c.MutableProto ().mutable_movement ();
+  SetRepeatedCoords (wp, *mv->mutable_waypoints ());
 }
 
 void

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -363,6 +363,41 @@ MaybeTransferCharacter (Character& c, const Json::Value& upd)
   c.SetOwner (sendTo.asString ());
 }
 
+/**
+ * Sets the character's chosen speed from the update, if there is a command
+ * to do so in it.
+ */
+void
+MaybeSetCharacterSpeed (Character& c, const Json::Value& upd)
+{
+  CHECK (upd.isObject ());
+  const auto& val = upd["speed"];
+  if (!val.isUInt64 ())
+    return;
+
+  if (!c.GetProto ().has_movement ())
+    {
+      LOG (WARNING)
+          << "Can't set speed on character " << c.GetId ()
+          << ", which is not moving";
+      return;
+    }
+
+  const unsigned speed = val.asUInt64 ();
+  if (speed == 0 || speed > MAX_CHOSEN_SPEED)
+    {
+      LOG (WARNING)
+          << "Invalid chosen speed for character " << c.GetId ()
+          << ": " << upd;
+      return;
+    }
+
+  VLOG (1)
+      << "Setting chosen speed for character " << c.GetId ()
+      << " to: " << speed;
+  c.MutableProto ().mutable_movement ()->set_chosen_speed (speed);
+}
+
 } // anonymous namespace
 
 void
@@ -415,7 +450,12 @@ MoveProcessor::PerformCharacterUpdate (Character& c, const Json::Value& upd)
 {
   MaybeTransferCharacter (c, upd);
   MaybeStartProspecting (c, upd);
+
+  /* We need to process speed updates after the waypoints, because a speed
+     update is only valid if there is active movement.  That way, we can set
+     waypoints and a chosen speed in a single move.  */
   MaybeSetCharacterWaypoints (c, upd);
+  MaybeSetCharacterSpeed (c, upd);
 }
 
 namespace

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -36,6 +36,14 @@ namespace pxd
 {
 
 /**
+ * The maximum valid chosen speed value for a move.  This is consensus
+ * relevant, as it determines what moves will be considered valid.  The value
+ * is small enough to avoid overflowing the uint32 proto field, but it is also
+ * large enough to not be a restriction in practice (1k tiles per block).
+ */
+static constexpr unsigned MAX_CHOSEN_SPEED = 1000000;
+
+/**
  * Base class for MoveProcessor (handling confirmed moves) and PendingProcessor
  * (for processing pending moves).  It holds some common stuff for both
  * as well as some basic logic for processing some moves.


### PR DESCRIPTION
This set of changes allows players to voluntarily reduce their movement speed; in the future, this can be useful to move fast and slow vehicles as a convoy (see #32).

To make use of that, the speed should be set either together with waypoints or when a character is already moving in a follow-up move:

    {"c": {"42": {"wp": [...], "speed": 500}}}
    {"c": {"42": {"speed": 500}}}

The number is the speed in 1/1000 tiles, as elsewhere.  So with these commands, movement would be started or the existing movement "modified" so the vehicle only moves at one tile every two blocks.  Speeds above 1000000 or below 1 are considered invalid, in which case nothing will be changed for them.

When movement stops or is modified (e.g. new waypoints), the chosen speed is cleared and the vehicle returns back to its native speed.  When the speed is larger than the native speed, it is still stored but has no effect (i.e. the character moves at the minimum of the chosen speed and its native speed).

When set, this is also present alongside the waypoints in the character's game-state JSON.