### PR TITLE
Ground loot

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -20,6 +20,7 @@ libdatabase_la_SOURCES = \
   database.cpp \
   faction.cpp \
   fighter.cpp \
+  inventory.cpp \
   prizes.cpp \
   region.cpp \
   schema.cpp \
@@ -32,6 +33,7 @@ noinst_HEADERS = \
   database.hpp database.tpp \
   faction.hpp faction.tpp \
   fighter.hpp \
+  inventory.hpp \
   lazyproto.hpp lazyproto.tpp \
   prizes.hpp \
   region.hpp \
@@ -74,6 +76,7 @@ tests_SOURCES = \
   database_tests.cpp \
   faction_tests.cpp \
   fighter_tests.cpp \
+  inventory_tests.cpp \
   lazyproto_tests.cpp \
   prizes_tests.cpp \
   region_tests.cpp \

--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -15,6 +15,7 @@ libdatabase_la_LIBADD = \
 libdatabase_la_SOURCES = \
   account.cpp \
   character.cpp \
+  coord.cpp \
   damagelists.cpp \
   database.cpp \
   faction.cpp \
@@ -26,6 +27,7 @@ libdatabase_la_SOURCES = \
 noinst_HEADERS = \
   account.hpp \
   character.hpp \
+  coord.hpp coord.tpp \
   damagelists.hpp \
   database.hpp database.tpp \
   faction.hpp faction.tpp \
@@ -67,6 +69,7 @@ tests_LDADD = \
 tests_SOURCES = \
   account_tests.cpp \
   character_tests.cpp \
+  coord_tests.cpp \
   damagelists_tests.cpp \
   database_tests.cpp \
   faction_tests.cpp \

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -19,6 +19,7 @@
 #ifndef DATABASE_CHARACTER_HPP
 #define DATABASE_CHARACTER_HPP
 
+#include "coord.hpp"
 #include "database.hpp"
 #include "faction.hpp"
 #include "lazyproto.hpp"
@@ -39,20 +40,18 @@ namespace pxd
 /**
  * Database result type for rows from the characters table.
  */
-struct CharacterResult : public ResultWithFaction
+struct CharacterResult : public ResultWithFaction, public ResultWithCoord
 {
   RESULT_COLUMN (int64_t, id, 1);
   RESULT_COLUMN (std::string, owner, 2);
-  RESULT_COLUMN (int64_t, x, 3);
-  RESULT_COLUMN (int64_t, y, 4);
-  RESULT_COLUMN (pxd::proto::VolatileMovement, volatilemv, 5);
-  RESULT_COLUMN (pxd::proto::HP, hp, 6);
-  RESULT_COLUMN (pxd::proto::RegenData, regendata, 7);
-  RESULT_COLUMN (int64_t, busy, 8);
-  RESULT_COLUMN (pxd::proto::Character, proto, 9);
-  RESULT_COLUMN (int64_t, attackrange, 10);
-  RESULT_COLUMN (bool, canregen, 11);
-  RESULT_COLUMN (bool, hastarget, 12);
+  RESULT_COLUMN (pxd::proto::VolatileMovement, volatilemv, 3);
+  RESULT_COLUMN (pxd::proto::HP, hp, 4);
+  RESULT_COLUMN (pxd::proto::RegenData, regendata, 5);
+  RESULT_COLUMN (int64_t, busy, 6);
+  RESULT_COLUMN (pxd::proto::Character, proto, 7);
+  RESULT_COLUMN (int64_t, attackrange, 8);
+  RESULT_COLUMN (bool, canregen, 9);
+  RESULT_COLUMN (bool, hastarget, 10);
 };
 
 /**

--- a/database/coord.cpp
+++ b/database/coord.cpp
@@ -1,0 +1,33 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "coord.hpp"
+
+namespace pxd
+{
+
+void
+BindCoordParameter (Database::Statement& stmt,
+                    const unsigned indX, const unsigned indY,
+                    const HexCoord& coord)
+{
+  stmt.Bind (indX, coord.GetX ());
+  stmt.Bind (indY, coord.GetY ());
+}
+
+} // namespace pxd

--- a/database/coord.hpp
+++ b/database/coord.hpp
@@ -1,0 +1,60 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_COORD_HPP
+#define DATABASE_COORD_HPP
+
+#include "database.hpp"
+
+#include "hexagonal/coord.hpp"
+
+#include <cstdint>
+
+namespace pxd
+{
+
+/**
+ * A database result that includes a x/y coordinate.
+ */
+struct ResultWithCoord : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, x, 51);
+  RESULT_COLUMN (int64_t, y, 52);
+};
+
+/**
+ * Retrieves a coordinate from a database column.
+ *
+ * This is templated, so that it can accept different database result types.
+ * They should all be derived from ResultWithCoord, though.
+ */
+template <typename T>
+  HexCoord GetCoordFromColumn (const Database::Result<T>& res);
+
+/**
+ * Binds a coordinate value to a pair of statement parameter.
+ */
+void BindCoordParameter (Database::Statement& stmt,
+                         unsigned indX, unsigned indY,
+                         const HexCoord& coord);
+
+} // namespace pxd
+
+#include "coord.tpp"
+
+#endif // DATABASE_COORD_HPP

