### PR TITLE
Lock names/accounts to factions

### DIFF
--- a/database/account.hpp
+++ b/database/account.hpp
@@ -20,6 +20,7 @@
 #define DATABASE_ACCOUNT_HPP
 
 #include "database.hpp"
+#include "faction.hpp"
 
 #include <memory>
 #include <string>
@@ -30,7 +31,7 @@ namespace pxd
 /**
  * Database result type for rows from the accounts table.
  */
-struct AccountResult : public Database::ResultType
+struct AccountResult : public ResultWithFaction
 {
   RESULT_COLUMN (std::string, name, 1);
   RESULT_COLUMN (int64_t, kills, 2);
@@ -52,6 +53,9 @@ private:
   /** The Xaya name of this account.  */
   std::string name;
 
+  /** The faction of this account.  */
+  Faction faction;
+
   /** The account's number of kills.  */
   unsigned kills;
 
@@ -65,9 +69,10 @@ private:
   bool dirty;
 
   /**
-   * Constructs an instance with "default / empty" data for the given name.
+   * Constructs an instance with "default / empty" data for the given name
+   * and selected faction.
    */
-  explicit Account (Database& d, const std::string& n);
+  explicit Account (Database& d, const std::string& n, Faction f);
 
   /**
    * Constructs an instance based on the given DB result set.  The result
@@ -95,6 +100,12 @@ public:
   GetName () const
   {
     return name;
+  }
+
+  Faction
+  GetFaction () const
+  {
+    return faction;
   }
 
   unsigned
@@ -151,6 +162,15 @@ public:
   void operator= (const AccountsTable&) = delete;
 
   /**
+   * Creates a new entry in the database for the given name and selected
+   * faction.  Each player has to select their faction before doing anything
+   * else, and that move will create the account in the database.
+   *
+   * Calling this method for a name that already has an account is an error.
+   */
+  Handle CreateNew (const std::string& name, Faction faction);
+
+  /**
    * Returns a handle for the instance based on a Database::Result.
    */
   Handle GetFromResult (const Database::Result<AccountResult>& res);
@@ -161,11 +181,11 @@ public:
   Handle GetByName (const std::string& name);
 
   /**
-   * Queries the database for all accounts with (potentially) non-empty
-   * data stored.  Returns a result set that can be used together with
+   * Queries the database for all accounts which have been initialised yet
+   * with a faction.  Returns a result set that can be used together with
    * GetFromResult.
    */
-  Database::Result<AccountResult> QueryNonTrivial ();
+  Database::Result<AccountResult> QueryInitialised ();
 
 };
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -26,7 +26,9 @@ CREATE TABLE IF NOT EXISTS `characters` (
 
   -- The faction (as integer corresponding to the Faction enum in C++).
   -- We need this for querying combat targets, which should be possible to
-  -- do without decoding the proto.
+  -- do without decoding the proto.  Note that this field is in theory
+  -- redundant with the owner account's faction, but we have it duplicated here
+  -- for easy access and because the faction is often needed for characters.
   `faction` INTEGER NOT NULL,
 
   -- Current position of the character on the map.  We need this in the table

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -130,6 +130,9 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   -- The Xaya p/ name of this account.
   `name` TEXT PRIMARY KEY,
 
+  -- The faction (as integer corresponding to the Faction enum in C++).
+  `faction` INTEGER NOT NULL,
+
   -- The number of characters killed by the account in total.
   `kills` INTEGER NOT NULL,
 

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -2,6 +2,7 @@ TEST_LIBRARY = \
   pxtest.py
 
 REGTESTS = \
+  accounts.py \
   characters.py \
   combat_damage.py \
   combat_targets.py \

--- a/gametest/accounts.py
+++ b/gametest/accounts.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# coding=utf8
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests creation / initialisation of accounts.
+"""
+
+from pxtest import PXTest, CHARACTER_COST
+
+
+class AccountsTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("No accounts yet...")
+    accounts = self.getAccounts ()
+    self.assertEqual (accounts, {})
+
+    self.mainLogger.info ("Initialising basic accounts...")
+    self.initAccount ("domob", "r")
+    self.initAccount ("domob", "g")
+    self.initAccount ("andy", "b")
+    self.generate (1)
+
+    accounts = self.getAccounts ()
+    self.assertEqual (accounts["domob"].getFaction (), "r")
+    self.assertEqual (accounts["andy"].getFaction (), "b")
+
+
+if __name__ == "__main__":
+  AccountsTest ().main ()

--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -49,7 +49,7 @@ class CharactersTest (PXTest):
     self.mainLogger.info ("Creating first character...")
     self.moveWithPayment ("adam", {
       "a": {"init": {"faction": "r"}},
-      "nc": [{"faction": "r"}],
+      "nc": [{}],
     }, CHARACTER_COST)
     self.generate (1)
     self.expectPartial ({
@@ -58,7 +58,7 @@ class CharactersTest (PXTest):
 
     self.mainLogger.info ("Testing \"\" as owner name...")
     self.initAccount ("", "g")
-    self.createCharacter ("", "g")
+    self.createCharacters ("")
     self.generate (1)
     self.expectPartial ({
       "adam": {"owner": "adam", "faction": "r"},
@@ -66,17 +66,17 @@ class CharactersTest (PXTest):
     })
 
     self.mainLogger.info ("Creating second character for one owner...")
-    self.createCharacter ("adam", "b")
+    self.createCharacters ("adam")
     self.generate (1)
     self.expectPartial ({
       "adam": {"owner": "adam", "faction": "r"},
-      "adam 2": {"owner": "adam", "faction": "b"},
+      "adam 2": {"owner": "adam", "faction": "r"},
       "": {"owner": "", "faction": "g"},
     })
 
     self.mainLogger.info ("Testing Unicode owner...")
     self.initAccount (u"äöü", "b")
-    self.createCharacter (u"äöü", "b")
+    self.createCharacters (u"äöü")
     self.generate (1)
     self.expectPartial ({
       "adam": {"owner": "adam"},
@@ -90,7 +90,7 @@ class CharactersTest (PXTest):
     c.sendMove ({"send": "andy"})
     self.generate (1)
     self.expectPartial ({
-      "adam": {"owner": "adam", "faction": "b"},
+      "adam": {"owner": "adam", "faction": "r"},
       "andy": {"owner": "andy", "faction": "r"},
       "": {"owner": ""},
       u"äöü": {"owner": u"äöü"},
@@ -110,12 +110,7 @@ class CharactersTest (PXTest):
 
     self.mainLogger.info ("Multiple creations in one transaction...")
     self.initAccount ("domob", "r")
-    data = [
-      {"faction": "r"},
-      {"faction": "r"},
-      {"faction": "r"},
-    ]
-    self.moveWithPayment ("domob", {"nc": data}, 2.5 * CHARACTER_COST)
+    self.moveWithPayment ("domob", {"nc": [{}, {}, {}]}, 2.5 * CHARACTER_COST)
     self.generate (1)
     self.expectPartial ({
       "adam": {"owner": "adam"},
@@ -153,7 +148,7 @@ class CharactersTest (PXTest):
 
     self.collectPremine ()
     self.initAccount ("domob", "b")
-    self.createCharacter ("domob", "b")
+    self.createCharacters ("domob")
     self.generate (1)
     self.expectPartial ({
       "domob": {"owner": "domob"},

--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -86,6 +86,7 @@ class CharactersTest (PXTest):
     })
 
     self.mainLogger.info ("Transfering a character...")
+    self.initAccount ("andy", "r")
     c = self.getCharacters ()["adam"]
     c.sendMove ({"send": "andy"})
     self.generate (1)
@@ -109,7 +110,7 @@ class CharactersTest (PXTest):
     })
 
     self.mainLogger.info ("Multiple creations in one transaction...")
-    self.initAccount ("domob", "r")
+    self.initAccount ("domob", "b")
     self.moveWithPayment ("domob", {"nc": [{}, {}, {}]}, 2.5 * CHARACTER_COST)
     self.generate (1)
     self.expectPartial ({
@@ -117,11 +118,12 @@ class CharactersTest (PXTest):
       "andy": {"owner": "andy"},
       "": {"owner": ""},
       u"äöü": {"owner": u"äöü"},
-      "domob": {"faction": "r"},
-      "domob 2": {"faction": "r"},
+      "domob": {"faction": "b"},
+      "domob 2": {"faction": "b"},
     })
 
     self.mainLogger.info ("Updates with ID lists...")
+    self.initAccount ("idlist", "b")
     id1 = self.getCharacters ()["domob"].getId ()
     id2 = self.getCharacters ()["domob 2"].getId ()
     self.sendMove ("domob", {
@@ -147,7 +149,7 @@ class CharactersTest (PXTest):
     self.rpc.xaya.invalidateblock (blk)
 
     self.collectPremine ()
-    self.initAccount ("domob", "b")
+    self.initAccount ("domob", "r")
     self.createCharacters ("domob")
     self.generate (1)
     self.expectPartial ({

--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -40,7 +40,6 @@ class CharactersTest (PXTest):
     self.assertEqual (len (chars), len (expected))
 
     for nm, c in chars.iteritems ():
-      assert nm in expected
       c.expectPartial (expected[nm])
 
   def run (self):
@@ -87,15 +86,21 @@ class CharactersTest (PXTest):
 
     self.mainLogger.info ("Transfering a character...")
     self.initAccount ("andy", "r")
+    self.generate (1)
     c = self.getCharacters ()["adam"]
+    cid = c.getId ()
     c.sendMove ({"send": "andy"})
     self.generate (1)
-    self.expectPartial ({
-      "adam": {"owner": "adam", "faction": "r"},
-      "andy": {"owner": "andy", "faction": "r"},
-      "": {"owner": ""},
-      u"äöü": {"owner": u"äöü"},
-    })
+    self.getCharacters ()["andy"].expectPartial ({"id": cid})
+
+    self.mainLogger.info ("Invalid transfers...")
+    self.initAccount ("green", "g")
+    c = self.getCharacters ()["andy"]
+    cid = c.getId ()
+    c.sendMove ({"send": "uninitialised account"})
+    c.sendMove ({"send": "green"})
+    self.generate (1)
+    self.getCharacters ()["andy"].expectPartial ({"id": cid})
 
     self.mainLogger.info ("Non-owner cannot update the character...")
     c = self.getCharacters ()["adam"]
@@ -124,6 +129,7 @@ class CharactersTest (PXTest):
 
     self.mainLogger.info ("Updates with ID lists...")
     self.initAccount ("idlist", "b")
+    self.generate (1)
     id1 = self.getCharacters ()["domob"].getId ()
     id2 = self.getCharacters ()["domob 2"].getId ()
     self.sendMove ("domob", {

--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -17,12 +17,12 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest, CHARACTER_COST
-
 """
 Runs tests about the basic handling of characters (creating them, transferring
 them and retrieving them through RPC).
 """
+
+from pxtest import PXTest, CHARACTER_COST
 
 
 class CharactersTest (PXTest):
@@ -47,14 +47,17 @@ class CharactersTest (PXTest):
     self.collectPremine ()
 
     self.mainLogger.info ("Creating first character...")
-    self.createCharacter ("adam", "r")
-    self.sendMove ("", {"nc": {"name": "eve", "faction": "r"}})
+    self.moveWithPayment ("adam", {
+      "a": {"init": {"faction": "r"}},
+      "nc": [{"faction": "r"}],
+    }, CHARACTER_COST)
     self.generate (1)
     self.expectPartial ({
       "adam": {"owner": "adam", "faction": "r"},
     })
 
     self.mainLogger.info ("Testing \"\" as owner name...")
+    self.initAccount ("", "g")
     self.createCharacter ("", "g")
     self.generate (1)
     self.expectPartial ({
@@ -72,6 +75,7 @@ class CharactersTest (PXTest):
     })
 
     self.mainLogger.info ("Testing Unicode owner...")
+    self.initAccount (u"äöü", "b")
     self.createCharacter (u"äöü", "b")
     self.generate (1)
     self.expectPartial ({
@@ -105,10 +109,11 @@ class CharactersTest (PXTest):
     })
 
     self.mainLogger.info ("Multiple creations in one transaction...")
+    self.initAccount ("domob", "r")
     data = [
       {"faction": "r"},
-      {"faction": "g"},
-      {"faction": "b"},
+      {"faction": "r"},
+      {"faction": "r"},
     ]
     self.moveWithPayment ("domob", {"nc": data}, 2.5 * CHARACTER_COST)
     self.generate (1)
@@ -118,7 +123,7 @@ class CharactersTest (PXTest):
       "": {"owner": ""},
       u"äöü": {"owner": u"äöü"},
       "domob": {"faction": "r"},
-      "domob 2": {"faction": "g"},
+      "domob 2": {"faction": "r"},
     })
 
     self.mainLogger.info ("Updates with ID lists...")
@@ -147,6 +152,7 @@ class CharactersTest (PXTest):
     self.rpc.xaya.invalidateblock (blk)
 
     self.collectPremine ()
+    self.initAccount ("domob", "b")
     self.createCharacter ("domob", "b")
     self.generate (1)
     self.expectPartial ({
@@ -155,7 +161,6 @@ class CharactersTest (PXTest):
 
     self.rpc.xaya.reconsiderblock (blk)
     self.expectGameState (originalState)
-
 
 
 if __name__ == "__main__":

--- a/gametest/combat_damage.py
+++ b/gametest/combat_damage.py
@@ -16,11 +16,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest, offsetCoord
-
 """
 Tests dealing damage, regenerating the shield and killing characters.
 """
+
+from pxtest import PXTest, offsetCoord
 
 # Owner of the target character.
 TARGET = "target"
@@ -48,9 +48,11 @@ class CombatDamageTest (PXTest):
     numAttackers = 5
 
     self.mainLogger.info ("Creating test characters...")
+    self.initAccount (TARGET, "b")
     self.createCharacter (TARGET, "b")
-    self.createCharacter ("attacker 1", "r")
-    self.createCharacter ("attacker 2", "r")
+    self.initAccount ("attacker", "r")
+    self.createCharacter ("attacker", "r")
+    self.createCharacter ("attacker", "r")
     self.generate (1)
 
     # We use a known good position as offset for our test.
@@ -58,7 +60,7 @@ class CombatDamageTest (PXTest):
     self.inRange = offsetCoord ({"x": 0, "y": 0}, self.offset, False)
     outOfRange = offsetCoord ({"x": 0, "y": 20}, self.offset, False)
     self.moveCharactersTo ({
-      "attacker 1": offsetCoord ({"x": 0, "y": 1}, self.offset, False),
+      "attacker": offsetCoord ({"x": 0, "y": 1}, self.offset, False),
       "attacker 2": offsetCoord ({"x": 1, "y": 0}, self.offset, False),
     })
     self.getTargetHP ()

--- a/gametest/combat_damage.py
+++ b/gametest/combat_damage.py
@@ -49,10 +49,9 @@ class CombatDamageTest (PXTest):
 
     self.mainLogger.info ("Creating test characters...")
     self.initAccount (TARGET, "b")
-    self.createCharacter (TARGET, "b")
+    self.createCharacters (TARGET)
     self.initAccount ("attacker", "r")
-    self.createCharacter ("attacker", "r")
-    self.createCharacter ("attacker", "r")
+    self.createCharacters ("attacker", 2)
     self.generate (1)
 
     # We use a known good position as offset for our test.

--- a/gametest/combat_targets.py
+++ b/gametest/combat_targets.py
@@ -56,10 +56,9 @@ class CombatTargetTest (PXTest):
 
     self.mainLogger.info ("Creating test characters...")
     self.initAccount ("red", "r")
-    self.createCharacter ("red", "r")
+    self.createCharacters ("red")
     self.initAccount ("green", "g")
-    self.createCharacter ("green", "g")
-    self.createCharacter ("green", "g")
+    self.createCharacters ("green", 2)
     self.generate (1)
 
     # We use the starting coordinate of green 1 as offset for coordinates,

--- a/gametest/combat_targets.py
+++ b/gametest/combat_targets.py
@@ -16,11 +16,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest, offsetCoord
-
 """
 Tests the target selection aspect of combat.
 """
+
+from pxtest import PXTest, offsetCoord
 
 
 class CombatTargetTest (PXTest):
@@ -55,32 +55,34 @@ class CombatTargetTest (PXTest):
     self.collectPremine ()
 
     self.mainLogger.info ("Creating test characters...")
-    self.createCharacter ("a", "r")
-    self.createCharacter ("b", "g")
-    self.createCharacter ("c", "g")
+    self.initAccount ("red", "r")
+    self.createCharacter ("red", "r")
+    self.initAccount ("green", "g")
+    self.createCharacter ("green", "g")
+    self.createCharacter ("green", "g")
     self.generate (1)
 
-    # We use the starting coordinate of b as offset for coordinates,
+    # We use the starting coordinate of green 1 as offset for coordinates,
     # so that the test is independent of the actual starting positions
     # of the characters.
-    c = self.getCharacters ()["b"]
+    c = self.getCharacters ()["green"]
     self.offset = c.getPosition ()
 
     # Move all other characters in range before continuing with
     # the rest of the test.
     self.moveCharactersTo ({
-      "a": offsetCoord ({"x": 1, "y": 0}, self.offset, False),
-      "c": offsetCoord ({"x": 0, "y": 1}, self.offset, False),
+      "red": offsetCoord ({"x": 1, "y": 0}, self.offset, False),
+      "green 2": offsetCoord ({"x": 0, "y": 1}, self.offset, False),
     })
 
     self.mainLogger.info ("Testing randomised target selection...")
-    cnts = {"b": 0, "c": 0}
+    cnts = {"green": 0, "green 2": 0}
     rolls = 10
     for _ in range (rolls):
       self.generate (1)
-      self.assertEqual (self.getTargetCharacter ("b"), "a")
-      self.assertEqual (self.getTargetCharacter ("c"), "a")
-      fooTarget = self.getTargetCharacter ("a")
+      self.assertEqual (self.getTargetCharacter ("green"), "red")
+      self.assertEqual (self.getTargetCharacter ("green 2"), "red")
+      fooTarget = self.getTargetCharacter ("red")
       assert fooTarget is not None
       assert fooTarget in cnts
       cnts[fooTarget] += 1
@@ -92,18 +94,18 @@ class CombatTargetTest (PXTest):
       assert cnt > 0
 
     self.mainLogger.info ("Testing target selection when moving into range...")
-    c = self.getCharacters ()["a"]
+    c = self.getCharacters ()["red"]
     self.moveCharactersTo ({
-      "a": offsetCoord ({"x": 13, "y": 0}, self.offset, False),
+      "red": offsetCoord ({"x": 13, "y": 0}, self.offset, False),
     })
-    assert self.getTargetCharacter ("b") is None
+    assert self.getTargetCharacter ("green") is None
     # Note that we can move a directly to the offset coordinate (where also
     # b is), since a and b are of different factions.
     c.sendMove ({"wp": [self.offset]})
     self.generate (1)
-    self.assertEqual (self.getCharacters ()["a"].getPosition (),
+    self.assertEqual (self.getCharacters ()["red"].getPosition (),
                       offsetCoord ({"x": 10, "y": 0}, self.offset, False))
-    self.assertEqual (self.getTargetCharacter ("b"), "a")
+    self.assertEqual (self.getTargetCharacter ("green"), "red")
 
 
 if __name__ == "__main__":

--- a/gametest/damage_lists.py
+++ b/gametest/damage_lists.py
@@ -55,9 +55,9 @@ class DamageListsTest (PXTest):
 
     self.mainLogger.info ("Creating test characters...")
     self.initAccount ("target", "b")
-    self.createCharacter ("target", "b")
+    self.createCharacters ("target")
     self.initAccount ("attacker", "r")
-    self.createCharacters ("attacker", ["r"] * 2)
+    self.createCharacters ("attacker", 2)
     self.generate (1)
 
     # We use a known good position as offset and move the characters

--- a/gametest/damage_lists.py
+++ b/gametest/damage_lists.py
@@ -16,11 +16,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest, offsetCoord
-
 """
 Tests tracking of damage lists.
 """
+
+from pxtest import PXTest, offsetCoord
 
 
 class DamageListsTest (PXTest):
@@ -54,9 +54,10 @@ class DamageListsTest (PXTest):
     self.collectPremine ()
 
     self.mainLogger.info ("Creating test characters...")
+    self.initAccount ("target", "b")
     self.createCharacter ("target", "b")
-    self.createCharacter ("attacker 1", "r")
-    self.createCharacter ("attacker 2", "r")
+    self.initAccount ("attacker", "r")
+    self.createCharacters ("attacker", ["r"] * 2)
     self.generate (1)
 
     # We use a known good position as offset and move the characters
@@ -64,19 +65,19 @@ class DamageListsTest (PXTest):
     self.offset = {"x": -1100, "y": 1042}
     self.moveCharactersTo ({
       "target": self.offset,
-      "attacker 1": offsetCoord ({"x": -5, "y": 0}, self.offset, False),
+      "attacker": offsetCoord ({"x": -5, "y": 0}, self.offset, False),
       "attacker 2": offsetCoord ({"x": 5, "y": 0}, self.offset, False),
     })
 
     # Check state after exactly one round of attacks.
     self.mainLogger.info ("Attacking and testing damage lists...")
     self.generate (1)
-    self.expectAttackers ("target", ["attacker 1", "attacker 2"])
-    if len (self.getAttackers ("attacker 1")) > 0:
-      self.expectAttackers ("attacker 1", ["target"])
+    self.expectAttackers ("target", ["attacker", "attacker 2"])
+    if len (self.getAttackers ("attacker")) > 0:
+      self.expectAttackers ("attacker", ["target"])
       self.expectAttackers ("attacker 2", [])
     else:
-      self.expectAttackers ("attacker 1", [])
+      self.expectAttackers ("attacker", [])
       self.expectAttackers ("attacker 2", ["target"])
 
     # Move the target out of range and verify timeout of the damage list.
@@ -88,7 +89,7 @@ class DamageListsTest (PXTest):
       "target": offsetCoord ({"x": -100, "y": 0}, self.offset, False),
     })
     self.generate (99)
-    self.expectAttackers ("target", ["attacker 1", "attacker 2"])
+    self.expectAttackers ("target", ["attacker", "attacker 2"])
     self.generate (1)
     self.expectAttackers ("target", [])
 

--- a/gametest/fame.py
+++ b/gametest/fame.py
@@ -16,11 +16,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest
-
 """
 Tests the fame and kills update of accounts.
 """
+
+from pxtest import PXTest
 
 
 class FameTest (PXTest):
@@ -29,7 +29,9 @@ class FameTest (PXTest):
     self.collectPremine ()
 
     self.mainLogger.info ("Characters killing each other at the same time...")
+    self.initAccount ("foo", "r")
     self.createCharacter ("foo", "r")
+    self.initAccount ("bar", "g")
     self.createCharacter ("bar", "g")
     self.generate (1)
     self.moveCharactersTo ({
@@ -51,8 +53,11 @@ class FameTest (PXTest):
     self.assertEqual (accounts["bar"].data["fame"], 100)
 
     self.mainLogger.info ("Multiple killers...")
+    self.initAccount ("red", "r")
     self.createCharacters ("red", 2 * ["r"])
+    self.initAccount ("green", "g")
     self.createCharacter ("green", "g")
+    self.initAccount ("blue", "b")
     self.createCharacter ("blue", "b")
     self.generate (1)
     self.moveCharactersTo ({
@@ -80,8 +85,11 @@ class FameTest (PXTest):
 
     self.mainLogger.info ("Many characters for a name...")
     armySize = 10
+    self.initAccount ("army", "r")
     self.createCharacters ("army", armySize * ["r"])
+    self.initAccount ("other army", "r")
     self.createCharacters ("other army", armySize * ["r"])
+    self.initAccount ("target", "b")
     self.createCharacters ("target", 2 * ["b"])
     self.generate (1)
     mv = {

--- a/gametest/fame.py
+++ b/gametest/fame.py
@@ -30,9 +30,9 @@ class FameTest (PXTest):
 
     self.mainLogger.info ("Characters killing each other at the same time...")
     self.initAccount ("foo", "r")
-    self.createCharacter ("foo", "r")
+    self.createCharacters ("foo")
     self.initAccount ("bar", "g")
-    self.createCharacter ("bar", "g")
+    self.createCharacters ("bar")
     self.generate (1)
     self.moveCharactersTo ({
       "foo": {"x": 0, "y": 0},
@@ -54,11 +54,11 @@ class FameTest (PXTest):
 
     self.mainLogger.info ("Multiple killers...")
     self.initAccount ("red", "r")
-    self.createCharacters ("red", 2 * ["r"])
+    self.createCharacters ("red", 2)
     self.initAccount ("green", "g")
-    self.createCharacter ("green", "g")
+    self.createCharacters ("green")
     self.initAccount ("blue", "b")
-    self.createCharacter ("blue", "b")
+    self.createCharacters ("blue")
     self.generate (1)
     self.moveCharactersTo ({
       "blue": {"x": 0, "y": 0},
@@ -86,11 +86,11 @@ class FameTest (PXTest):
     self.mainLogger.info ("Many characters for a name...")
     armySize = 10
     self.initAccount ("army", "r")
-    self.createCharacters ("army", armySize * ["r"])
+    self.createCharacters ("army", armySize)
     self.initAccount ("other army", "r")
-    self.createCharacters ("other army", armySize * ["r"])
+    self.createCharacters ("other army", armySize)
     self.initAccount ("target", "b")
-    self.createCharacters ("target", 2 * ["b"])
+    self.createCharacters ("target", 2)
     self.generate (1)
     mv = {
       "target": {"x": 100, "y": 0},

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -16,11 +16,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest
-
 """
 Tests the god-mode commands.
 """
+
+from pxtest import PXTest
 
 
 class GodModeTest (PXTest):
@@ -28,6 +28,7 @@ class GodModeTest (PXTest):
   def run (self):
     self.collectPremine ()
 
+    self.initAccount ("domob", "r")
     self.createCharacter ("domob", "r")
     self.generate (1)
     c = self.getCharacters ()["domob"]

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -29,7 +29,7 @@ class GodModeTest (PXTest):
     self.collectPremine ()
 
     self.initAccount ("domob", "r")
-    self.createCharacter ("domob", "r")
+    self.createCharacters ("domob")
     self.generate (1)
     c = self.getCharacters ()["domob"]
     pos = c.getPosition ()

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -96,7 +96,7 @@ class MovementTest (PXTest):
 
     self.mainLogger.info ("Creating test character...")
     self.initAccount ("domob", "r")
-    self.createCharacter ("domob", "r")
+    self.createCharacters ("domob")
     self.generate (1)
 
     # Start off from a known good location to make sure all is fine and
@@ -216,7 +216,7 @@ class MovementTest (PXTest):
     self.mainLogger.info ("Testing blocking the path...")
 
     self.initAccount ("blocker", "r")
-    self.createCharacter ("blocker", "r")
+    self.createCharacters ("blocker")
     self.generate (1)
 
     self.moveCharactersTo ({

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -16,11 +16,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest, offsetCoord
-
 """
 Tests movement of characters on the map.
 """
+
+from pxtest import PXTest, offsetCoord
 
 
 class MovementTest (PXTest):
@@ -95,6 +95,7 @@ class MovementTest (PXTest):
     self.collectPremine ()
 
     self.mainLogger.info ("Creating test character...")
+    self.initAccount ("domob", "r")
     self.createCharacter ("domob", "r")
     self.generate (1)
 
@@ -214,6 +215,7 @@ class MovementTest (PXTest):
 
     self.mainLogger.info ("Testing blocking the path...")
 
+    self.initAccount ("blocker", "r")
     self.createCharacter ("blocker", "r")
     self.generate (1)
 

--- a/gametest/multiupdate.py
+++ b/gametest/multiupdate.py
@@ -30,7 +30,7 @@ class MultiUpdateTest (PXTest):
 
     self.mainLogger.info ("Creating test character...")
     self.initAccount ("domob", "r")
-    self.createCharacter ("domob", "r")
+    self.createCharacters ("domob")
     self.generate (1)
 
     # Start off from a known good location to make sure all is fine and

--- a/gametest/multiupdate.py
+++ b/gametest/multiupdate.py
@@ -16,11 +16,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest, offsetCoord
-
 """
 Tests that Taurion works fine with multiple name updates in a single block.
 """
+
+from pxtest import PXTest, offsetCoord
 
 
 class MultiUpdateTest (PXTest):
@@ -29,6 +29,7 @@ class MultiUpdateTest (PXTest):
     self.collectPremine ()
 
     self.mainLogger.info ("Creating test character...")
+    self.initAccount ("domob", "r")
     self.createCharacter ("domob", "r")
     self.generate (1)
 

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -45,6 +45,7 @@ class PendingTest (PXTest):
     regionId = self.rpc.game.getregionat (coord=position)["id"]
 
     self.mainLogger.info ("Creating test character...")
+    self.initAccount ("domob", "r")
     self.createCharacter ("domob", "r")
     self.generate (1)
     self.moveCharactersTo ({
@@ -59,7 +60,7 @@ class PendingTest (PXTest):
     })
 
     self.mainLogger.info ("Performing pending updates...")
-    self.createCharacter ("domob", "g")
+    self.createCharacter ("domob", "r")
     c = self.getCharacters ()["domob"]
     c.sendMove ({"wp": []})
 
@@ -74,12 +75,13 @@ class PendingTest (PXTest):
         ],
       "newcharacters":
         [
-          {"name": "domob", "creations": [{"faction": "g"}]},
+          {"name": "domob", "creations": [{"faction": "r"}]},
         ],
     })
 
-    self.createCharacter ("domob", "b")
-    self.createCharacter ("andy", "r")
+    self.createCharacter ("domob", "r")
+    self.initAccount ("andy", "b")
+    self.createCharacter ("andy", "b")
     c.sendMove ({"wp": [{"x": 5, "y": -5}]})
 
     sleepSome ()
@@ -93,8 +95,8 @@ class PendingTest (PXTest):
         ],
       "newcharacters":
         [
-          {"name": "andy", "creations": [{"faction": "r"}]},
-          {"name": "domob", "creations": [{"faction": "g"}, {"faction": "b"}]},
+          {"name": "andy", "creations": [{"faction": "b"}]},
+          {"name": "domob", "creations": [{"faction": "r"}] * 2},
         ],
     })
 
@@ -111,8 +113,8 @@ class PendingTest (PXTest):
         ],
       "newcharacters":
         [
-          {"name": "andy", "creations": [{"faction": "r"}]},
-          {"name": "domob", "creations": [{"faction": "g"}, {"faction": "b"}]},
+          {"name": "andy", "creations": [{"faction": "b"}]},
+          {"name": "domob", "creations": [{"faction": "r"}, {"faction": "r"}]},
         ],
     })
 

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -47,7 +47,7 @@ class PendingTest (PXTest):
     self.mainLogger.info ("Creating test character...")
     self.initAccount ("andy", "b")
     self.initAccount ("domob", "r")
-    self.createCharacter ("domob", "r")
+    self.createCharacters ("domob")
     self.generate (1)
     self.moveCharactersTo ({
       "domob": position,
@@ -61,7 +61,7 @@ class PendingTest (PXTest):
     })
 
     self.mainLogger.info ("Performing pending updates...")
-    self.createCharacter ("domob", "r")
+    self.createCharacters ("domob")
     c = self.getCharacters ()["domob"]
     c.sendMove ({"wp": []})
 
@@ -80,8 +80,8 @@ class PendingTest (PXTest):
         ],
     })
 
-    self.createCharacter ("domob", "r")
-    self.createCharacter ("andy", "b")
+    self.createCharacters ("domob")
+    self.createCharacters ("andy")
     c.sendMove ({"wp": [{"x": 5, "y": -5}]})
 
     sleepSome ()

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -45,6 +45,7 @@ class PendingTest (PXTest):
     regionId = self.rpc.game.getregionat (coord=position)["id"]
 
     self.mainLogger.info ("Creating test character...")
+    self.initAccount ("andy", "b")
     self.initAccount ("domob", "r")
     self.createCharacter ("domob", "r")
     self.generate (1)
@@ -80,7 +81,6 @@ class PendingTest (PXTest):
     })
 
     self.createCharacter ("domob", "r")
-    self.initAccount ("andy", "b")
     self.createCharacter ("andy", "b")
     c.sendMove ({"wp": [{"x": 5, "y": -5}]})
 

--- a/gametest/prospecting.py
+++ b/gametest/prospecting.py
@@ -64,11 +64,11 @@ class ProspectingTest (PXTest):
 
     self.mainLogger.info ("Setting up test characters...")
     self.initAccount ("target", "r")
-    self.createCharacter ("target", "r")
+    self.createCharacters ("target")
     self.initAccount ("attacker 1", "g")
-    self.createCharacter ("attacker 1", "g")
+    self.createCharacters ("attacker 1")
     self.initAccount ("attacker 2", "g")
-    self.createCharacter ("attacker 2", "g")
+    self.createCharacters ("attacker 2")
     self.generate (1)
 
     # Set up known positions of the characters.  We use a known good position
@@ -206,7 +206,7 @@ class ProspectingTest (PXTest):
     self.mainLogger.info ("Testing randomisation of prizes...")
 
     self.initAccount ("prize trier", "r")
-    c = self.createCharacter ("prize trier", "r")
+    c = self.createCharacters ("prize trier")
     self.generate (1)
     pos = {"x": -1000, "y": 1000}
     self.moveCharactersTo ({"prize trier": pos})
@@ -287,7 +287,7 @@ class ProspectingTest (PXTest):
         assert region.getId () not in regionIds
         regionIds.add (region.getId ())
 
-        self.createCharacter ("prize trier", "r")
+        self.createCharacters ("prize trier")
         nm = "prize trier %d" % nextInd
         nextInd += 1
         sendTo[nm] = pos

--- a/gametest/prospecting.py
+++ b/gametest/prospecting.py
@@ -16,12 +16,12 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest, offsetCoord
-
 """
 Tests prospecting with characters and various interactions of that with
 movement and combat.
 """
+
+from pxtest import PXTest, offsetCoord
 
 # Timestamps when the competition is still active and when it is
 # already over.  Note that for some reason we cannot be exact to the
@@ -63,8 +63,11 @@ class ProspectingTest (PXTest):
     self.generate (1)
 
     self.mainLogger.info ("Setting up test characters...")
+    self.initAccount ("target", "r")
     self.createCharacter ("target", "r")
+    self.initAccount ("attacker 1", "g")
     self.createCharacter ("attacker 1", "g")
+    self.initAccount ("attacker 2", "g")
     self.createCharacter ("attacker 2", "g")
     self.generate (1)
 
@@ -202,6 +205,7 @@ class ProspectingTest (PXTest):
     # same region to get both no prize and a silver tier.
     self.mainLogger.info ("Testing randomisation of prizes...")
 
+    self.initAccount ("prize trier", "r")
     c = self.createCharacter ("prize trier", "r")
     self.generate (1)
     pos = {"x": -1000, "y": 1000}
@@ -274,6 +278,7 @@ class ProspectingTest (PXTest):
 
     sendTo = {}
     regionIds = set ()
+    nextInd = 2
     for i in range (2):
       for j in range (10):
         pos = {"x": 20 * i, "y": 20 * j}
@@ -282,8 +287,9 @@ class ProspectingTest (PXTest):
         assert region.getId () not in regionIds
         regionIds.add (region.getId ())
 
-        nm = "char %d, %d" % (i, j)
-        self.createCharacter (nm, "r")
+        self.createCharacter ("prize trier", "r")
+        nm = "prize trier %d" % nextInd
+        nextInd += 1
         sendTo[nm] = pos
     self.generate (1)
     self.moveCharactersTo (sendTo)

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -172,28 +172,13 @@ class PXTest (XayaGameTest):
 
     return self.sendMove (name, move)
 
-  def createCharacter (self, owner, faction):
-    """
-    Utility method to send a move creating a character.
-    """
-
-    data = {
-      "faction": faction,
-    }
-
-    return self.moveWithPayment (owner, {"nc": [data]}, CHARACTER_COST)
-
-  def createCharacters (self, owner, factions):
+  def createCharacters (self, owner, num=1):
     """
     Utility method to create multiple characters for a given owner.
     """
 
-    data = [{
-      "faction": faction,
-    } for faction in factions]
-
-    return self.moveWithPayment (owner, {"nc": data},
-                                 len (data) * CHARACTER_COST)
+    return self.moveWithPayment (owner, {"nc": [{}] * num},
+                                 num * CHARACTER_COST)
 
   def getCharacters (self):
     """

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -111,6 +111,9 @@ class Account (object):
   def getName (self):
     return self.data["name"]
 
+  def getFaction (self):
+    return self.data["faction"]
+
 
 class Region (object):
   """
@@ -151,6 +154,23 @@ class PXTest (XayaGameTest):
     """
 
     return self.sendMove (name, move, {"sendCoins": {DEVADDR: devAmount}})
+
+  def initAccount (self, name, faction):
+    """
+    Utility method to initialise an account.
+    """
+
+    move = {
+      "a":
+        {
+          "init":
+            {
+              "faction": faction,
+            },
+        },
+    }
+
+    return self.sendMove (name, move)
 
   def createCharacter (self, owner, faction):
     """

--- a/gametest/splitstaterpcs.py
+++ b/gametest/splitstaterpcs.py
@@ -33,8 +33,8 @@ class SplitStateRpcsTest (PXTest):
     # regions and kills/fame.
     self.initAccount ("prospector", "r")
     self.initAccount ("killed", "g")
-    self.createCharacter ("prospector", "r")
-    self.createCharacter ("killed", "g")
+    self.createCharacters ("prospector")
+    self.createCharacters ("killed")
     self.generate (1)
     self.moveCharactersTo ({
       "prospector": {"x": 0, "y": 0},

--- a/gametest/splitstaterpcs.py
+++ b/gametest/splitstaterpcs.py
@@ -31,6 +31,8 @@ class SplitStateRpcsTest (PXTest):
 
     # Set up a non-trivial situation, where we have characters, prospected
     # regions and kills/fame.
+    self.initAccount ("prospector", "r")
+    self.initAccount ("killed", "g")
     self.createCharacter ("prospector", "r")
     self.createCharacter ("killed", "g")
     self.generate (1)

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -18,6 +18,7 @@
 
 #include "combat.hpp"
 
+#include "database/account.hpp"
 #include "database/character.hpp"
 #include "database/damagelists.hpp"
 #include "database/dbtest.hpp"
@@ -47,18 +48,22 @@ InsertCharacters (Database& db, const unsigned numIdle,
                   const unsigned numTargets, const unsigned numAttacks,
                   const unsigned targetHP)
 {
+  AccountsTable acc(db);
   CharacterTable tbl(db);
+
+  acc.CreateNew ("red", Faction::RED);
+  acc.CreateNew ("green", Faction::GREEN);
 
   for (unsigned i = 0; i < numIdle; ++i)
     {
-      auto c = tbl.CreateNew ("domob", Faction::RED);
+      auto c = tbl.CreateNew ("red", Faction::RED);
       c->MutableProto ().mutable_combat_data ();
       c.reset ();
     }
 
   for (unsigned i = 0; i < numTargets; ++i)
     {
-      auto c = tbl.CreateNew ("domob", Faction::GREEN);
+      auto c = tbl.CreateNew ("green", Faction::GREEN);
       const auto id = c->GetId ();
       auto& regen = c->MutableRegenData ();
       regen.set_shield_regeneration_mhp (1000);
@@ -66,7 +71,7 @@ InsertCharacters (Database& db, const unsigned numIdle,
       c->MutableHP ().set_armour (targetHP);
       c.reset ();
 
-      c = tbl.CreateNew ("domob", Faction::RED);
+      c = tbl.CreateNew ("red", Faction::RED);
       auto* cd = c->MutableProto ().mutable_combat_data ();
       for (unsigned j = 0; j < numAttacks; ++j)
         {

--- a/src/combat_target_bench.cpp
+++ b/src/combat_target_bench.cpp
@@ -18,6 +18,7 @@
 
 #include "combat.hpp"
 
+#include "database/account.hpp"
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
 #include "database/faction.hpp"
@@ -46,7 +47,11 @@ InsertCharacters (Database& db, const Faction f,
 {
   constexpr HexCoord::IntT spacing = 100;
 
+  AccountsTable acc(db);
   CharacterTable tbl(db);
+
+  const std::string nm = FactionToString (f);
+  acc.CreateNew (nm, f);
 
   for (unsigned r = 0; r < rows; ++r)
     for (unsigned c = 0; c < cols; ++c)
@@ -54,7 +59,7 @@ InsertCharacters (Database& db, const Faction f,
         const HexCoord pos(c * spacing, r * spacing);
         for (unsigned i = 0; i < k; ++i)
           {
-            auto c = tbl.CreateNew ("domob", f);
+            auto c = tbl.CreateNew (nm, f);
             c->SetPosition (pos);
             auto& pb = c->MutableProto ();
             auto* attack = pb.mutable_combat_data ()->add_attacks ();

--- a/src/fame.cpp
+++ b/src/fame.cpp
@@ -47,6 +47,7 @@ FameUpdater::~FameUpdater ()
           << "Applying fame delta " << entry.second << " for " << entry.first;
 
       auto h = accounts.GetByName (entry.first);
+      CHECK (h != nullptr);
       int fame = h->GetFame ();
       fame += entry.second;
       fame = std::min<int> (MAX_FAME, std::max (0, fame));
@@ -70,7 +71,9 @@ FameUpdater::UpdateForKill (const Database::IdT victim,
   /* Determine the victim's fame level.  */
   auto victimCharacter = characters.GetById (victim);
   const std::string& victimOwner = victimCharacter->GetOwner ();
-  const unsigned victimFame = accounts.GetByName (victimOwner)->GetFame ();
+  auto victimAccount = accounts.GetByName (victimOwner);
+  CHECK (victimAccount != nullptr);
+  const unsigned victimFame = victimAccount->GetFame ();
   const int victimLevel = GetLevel (victimFame);
   VLOG (1)
       << "Victim fame: " << victimFame << " (level: " << victimLevel << ")";
@@ -92,6 +95,7 @@ FameUpdater::UpdateForKill (const Database::IdT victim,
     {
       VLOG (1) << "Killing account: " << owner;
       auto a = accounts.GetByName (owner);
+      CHECK (a != nullptr);
       a->SetKills (a->GetKills () + 1);
 
       const unsigned fame = a->GetFame ();

--- a/src/fame_tests.cpp
+++ b/src/fame_tests.cpp
@@ -109,11 +109,16 @@ protected:
   }
 
   /**
-   * Creates a character for the given name and returns its ID.
+   * Creates a character for the given name and returns its ID.  Auto-inserts
+   * the account for that name if necessary.
    */
   Database::IdT
   CreateCharacter (const std::string& owner)
   {
+    auto a = accounts.GetByName (owner);
+    if (a == nullptr)
+      accounts.CreateNew (owner, Faction::RED);
+
     return characters.CreateNew (owner, Faction::RED)->GetId ();
   }
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -234,6 +234,7 @@ template <>
 {
   Json::Value res(Json::objectValue);
   res["name"] = a.GetName ();
+  res["faction"] = FactionToString (a.GetFaction ());
   res["kills"] = IntToJson (a.GetKills ());
   res["fame"] = IntToJson (a.GetFame ());
 
@@ -308,7 +309,7 @@ Json::Value
 GameStateJson::Accounts ()
 {
   AccountsTable tbl(db);
-  return ResultsAsArray (tbl, tbl.QueryNonTrivial ());
+  return ResultsAsArray (tbl, tbl.QueryInitialised ());
 }
 
 Json::Value

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -415,14 +415,14 @@ protected:
 
 TEST_F (AccountJsonTests, KillsAndFame)
 {
-  tbl.GetByName ("foo")->SetKills (10);
-  tbl.GetByName ("bar")->SetFame (42);
+  tbl.CreateNew ("foo", Faction::RED)->SetKills (10);
+  tbl.CreateNew ("bar", Faction::BLUE)->SetFame (42);
 
   ExpectStateJson (R"({
     "accounts":
       [
-        {"name": "bar", "kills": 0, "fame": 42},
-        {"name": "foo", "kills": 10, "fame": 100}
+        {"name": "bar", "faction": "b", "kills": 0, "fame": 42},
+        {"name": "foo", "faction": "r", "kills": 10, "fame": 100}
       ]
   })");
 }

--- a/src/logic.hpp
+++ b/src/logic.hpp
@@ -102,6 +102,15 @@ private:
                            const Params& params, const BaseMap& map,
                            const Json::Value& blockData);
 
+  /**
+   * Performs (potentially slow) validations on the current database state.
+   * This is used when compiled with --enable-slow-asserts after each block
+   * update, for testing purposes.  It should not be run in production builds
+   * because it may really slow down syncing.  If an error is detected, then
+   * this CHECK-fails the binary.
+   */
+  static void ValidateStateSlow (Database& db);
+
   friend class PXLogicTests;
   friend class PXRpcServer;
   friend class SQLiteGameDatabase;

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -24,6 +24,7 @@
 #include "protoutils.hpp"
 #include "testutils.hpp"
 
+#include "database/account.hpp"
 #include "database/character.hpp"
 #include "database/damagelists.hpp"
 #include "database/dbtest.hpp"
@@ -60,11 +61,12 @@ private:
 protected:
 
   const BaseMap map;
+  AccountsTable accounts;
   CharacterTable characters;
   RegionsTable regions;
 
   PXLogicTests ()
-    : params(xaya::Chain::MAIN), characters(db), regions(db)
+    : params(xaya::Chain::MAIN), accounts(db), characters(db), regions(db)
   {
     InitialisePrizes (db, params);
   }
@@ -88,6 +90,21 @@ protected:
     in >> blockData["moves"];
 
     return blockData;
+  }
+
+  /**
+   * Creates a new character for the given name and faction.  Initialises
+   * the account in the database first as needed.
+   */
+  CharacterTable::Handle
+  CreateCharacter (const std::string& name, const Faction f)
+  {
+    auto a = accounts.GetByName (name);
+    if (a == nullptr)
+      a = accounts.CreateNew (name, f);
+
+    CHECK (a->GetFaction () == f);
+    return characters.CreateNew (name, f);
   }
 
   /**
@@ -144,7 +161,7 @@ AddUnityAttack (Character& c, const HexCoord::IntT range)
 
 TEST_F (PXLogicTests, WaypointsBeforeMovement)
 {
-  auto c = characters.CreateNew ("domob", Faction::RED);
+  auto c = CreateCharacter ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
   c->MutableVolatileMv ().set_partial_step (1000);
   auto& pb = c->MutableProto ();
@@ -167,12 +184,12 @@ TEST_F (PXLogicTests, WaypointsBeforeMovement)
 
 TEST_F (PXLogicTests, MovementBeforeTargeting)
 {
-  auto c = characters.CreateNew ("domob", Faction::RED);
+  auto c = CreateCharacter ("domob", Faction::RED);
   const auto id1 = c->GetId ();
   AddUnityAttack (*c, 10);
   c.reset ();
 
-  c = characters.CreateNew ("domob", Faction::GREEN);
+  c = CreateCharacter ("andy", Faction::GREEN);
   const auto id2 = c->GetId ();
   c->SetPosition (HexCoord (11, 0));
   auto& pb = c->MutableProto ();
@@ -203,20 +220,20 @@ TEST_F (PXLogicTests, MovementBeforeTargeting)
 
 TEST_F (PXLogicTests, KilledVehicleNoLongerBlocks)
 {
-  auto c = characters.CreateNew ("attacker", Faction::GREEN);
+  auto c = CreateCharacter ("attacker", Faction::GREEN);
   const auto idAttacker = c->GetId ();
   c->SetPosition (HexCoord (11, 0));
   AddUnityAttack (*c, 1);
   c.reset ();
 
-  c = characters.CreateNew ("obstacle", Faction::RED);
+  c = CreateCharacter ("obstacle", Faction::RED);
   const auto idObstacle = c->GetId ();
   c->SetPosition (HexCoord (10, 0));
   c->MutableHP ().set_armour (1);
   c->MutableProto ().mutable_combat_data ();
   c.reset ();
 
-  c = characters.CreateNew ("moving", Faction::RED);
+  c = CreateCharacter ("moving", Faction::RED);
   const auto idMoving = c->GetId ();
   c->SetPosition (HexCoord (9, 0));
   auto& pb = c->MutableProto ();
@@ -246,11 +263,11 @@ TEST_F (PXLogicTests, KilledVehicleNoLongerBlocks)
 
 TEST_F (PXLogicTests, DamageInNextRound)
 {
-  auto c = characters.CreateNew ("domob", Faction::RED);
+  auto c = CreateCharacter ("domob", Faction::RED);
   AddUnityAttack (*c, 1);
   c.reset ();
 
-  c = characters.CreateNew ("domob", Faction::GREEN);
+  c = CreateCharacter ("andy", Faction::GREEN);
   const auto idTarget = c->GetId ();
   c->MutableHP ().set_armour (100);
   c->MutableProto ().mutable_combat_data ();
@@ -264,11 +281,11 @@ TEST_F (PXLogicTests, DamageInNextRound)
 
 TEST_F (PXLogicTests, DamageKillsRegeneration)
 {
-  auto c = characters.CreateNew ("domob", Faction::RED);
+  auto c = CreateCharacter ("domob", Faction::RED);
   AddUnityAttack (*c, 1);
   c.reset ();
 
-  c = characters.CreateNew ("domob", Faction::GREEN);
+  c = CreateCharacter ("andy", Faction::GREEN);
   const auto idTarget = c->GetId ();
   c->MutableProto ().mutable_combat_data ();
   c.reset ();
@@ -296,12 +313,12 @@ TEST_F (PXLogicTests, DamageLists)
 {
   DamageLists dl(db, 0);
 
-  auto c = characters.CreateNew ("domob", Faction::RED);
+  auto c = CreateCharacter ("domob", Faction::RED);
   const auto idAttacker = c->GetId ();
   AddUnityAttack (*c, 1);
   c.reset ();
 
-  c = characters.CreateNew ("domob", Faction::GREEN);
+  c = CreateCharacter ("andy", Faction::GREEN);
   const auto idTarget = c->GetId ();
   c->MutableProto ().mutable_combat_data ();
   auto& regen = c->MutableRegenData ();
@@ -344,7 +361,7 @@ TEST_F (PXLogicTests, FameUpdate)
   std::vector<Database::IdT> ids;
   for (const auto f : {Faction::RED, Faction::GREEN})
     {
-      auto c = characters.CreateNew ("domob", f);
+      auto c = CreateCharacter (FactionToString (f), f);
       ids.push_back (c->GetId ());
       AddUnityAttack (*c, 1);
       auto& regen = c->MutableRegenData ();
@@ -390,7 +407,7 @@ TEST_F (PXLogicTests, ProspectingBeforeMovement)
       << "Neighbouring coordinates " << pos1 << " and " << pos2
       << " are in differing regions " << region1 << " and " << region2;
 
-  auto c = characters.CreateNew ("domob", Faction::RED);
+  auto c = CreateCharacter ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos1);
   c->MutableVolatileMv ().set_partial_step (1000);
@@ -423,13 +440,13 @@ TEST_F (PXLogicTests, ProspectingUserKilled)
   const auto region = map.Regions ().GetRegionId (pos);
 
   /* Set up characters such that one is killing the other on the next round.  */
-  auto c = characters.CreateNew ("domob", Faction::RED);
+  auto c = CreateCharacter ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos);
   AddUnityAttack (*c, 1);
   c.reset ();
 
-  c = characters.CreateNew ("domob", Faction::GREEN);
+  c = CreateCharacter ("andy", Faction::GREEN);
   ASSERT_EQ (c->GetId (), 2);
   c->SetPosition (pos);
   c->MutableProto ().mutable_combat_data ();
@@ -443,7 +460,7 @@ TEST_F (PXLogicTests, ProspectingUserKilled)
      with the character that will be killed.  */
   UpdateState (R"([
     {
-      "name": "domob",
+      "name": "andy",
       "move": {"c": {"2": {"prospect": {}}}}
     }
   ])");
@@ -485,7 +502,7 @@ TEST_F (PXLogicTests, FinishingProspecting)
   const HexCoord pos(5, 5);
   const auto region = map.Regions ().GetRegionId (pos);
 
-  auto c = characters.CreateNew ("domob", Faction::RED);
+  auto c = CreateCharacter ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos);
   c->MutableProto ().mutable_combat_data ();

--- a/src/movement_bench.cpp
+++ b/src/movement_bench.cpp
@@ -21,6 +21,7 @@
 #include "params.hpp"
 #include "protoutils.hpp"
 
+#include "database/account.hpp"
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
 #include "database/faction.hpp"
@@ -44,6 +45,16 @@ namespace
  * tile per block.
  */
 constexpr PathFinder::DistanceT SPEED = 1000;
+
+/**
+ * Initialises the test account in the database.
+ */
+void
+InitialiseAccount (Database& db)
+{
+  AccountsTable tbl(db);
+  tbl.CreateNew ("domob", Faction::RED);
+}
 
 /**
  * Constructs a test character in the given character table.  This takes
@@ -80,6 +91,8 @@ MovementOneSegment (benchmark::State& state)
   const HexCoord::IntT numTiles = state.range (0);
   const unsigned numMoving = state.range (1);
   const unsigned numWP = state.range (2);
+
+  InitialiseAccount (db);
 
   CharacterTable tbl(db);
   std::vector<Database::IdT> charIds;
@@ -147,6 +160,8 @@ MovementLongHaul (benchmark::State& state)
 
   const HexCoord::IntT wpDist = state.range (0);
   const HexCoord::IntT total = state.range (1);
+
+  InitialiseAccount (db);
 
   CharacterTable tbl(db);
   const auto id = CreateCharacter (tbl)->GetId ();

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -328,10 +328,22 @@ MoveProcessor::ProcessOne (const Json::Value& moveObj)
      e.g. choose one's faction and create characters in a single move.  */
   TryAccountUpdate (name, mv["a"]);
 
+  /* If there is no account (after potentially updating/initialising it),
+     then let's not try to process any more updates.  This explicitly
+     enforces that accounts have to be initialised before doing anything
+     else, even if perhaps some changes wouldn't actually require access
+     to an account in their processing.  */
+  if (accounts.GetByName (name) == nullptr)
+    {
+      LOG (WARNING)
+          << "Account " << name << " does not exist, ignoring move " << moveObj;
+      return;
+    }
+
   /* Note that the order between character update and character creation
      matters:  By having the update *before* the creation, we explicitly
      forbid a situation in which a newly created character is updated right
-     away.  That would be tricky (since the ID would have to be predicated),
+     away.  That would be tricky (since the ID would have to be predicted),
      but it would have been possible sometimes if the order were reversed.
      We want to exclude such trickery and thus do the update first.  */
   TryCharacterUpdates (name, mv);

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -70,6 +70,13 @@ BaseMoveProcessor::TryCharacterCreation (const std::string& name,
 
   VLOG (1) << "Attempting to create new characters through move: " << cmd;
 
+  const auto account = accounts.GetByName (name);
+  CHECK (account != nullptr);
+  const Faction faction = account->GetFaction ();
+  VLOG (1)
+      << "The new characters' account " << name
+      << " has faction: " << FactionToString (faction);
+
   for (const auto& cur : cmd)
     {
       if (!cur.isObject ())
@@ -79,21 +86,7 @@ BaseMoveProcessor::TryCharacterCreation (const std::string& name,
           continue;
         }
 
-      const auto& factionVal = cur["faction"];
-      if (!factionVal.isString ())
-        {
-          LOG (WARNING)
-              << "Character creation does not specify faction: " << cur;
-          continue;
-        }
-      const Faction faction = FactionFromString (factionVal.asString ());
-      if (faction == Faction::INVALID)
-        {
-          LOG (WARNING) << "Invalid faction specified for character: " << cur;
-          continue;
-        }
-
-      if (cur.size () != 1)
+      if (cur.size () != 0)
         {
           LOG (WARNING) << "Character creation has extra fields: " << cur;
           continue;

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -181,6 +181,12 @@ private:
   void HandleGodMode (const Json::Value& cmd);
 
   /**
+   * Transfers the given character if the update JSON contains a request
+   * to do so.
+   */
+  void MaybeTransferCharacter (Character& c, const Json::Value& upd);
+
+  /**
    * Sets the character's waypoints if a valid command for starting a move
    * is there.
    */

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -23,6 +23,7 @@
 #include "dynobstacles.hpp"
 #include "params.hpp"
 
+#include "database/account.hpp"
 #include "database/character.hpp"
 #include "database/database.hpp"
 #include "database/region.hpp"
@@ -65,6 +66,9 @@ protected:
    */
   Database& db;
 
+  /** Access handle for the accounts database table.  */
+  AccountsTable accounts;
+
   /** Access handle for the characters table in the DB.  */
   CharacterTable characters;
 
@@ -73,7 +77,7 @@ protected:
 
   explicit BaseMoveProcessor (Database& d, const Params& p, const BaseMap& m)
     : params(p), map(m), db(d),
-      characters(db), regions(db)
+      accounts(db), characters(db), regions(db)
   {}
 
   /**
@@ -187,6 +191,17 @@ private:
    * location on the map.
    */
   void MaybeStartProspecting (Character& c, const Json::Value& upd);
+
+  /**
+   * Tries to handle an account initialisation (choosing faction) from
+   * the given move.
+   */
+  void MaybeInitAccount (const std::string& name, const Json::Value& init);
+
+  /**
+   * Tries to handle a move that updates an account.
+   */
+  void TryAccountUpdate (const std::string& name, const Json::Value& upd);
 
 protected:
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -533,10 +533,23 @@ TEST_F (CharacterUpdateTests, ValidTransfer)
 
 TEST_F (CharacterUpdateTests, InvalidTransfer)
 {
-  Process (R"([{
-    "name": "domob",
-    "move": {"c": {"1": {"send": false}}}
-  }])");
+  accounts.CreateNew ("wrong faction", Faction::GREEN);
+
+  Process (R"([
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"send": false}}}
+    },
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"send": "uninitialised account"}}}
+    },
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"send": "wrong faction"}}}
+    }
+  ])");
+
   ExpectCharacterOwners ({{1, "domob"}});
 }
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -222,7 +222,7 @@ TEST_F (AccountUpdateTests, InitialisationAndCharacterCreation)
     {"name": "domob", "move":
       {
         "a": {"x": 42, "init": {"faction": "b"}},
-        "nc": [{"faction": "b"}]
+        "nc": [{}]
       }
     }
   ])", params.CharacterCost ());
@@ -257,13 +257,7 @@ TEST_F (CharacterCreationTests, InvalidCommands)
   ProcessWithDevPayment (R"([
     {"name": "domob", "move": {}},
     {"name": "domob", "move": {"nc": 42}},
-    {"name": "domob", "move": {"nc": [{}]}},
-    {"name": "domob", "move":
-      {
-        "nc": [{"faction": "r", "other": false}]
-      }},
-    {"name": "domob", "move": {"nc": [{"faction": "x"}]}},
-    {"name": "domob", "move": {"nc": [{"faction": 0}]}}
+    {"name": "domob", "move": {"nc": [{"faction": "r"}]}}
   ])", params.CharacterCost ());
 
   auto res = tbl.QueryAll ();
@@ -273,7 +267,7 @@ TEST_F (CharacterCreationTests, InvalidCommands)
 TEST_F (CharacterCreationTests, AccountNotInitialised)
 {
   ProcessWithDevPayment (R"([
-    {"name": "domob", "move": {"nc": []}}
+    {"name": "domob", "move": {"nc": [{}]}}
   ])", params.CharacterCost ());
 
   auto res = tbl.QueryAll ();
@@ -283,12 +277,12 @@ TEST_F (CharacterCreationTests, AccountNotInitialised)
 TEST_F (CharacterCreationTests, ValidCreation)
 {
   accounts.CreateNew ("domob", Faction::RED);
-  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("andy", Faction::BLUE);
 
   ProcessWithDevPayment (R"([
     {"name": "domob", "move": {"nc": []}},
-    {"name": "domob", "move": {"nc": [{"faction": "r"}]}},
-    {"name": "andy", "move": {"nc": [{"faction": "b"}]}}
+    {"name": "domob", "move": {"nc": [{}]}},
+    {"name": "andy", "move": {"nc": [{}]}}
   ])", params.CharacterCost ());
 
   auto res = tbl.QueryAll ();
@@ -312,13 +306,13 @@ TEST_F (CharacterCreationTests, DevPayment)
   accounts.CreateNew ("andy", Faction::GREEN);
 
   Process (R"([
-    {"name": "domob", "move": {"nc": [{"faction": "r"}]}}
+    {"name": "domob", "move": {"nc": [{}]}}
   ])");
   ProcessWithDevPayment (R"([
-    {"name": "domob", "move": {"nc": [{"faction": "r"}]}}
+    {"name": "domob", "move": {"nc": [{}]}}
   ])", params.CharacterCost () - 1);
   ProcessWithDevPayment (R"([
-    {"name": "andy", "move": {"nc": [{"faction": "g"}]}}
+    {"name": "andy", "move": {"nc": [{}]}}
   ])", params.CharacterCost () + 1);
 
   auto res = tbl.QueryAll ();
@@ -338,13 +332,7 @@ TEST_F (CharacterCreationTests, Multiple)
       "name": "domob",
       "move":
         {
-          "nc":
-            [
-              {"faction": "invalid"},
-              {"faction": "r"},
-              {"faction": "r"},
-              {"faction": "r"}
-            ]
+          "nc": [{}, {}, {}]
         }
     }
   ])", 2 * params.CharacterCost ());
@@ -442,7 +430,7 @@ TEST_F (CharacterUpdateTests, CreationAndUpdate)
     "name": "domob",
     "move":
       {
-        "nc": [{"faction": "r"}],
+        "nc": [{}],
         "c": {"1": {"send": "daniel"}, "2": {"send": "andy"}}
       }
   }])", params.CharacterCost ());

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -219,6 +219,16 @@ PendingStateUpdater::ProcessMove (const Json::Value& moveObj)
   if (!ExtractMoveBasics (moveObj, name, mv, paidToDev))
     return;
 
+  if (accounts.GetByName (name) == nullptr)
+    {
+      /* This is also triggered for moves actually registering an account,
+         so it not something really "bad" we need to warn about.  */
+      VLOG (1)
+          << "Account " << name
+          << " does not exist, ignoring pending move " << moveObj;
+      return;
+    }
+
   TryCharacterUpdates (name, mv);
   TryCharacterCreation (name, mv, paidToDev);
 }

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -21,6 +21,7 @@
 #include "jsonutils.hpp"
 #include "testutils.hpp"
 
+#include "database/account.hpp"
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
 
@@ -42,10 +43,11 @@ protected:
 
   PendingState state;
 
+  AccountsTable accounts;
   CharacterTable characters;
 
   PendingStateTests ()
-    : characters(db)
+    : accounts(db), characters(db)
   {}
 
   /**
@@ -81,7 +83,7 @@ TEST_F (PendingStateTests, Clear)
 {
   state.AddCharacterCreation ("domob", Faction::RED);
 
-  auto h = characters.CreateNew ("domob", Faction::GREEN);
+  auto h = characters.CreateNew ("domob", Faction::RED);
   state.AddCharacterWaypoints (*h, {});
   h.reset ();
 
@@ -104,8 +106,8 @@ TEST_F (PendingStateTests, Clear)
 TEST_F (PendingStateTests, Waypoints)
 {
   auto c1 = characters.CreateNew ("domob", Faction::RED);
-  auto c2 = characters.CreateNew ("domob", Faction::GREEN);
-  auto c3 = characters.CreateNew ("domob", Faction::BLUE);
+  auto c2 = characters.CreateNew ("domob", Faction::RED);
+  auto c3 = characters.CreateNew ("domob", Faction::RED);
 
   ASSERT_EQ (c1->GetId (), 1);
   ASSERT_EQ (c2->GetId (), 2);
@@ -213,7 +215,7 @@ TEST_F (PendingStateTests, CharacterCreation)
   state.AddCharacterCreation ("foo", Faction::RED);
   state.AddCharacterCreation ("bar", Faction::GREEN);
   state.AddCharacterCreation ("foo", Faction::RED);
-  state.AddCharacterCreation ("bar", Faction::BLUE);
+  state.AddCharacterCreation ("bar", Faction::GREEN);
 
   ExpectStateJson (R"(
     {
@@ -224,7 +226,7 @@ TEST_F (PendingStateTests, CharacterCreation)
             "creations":
               [
                 {"faction": "g"},
-                {"faction": "b"}
+                {"faction": "g"}
               ]
           },
           {
@@ -293,8 +295,23 @@ protected:
 
 };
 
+TEST_F (PendingStateUpdaterTests, AccountNotInitialised)
+{
+  ProcessWithDevPayment ("domob", params.CharacterCost (), R"({
+    "nc": [{"faction": "r"}]
+  })");
+
+  ExpectStateJson (R"(
+    {
+      "newcharacters": []
+    }
+  )");
+}
+
 TEST_F (PendingStateUpdaterTests, InvalidCreation)
 {
+  accounts.CreateNew ("domob", Faction::RED);
+
   ProcessWithDevPayment ("domob", params.CharacterCost (), R"(
     {
       "nc": [{"faction": "r", "x": 5}]
@@ -315,14 +332,14 @@ TEST_F (PendingStateUpdaterTests, InvalidCreation)
 
 TEST_F (PendingStateUpdaterTests, ValidCreations)
 {
+  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("andy", Faction::GREEN);
+
   ProcessWithDevPayment ("domob", 2 * params.CharacterCost (), R"({
-    "nc": [{"faction": "r"}, {"faction": "g"}, {"faction": "b"}]
+    "nc": [{"faction": "r"}, {"faction": "r"}, {"faction": "r"}]
   })");
   ProcessWithDevPayment ("andy", params.CharacterCost (), R"({
-    "nc": [{"faction": "r"}]
-  })");
-  ProcessWithDevPayment ("domob", params.CharacterCost (), R"({
-    "nc": [{"faction": "r"}]
+    "nc": [{"faction": "g"}]
   })");
 
   ExpectStateJson (R"(
@@ -333,7 +350,7 @@ TEST_F (PendingStateUpdaterTests, ValidCreations)
             "name": "andy",
             "creations":
               [
-                {"faction": "r"}
+                {"faction": "g"}
               ]
           },
           {
@@ -341,7 +358,6 @@ TEST_F (PendingStateUpdaterTests, ValidCreations)
             "creations":
               [
                 {"faction": "r"},
-                {"faction": "g"},
                 {"faction": "r"}
               ]
           }
@@ -352,6 +368,9 @@ TEST_F (PendingStateUpdaterTests, ValidCreations)
 
 TEST_F (PendingStateUpdaterTests, InvalidUpdate)
 {
+  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("andy", Faction::RED);
+
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
 
   Process ("andy", R"({
@@ -373,6 +392,8 @@ TEST_F (PendingStateUpdaterTests, InvalidUpdate)
 
 TEST_F (PendingStateUpdaterTests, Waypoints)
 {
+  accounts.CreateNew ("domob", Faction::RED);
+
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 2);
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 3);
@@ -415,6 +436,8 @@ TEST_F (PendingStateUpdaterTests, Waypoints)
 
 TEST_F (PendingStateUpdaterTests, Prospecting)
 {
+  accounts.CreateNew ("domob", Faction::RED);
+
   const HexCoord pos(456, -789);
   auto h = characters.CreateNew ("domob", Faction::RED);
   ASSERT_EQ (h->GetId (), 1);
@@ -447,6 +470,8 @@ TEST_F (PendingStateUpdaterTests, Prospecting)
 
 TEST_F (PendingStateUpdaterTests, CreationAndUpdateTogether)
 {
+  accounts.CreateNew ("domob", Faction::RED);
+
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
 
   ProcessWithDevPayment ("domob", params.CharacterCost (), R"({

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -298,7 +298,7 @@ protected:
 TEST_F (PendingStateUpdaterTests, AccountNotInitialised)
 {
   ProcessWithDevPayment ("domob", params.CharacterCost (), R"({
-    "nc": [{"faction": "r"}]
+    "nc": [{}]
   })");
 
   ExpectStateJson (R"(
@@ -314,12 +314,12 @@ TEST_F (PendingStateUpdaterTests, InvalidCreation)
 
   ProcessWithDevPayment ("domob", params.CharacterCost (), R"(
     {
-      "nc": [{"faction": "r", "x": 5}]
+      "nc": [{"faction": "r"}]
     }
   )");
   Process ("domob", R"(
     {
-      "nc": [{"faction": "r"}]
+      "nc": [{}]
     }
   )");
 
@@ -336,10 +336,10 @@ TEST_F (PendingStateUpdaterTests, ValidCreations)
   accounts.CreateNew ("andy", Faction::GREEN);
 
   ProcessWithDevPayment ("domob", 2 * params.CharacterCost (), R"({
-    "nc": [{"faction": "r"}, {"faction": "r"}, {"faction": "r"}]
+    "nc": [{}, {}, {}]
   })");
   ProcessWithDevPayment ("andy", params.CharacterCost (), R"({
-    "nc": [{"faction": "g"}]
+    "nc": [{}]
   })");
 
   ExpectStateJson (R"(
@@ -475,7 +475,7 @@ TEST_F (PendingStateUpdaterTests, CreationAndUpdateTogether)
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
 
   ProcessWithDevPayment ("domob", params.CharacterCost (), R"({
-    "nc": [{"faction": "r"}],
+    "nc": [{}],
     "c": {"1": {"wp": []}}
   })");
 


### PR DESCRIPTION
This set of changes revamps how accounts and characters are created.  In the future, accounts need to be initialised by choosing a faction before they can be used for anything else.  This is done with a move like this:

    {"a":{"init":{"faction":"r"}}}

Afterwards, the account is locked to that faction, and cannot change it.  This is also returned in the `accounts` field of the game-state JSON.

Then, when creating characters, they will automatically be of the account's faction.  So the move to create characters now looks like this:

    {"nc":[{},{},{}]}

Finally, transfers of characters between accounts are now only possible if the receiving account has been initialised and is of the character's faction.

This implements #17.