--- a/database/coord.tpp
+++ b/database/coord.tpp
@@ -1,0 +1,39 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Template implementation code for coord.hpp.  */
+
+#include <type_traits>
+
+namespace pxd
+{
+
+template <typename T>
+  HexCoord
+  GetCoordFromColumn (const Database::Result<T>& res)
+{
+  static_assert (std::is_base_of<ResultWithCoord, T>::value,
+                 "GetCoordFromColumn needs a ResultWithCoord");
+
+  const auto x = res.template Get<typename T::x> ();
+  const auto y = res.template Get<typename T::y> ();
+
+  return HexCoord (x, y);
+}
+
+} // namespace pxd

--- a/database/coord_tests.cpp
+++ b/database/coord_tests.cpp
@@ -1,0 +1,86 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "coord.hpp"
+
+#include "dbtest.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace pxd
+{
+namespace
+{
+
+class CoordDatabaseTests : public DBTestFixture
+{
+
+protected:
+
+  CoordDatabaseTests ()
+  {
+    auto stmt = db.Prepare (R"(
+      CREATE TABLE `test` (
+        `id` INTEGER PRIMARY KEY,
+        `x` INTEGER NOT NULL,
+        `y` INTEGER NOT NULL
+      )
+    )");
+    stmt.Execute ();
+  }
+
+};
+
+TEST_F (CoordDatabaseTests, RoundTrip)
+{
+  const std::vector<HexCoord> tests = {
+    HexCoord (0, 0),
+    HexCoord (-4000, 4000),
+    HexCoord (12, 34),
+  };
+
+  for (const auto& t : tests)
+    {
+      const auto id = db.GetNextId ();
+      auto stmt = db.Prepare (R"(
+        INSERT INTO `test`
+          (`id`, `x`, `y`)
+          VALUES (?1, ?2, ?3)
+      )");
+      stmt.Bind (1, id);
+      BindCoordParameter (stmt, 2, 3, t);
+      stmt.Execute ();
+
+      stmt = db.Prepare (R"(
+        SELECT `x`, `y`
+          FROM `test`
+          WHERE `id` = ?1
+      )");
+      stmt.Bind (1, id);
+      auto res = stmt.Query<ResultWithCoord> ();
+
+      ASSERT_TRUE (res.Step ());
+      EXPECT_EQ (GetCoordFromColumn (res), t);
+      EXPECT_FALSE (res.Step ());
+    }
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/database/inventory.cpp
+++ b/database/inventory.cpp
@@ -1,0 +1,160 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "inventory.hpp"
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+/* ************************************************************************** */
+
+Inventory::Inventory ()
+{
+  data.SetToDefault ();
+}
+
+Inventory::Inventory (LazyProto<proto::Inventory>&& d)
+{
+  *this = std::move (d);
+}
+
+Inventory&
+Inventory::operator= (LazyProto<proto::Inventory>&& d)
+{
+  data = std::move (d);
+  return *this;
+}
+
+bool
+Inventory::IsEmpty () const
+{
+  return data.Get ().fungible ().empty ();
+}
+
+uint64_t
+Inventory::GetFungibleCount (const std::string& type) const
+{
+  const auto& fungible = data.Get ().fungible ();
+  const auto mit = fungible.find (type);
+  if (mit == fungible.end ())
+    return 0;
+  return mit->second;
+}
+
+void
+Inventory::SetFungibleCount (const std::string& type, const uint64_t count)
+{
+  auto& fungible = *data.Mutable ().mutable_fungible ();
+
+  if (count == 0)
+    fungible.erase (type); 
+  else
+    fungible[type] = count;
+}
+
+/* ************************************************************************** */
+
+GroundLoot::GroundLoot (Database& d, const HexCoord& pos)
+  : db(d), coord(pos)
+{
+  VLOG (1) << "Constructed an empty ground-loot instance for " << coord;
+}
+
+GroundLoot::GroundLoot (Database& d,
+                        const Database::Result<GroundLootResult>& res)
+  : db(d)
+{
+  coord = GetCoordFromColumn (res);
+  inventory = res.GetProto<GroundLootResult::inventory> ();
+  VLOG (1) << "Created ground-loot instance for " << coord << " from database";
+}
+
+GroundLoot::~GroundLoot ()
+{
+  if (!inventory.IsDirty ())
+    {
+      VLOG (1) << "Ground loot at " << coord << " is not dirty";
+      return;
+    }
+
+  if (inventory.IsEmpty ())
+    {
+      VLOG (1) << "Ground loot at " << coord << " is now empty, updating DB";
+
+      auto stmt = db.Prepare (R"(
+        DELETE FROM `ground_loot`
+          WHERE `x` = ?1 AND `y` = ?2
+      )");
+
+      BindCoordParameter (stmt, 1, 2, coord);
+      stmt.Execute ();
+      return;
+    }
+
+  VLOG (1) << "Updating non-empty ground loot at " << coord;
+
+  auto stmt = db.Prepare (R"(
+    INSERT OR REPLACE INTO `ground_loot`
+      (`x`, `y`, `inventory`)
+      VALUES (?1, ?2, ?3)
+  )");
+
+  BindCoordParameter (stmt, 1, 2, coord);
+  stmt.BindProto (3, inventory.GetProtoForBinding ());
+  stmt.Execute ();
+}
+
+/* ************************************************************************** */
+
+GroundLootTable::Handle
+GroundLootTable::GetFromResult (const Database::Result<GroundLootResult>& res)
+{
+  return Handle (new GroundLoot (db, res));
+}
+
+GroundLootTable::Handle
+GroundLootTable::GetByCoord (const HexCoord& coord)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `ground_loot`
+      WHERE `x` = ?1 AND `y` = ?2
+  )");
+  BindCoordParameter (stmt, 1, 2, coord);
+  auto res = stmt.Query<GroundLootResult> ();
+
+  if (!res.Step ())
+    return Handle (new GroundLoot (db, coord));
+
+  auto r = GetFromResult (res);
+  CHECK (!res.Step ());
+  return r;
+}
+
+Database::Result<GroundLootResult>
+GroundLootTable::QueryNonEmpty ()
+{
+  auto stmt = db.Prepare ("SELECT * FROM `ground_loot` ORDER BY `x`, `y`");
+  return stmt.Query<GroundLootResult> ();
+}
+
+/* ************************************************************************** */
+
+} // namespace pxd

--- a/database/inventory.hpp
+++ b/database/inventory.hpp
@@ -1,0 +1,235 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_INVENTORY_HPP
+#define DATABASE_INVENTORY_HPP
+
+#include "coord.hpp"
+#include "database.hpp"
+#include "lazyproto.hpp"
+
+#include "proto/inventory.pb.h"
+
+#include <google/protobuf/map.h>
+
+#include <string>
+
+namespace pxd
+{
+
+/**
+ * Wrapper class around the state of an inventory.  This is what game-logic
+ * code should use rather than plain Inventory protos.
+ */
+class Inventory
+{
+
+private:
+
+  /** The underlying data as proto.  */
+  LazyProto<proto::Inventory> data;
+
+public:
+
+  /**
+   * Constructs an instance representing an empty inventory (that can then
+   * be modified, for instance).
+   */
+  Inventory ();
+
+  /**
+   * Constructs an instance wrapping the given proto data.
+   */
+  explicit Inventory (LazyProto<proto::Inventory>&& d);
+
+  /**
+   * Sets the contained inventory from the given proto.
+   */
+  Inventory& operator= (LazyProto<proto::Inventory>&& d);
+
+  Inventory (const Inventory&) = delete;
+  void operator= (const Inventory&) = delete;
+
+  /**
+   * Returns the fungible inventory items as protobuf maps.  This can be
+   * used to iterate over all non-zero fungible items (e.g. to construct
+   * the JSON state for it).
+   */
+  const google::protobuf::Map<std::string, google::protobuf::uint64>&
+  GetFungible () const
+  {
+    return data.Get ().fungible ();
+  }
+
+  /**
+   * Returns the number of fungible items with the given key in the inventory.
+   * Returns zero for non-existant items.
+   */
+  uint64_t GetFungibleCount (const std::string& type) const;
+
+  /**
+   * Sets the number of fungible items with the given key in the inventory.
+   */
+  void SetFungibleCount (const std::string& type, uint64_t count);
+
+  /**
+   * Returns true if the inventory data has been modified (and thus needs to
+   * be saved back to the database).
+   */
+  bool
+  IsDirty () const
+  {
+    return data.IsDirty ();
+  }
+
+  /**
+   * Returns true if the inventory is empty.  Note that this forces the
+   * proto to get parsed if it hasn't yet been.
+   */
+  bool IsEmpty () const;
+
+  /**
+   * Gives access to the underlying lazy proto for binding purposes.
+   */
+  const LazyProto<proto::Inventory>&
+  GetProtoForBinding () const
+  {
+    return data;
+  }
+
+};
+
+/**
+ * Database result type for rows from the ground_loot table.
+ */
+struct GroundLootResult : public ResultWithCoord
+{
+  RESULT_COLUMN (proto::Inventory, inventory, 1);
+};
+
+/**
+ * Wrapper class around the loot on the ground at a certain location.
+ *
+ * Instantiations of this class should be made through GroundLootTable.
+ */
+class GroundLoot
+{
+
+private:
+
+  /** Database this belongs to.  */
+  Database& db;
+
+  /** The coordinate of this loot tile.  */
+  HexCoord coord;
+
+  /** The associated loot.  */
+  Inventory inventory;
+
+  /**
+   * Constructs an instance with empty inventory.
+   */
+  explicit GroundLoot (Database& d, const HexCoord& pos);
+
+  /**
+   * Constructs an instance based on an existing DB result.
+   */
+  explicit GroundLoot (Database& d,
+                       const Database::Result<GroundLootResult>& res);
+
+  friend class GroundLootTable;
+
+public:
+
+  /**
+   * In the destructor, potential updates to the database are made if the
+   * data has been modified.
+   */
+  ~GroundLoot ();
+
+  GroundLoot () = delete;
+  GroundLoot (const GroundLoot&) = delete;
+  void operator= (const GroundLoot&) = delete;
+
+  const HexCoord&
+  GetPosition () const
+  {
+    return coord;
+  }
+
+  const Inventory&
+  GetInventory () const
+  {
+    return inventory;
+  }
+
+  Inventory&
+  GetInventory ()
+  {
+    return inventory;
+  }
+
+};
+
+/**
+ * Utility class to query the ground-loot table and obtain GroundLoot instances
+ * from it accordingly.
+ */
+class GroundLootTable
+{
+
+private:
+
+  /** The Database reference for this instance.  */
+  Database& db;
+
+public:
+
+  /** Movable handle to a ground-loot instance.  */
+  using Handle = std::unique_ptr<GroundLoot>;
+
+  explicit GroundLootTable (Database& d)
+    : db(d)
+  {}
+
+  GroundLootTable () = delete;
+  GroundLootTable (const GroundLootTable&) = delete;
+  void operator= (const GroundLootTable&) = delete;
+
+  /**
+   * Returns a handle for the instance based on a Database::Result.
+   */
+  Handle GetFromResult (const Database::Result<GroundLootResult>& res);
+
+  /**
+   * Returns a handle for the loot instance at the given coordinate.  If there
+   * is not yet any loot, returns a handle for a "newly constructed"
+   * entry.
+   */
+  Handle GetByCoord (const HexCoord& coord);
+
+  /**
+   * Queries the database for all non-empty piles of loot on the ground.
+   */
+  Database::Result<GroundLootResult> QueryNonEmpty ();
+
+};
+
+} // namespace pxd
+
+#endif // DATABASE_INVENTORY_HPP

--- a/database/inventory_tests.cpp
+++ b/database/inventory_tests.cpp
@@ -1,0 +1,225 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "inventory.hpp"
+
+#include "dbtest.hpp"
+
+#include <google/protobuf/text_format.h>
+
+#include <gtest/gtest.h>
+
+#include <map>
+
+namespace pxd
+{
+namespace
+{
+
+using google::protobuf::TextFormat;
+
+/* ************************************************************************** */
+
+class InventoryTests : public testing::Test
+{
+
+protected:
+
+  Inventory inv;
+
+  /**
+   * Expects that the elements in the fungible "map" match the given
+   * set of expected elements.
+   */
+  void
+  ExpectFungibleElements (const std::map<std::string, uint64_t>& expected)
+  {
+    const auto& fungible = inv.GetFungible ();
+    ASSERT_EQ (expected.size (), fungible.size ());
+    for (const auto& entry : expected)
+      {
+        const auto mit = fungible.find (entry.first);
+        ASSERT_TRUE (mit != fungible.end ())
+            << "Entry " << entry.first << " not found in actual data";
+        ASSERT_EQ (mit->second, entry.second);
+      }
+  }
+
+};
+
+TEST_F (InventoryTests, DefaultData)
+{
+  ExpectFungibleElements ({});
+  EXPECT_EQ (inv.GetFungibleCount ("foo"), 0);
+  EXPECT_FALSE (inv.IsDirty ());
+  EXPECT_EQ (inv.GetProtoForBinding ().GetSerialised (), "");
+}
+
+TEST_F (InventoryTests, FromProto)
+{
+  LazyProto<proto::Inventory> pb;
+  pb.SetToDefault ();
+  CHECK (TextFormat::ParseFromString (R"(
+    fungible: { key: "foo" value: 10 }
+    fungible: { key: "bar" value: 5 }
+  )", &pb.Mutable ()));
+
+  inv = std::move (pb);
+
+  ExpectFungibleElements ({{"foo", 10}, {"bar", 5}});
+  EXPECT_FALSE (inv.IsEmpty ());
+}
+
+TEST_F (InventoryTests, Modification)
+{
+  inv.SetFungibleCount ("foo", 10);
+  inv.SetFungibleCount ("bar", 5);
+
+  ExpectFungibleElements ({{"foo", 10}, {"bar", 5}});
+  EXPECT_EQ (inv.GetFungibleCount ("foo"), 10);
+  EXPECT_EQ (inv.GetFungibleCount ("bar"), 5);
+  EXPECT_EQ (inv.GetFungibleCount ("baz"), 0);
+  EXPECT_FALSE (inv.IsEmpty ());
+  EXPECT_TRUE (inv.IsDirty ());
+
+  inv.SetFungibleCount ("foo", 0);
+  ExpectFungibleElements ({{"bar", 5}});
+  EXPECT_FALSE (inv.IsEmpty ());
+  EXPECT_TRUE (inv.IsDirty ());
+
+  inv.SetFungibleCount ("bar", 0);
+  EXPECT_TRUE (inv.IsEmpty ());
+  EXPECT_TRUE (inv.IsDirty ());
+}
+
+/* ************************************************************************** */
+
+struct CountResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, cnt, 1);
+};
+
+class GroundLootTests : public DBTestWithSchema
+{
+
+protected:
+
+  GroundLootTable tbl;
+
+  GroundLootTests ()
+    : tbl(db)
+  {}
+
+  /**
+   * Returns the number of entries in the ground-loot table.
+   */
+  unsigned
+  CountEntries ()
+  {
+    auto stmt = db.Prepare ("SELECT COUNT(*) AS `cnt` FROM `ground_loot`");
+    auto res = stmt.Query<CountResult> ();
+    CHECK (res.Step ());
+    const unsigned cnt = res.Get<CountResult::cnt> ();
+    CHECK (!res.Step ());
+    return cnt;
+  }
+
+};
+
+TEST_F (GroundLootTests, DefaultData)
+{
+  auto h = tbl.GetByCoord (HexCoord (1, 2));
+  EXPECT_EQ (h->GetPosition (), HexCoord (1, 2));
+  EXPECT_TRUE (h->GetInventory ().IsEmpty ());
+  h.reset ();
+
+  EXPECT_EQ (CountEntries (), 0);
+}
+
+TEST_F (GroundLootTests, Update)
+{
+  const HexCoord c1(1, 2);
+  tbl.GetByCoord (c1)->GetInventory ().SetFungibleCount ("foo", 5);
+
+  const HexCoord c2(1, 3);
+  tbl.GetByCoord (c2)->GetInventory ().SetFungibleCount ("bar", 42);
+
+  auto h = tbl.GetByCoord (c1);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 5);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("bar"), 0);
+
+  h = tbl.GetByCoord (c2);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 0);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("bar"), 42);
+
+  EXPECT_EQ (CountEntries (), 2);
+}
+
+TEST_F (GroundLootTests, Removal)
+{
+  const HexCoord c(1, 2);
+  tbl.GetByCoord (c)->GetInventory ().SetFungibleCount ("foo", 5);
+  EXPECT_EQ (CountEntries (), 1);
+
+  auto h = tbl.GetByCoord (c);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 5);
+  h->GetInventory ().SetFungibleCount ("foo", 0);
+  h.reset ();
+  EXPECT_EQ (CountEntries (), 0);
+
+  h = tbl.GetByCoord (c);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 0);
+  EXPECT_TRUE (h->GetInventory ().IsEmpty ());
+}
+
+using GroundLootTableTests = GroundLootTests;
+
+TEST_F (GroundLootTableTests, QueryNonEmpty)
+{
+  const HexCoord c1(1, 2);
+  const HexCoord c2(1, 3);
+  const HexCoord c3(2, 2);
+
+  tbl.GetByCoord (c1)->GetInventory ().SetFungibleCount ("foo", 1);
+  tbl.GetByCoord (c2)->GetInventory ().SetFungibleCount ("foo", 2);
+  tbl.GetByCoord (c3)->GetInventory ().SetFungibleCount ("foo", 3);
+
+  auto res = tbl.QueryNonEmpty ();
+
+  ASSERT_TRUE (res.Step ());
+  auto h = tbl.GetFromResult (res);
+  EXPECT_EQ (h->GetPosition (), c1);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 1);
+
+  ASSERT_TRUE (res.Step ());
+  h = tbl.GetFromResult (res);
+  EXPECT_EQ (h->GetPosition (), c2);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 2);
+
+  ASSERT_TRUE (res.Step ());
+  h = tbl.GetFromResult (res);
+  EXPECT_EQ (h->GetPosition (), c3);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 3);
+
+  ASSERT_FALSE (res.Step ());
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace pxd

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -162,6 +162,23 @@ CREATE TABLE IF NOT EXISTS `regions` (
 
 -- =============================================================================
 
+-- Data for piles of loot on the ground.  These represent the inventory
+-- of each tile of the map that has at least some loot.
+CREATE TABLE IF NOT EXISTS `ground_loot` (
+
+  -- The coordinates of the pile.
+  `x` INTEGER NOT NULL,
+  `y` INTEGER NOT NULL,
+
+  -- Serialised inventory proto.
+  `inventory` BLOB NOT NULL,
+
+  PRIMARY KEY (`x`, `y`)
+
+);
+
+-- =============================================================================
+
 -- Data about the still available prospecting prizes (so that we can
 -- ensure only a certain number can be found).
 CREATE TABLE IF NOT EXISTS `prizes` (

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -11,6 +11,7 @@ REGTESTS = \
   findpath.py \
   getregionat.py \
   godmode.py \
+  loot.py \
   movement.py \
   multiupdate.py \
   nullstate.py \

--- a/gametest/loot.py
+++ b/gametest/loot.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests handling of ground loot:  Placing it in god mode, picking it up by
+characters, dropping stuff by characters.
+"""
+
+from pxtest import PXTest
+
+
+class LootTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("Dropping loot in god mode...")
+    self.dropLoot ({"x": 1, "y": 2}, {"foo": 5, "bar": 10})
+    self.dropLoot ({"x": 1, "y": 2}, {"foo": 5})
+    self.dropLoot ({"x": -1, "y": 20}, {"foo": 5})
+    self.assertEqual (self.getRpc ("getgroundloot"), [
+      {
+        "position": {"x": -1, "y": 20},
+        "inventory":
+          {
+            "fungible": {"foo": 5},
+          },
+      },
+      {
+        "position": {"x": 1, "y": 2},
+        "inventory":
+          {
+            "fungible": {"bar": 10, "foo": 10},
+          },
+      },
+    ])
+
+
+if __name__ == "__main__":
+  LootTest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -233,6 +233,18 @@ class PXTest (XayaGameTest):
     self.adminCommand ({"god": {"sethp": sethp}})
     self.generate (1)
 
+  def dropLoot (self, position, fungible):
+    """
+    Issues a god-mode command to drop loot on the ground.  fungible should be
+    a dictionary mapping item-type strings to corresponding counts.
+    """
+
+    self.adminCommand ({"god": {"drop": [{
+      "pos": position,
+      "fungible": fungible,
+    }]}})
+    self.generate (1)
+
   def getAccounts (self):
     """
     Returns all accounts with non-trivial data in the current game state.

--- a/gametest/splitstaterpcs.py
+++ b/gametest/splitstaterpcs.py
@@ -16,12 +16,12 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest
-
 """
 Tests how the full game state corresponds to the "split state" RPCs
 like getaccounts or getregions.
 """
+
+from pxtest import PXTest
 
 
 class SplitStateRpcsTest (PXTest):
@@ -30,9 +30,11 @@ class SplitStateRpcsTest (PXTest):
     self.collectPremine ()
 
     # Set up a non-trivial situation, where we have characters, prospected
-    # regions and kills/fame.
+    # regions, kills/fame and ground loot.
     self.initAccount ("prospector", "r")
     self.initAccount ("killed", "g")
+    self.dropLoot ({"x": 1, "y": 2}, {"foo": 5, "bar": 10})
+    self.dropLoot ({"x": -1, "y": 20}, {"foo": 5})
     self.createCharacters ("prospector")
     self.createCharacters ("killed")
     self.generate (1)
@@ -50,14 +52,17 @@ class SplitStateRpcsTest (PXTest):
     state = self.getGameState ()
     accounts = self.getRpc ("getaccounts")
     characters = self.getRpc ("getcharacters")
+    loot = self.getRpc ("getgroundloot")
     regions = self.getRpc ("getregions")
     prizes = self.getRpc ("getprizestats")
     assert len (accounts) > 0
     assert len (characters) > 0
+    assert len (loot) > 0
     assert len (regions) > 0
     assert len (prizes) > 0
     self.assertEqual (accounts, state["accounts"])
     self.assertEqual (characters, state["characters"])
+    self.assertEqual (loot, state["groundloot"])
     self.assertEqual (regions, state["regions"])
     self.assertEqual (prizes, state["prizes"])
 

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -4,6 +4,7 @@ PROTOS = \
   character.proto \
   combat.proto \
   geometry.proto \
+  inventory.proto \
   movement.proto \
   region.proto
 EXTRA_DIST = $(PROTOS)

--- a/proto/inventory.proto
+++ b/proto/inventory.proto
@@ -1,0 +1,38 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+syntax = "proto2";
+
+package pxd.proto;
+
+/**
+ * Data about loot "somewhere".  This can be the inventory of a character,
+ * it can be the assets of an account in a building, and it can be the loot
+ * on the ground at a certain coordinate.
+ */
+message Inventory
+{
+
+  /**
+   * Data about fungible assets held.  This is simply a map from item types
+   * (which are hardcoded strings) to the amount of each type.  The amount
+   * is an integer number, representing some smallest fraction of the item.
+   */
+  map<string, uint64> fungible = 1;
+
+}

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -85,6 +85,11 @@ public:
   Json::Value Characters ();
 
   /**
+   * Returns the JSON data representing all ground loot.
+   */
+  Json::Value GroundLoot ();
+
+  /**
    * Returns the JSON data representing all regions in the game state.
    */
   Json::Value Regions ();

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -26,6 +26,7 @@
 #include "database/account.hpp"
 #include "database/character.hpp"
 #include "database/database.hpp"
+#include "database/inventory.hpp"
 #include "database/region.hpp"
 #include "mapdata/basemap.hpp"
 
@@ -72,12 +73,15 @@ protected:
   /** Access handle for the characters table in the DB.  */
   CharacterTable characters;
 
+  /** Access handle for ground loot.  */
+  GroundLootTable groundLoot;
+
   /** Access to the regions table.  */
   RegionsTable regions;
 
   explicit BaseMoveProcessor (Database& d, const Params& p, const BaseMap& m)
     : params(p), map(m), db(d),
-      accounts(db), characters(db), regions(db)
+      accounts(db), characters(db), groundLoot(db), regions(db)
   {}
 
   /**

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -153,6 +153,17 @@ PXRpcServer::getcharacters ()
 }
 
 Json::Value
+PXRpcServer::getgroundloot ()
+{
+  LOG (INFO) << "RPC method called: getgroundloot";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.GroundLoot ();
+      });
+}
+
+Json::Value
 PXRpcServer::getregions ()
 {
   LOG (INFO) << "RPC method called: getregions";

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -63,6 +63,7 @@ public:
 
   Json::Value getaccounts () override;
   Json::Value getcharacters () override;
+  Json::Value getgroundloot () override;
   Json::Value getregions () override;
   Json::Value getprizestats () override;
 

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -40,6 +40,11 @@
     "returns": {}
   },
   {
+    "name": "getgroundloot",
+    "params": {},
+    "returns": {}
+  },
+  {
     "name": "getregions",
     "params": {},
     "returns": {}


### PR DESCRIPTION
This is a first step towards implementing #42:  It adds basic logic for handling inventories of fungible items, stores them associated to tiles in the database (i.e. loot on the ground) and allows dropping loot there in god mode for testing.

The new data (i.e. all tiles with non-empty inventories on them) are returned as `groundloot` in the full game-state JSON, and by the new `getgroundloot` RPC method.

To place loot in god mode, an admin command like this can be used:

    {"god":{"drop":[{"pos":{"x":1,"y":2},"fungible":{"foo":5,"bar":10}}]}}

Fungible inventory items are simply identified by a string, and have an associated count.  For now, there is no special treatment implemented for any specific strings; in the future this will come with rules for how items get generated (apart from god mode) and how they can be used by players.