### PR TITLE
Inventory for characters

### DIFF
--- a/database/character.cpp
+++ b/database/character.cpp
@@ -51,6 +51,7 @@ Character::Character (Database& d, const Database::Result<CharacterResult>& res)
   hp = res.GetProto<CharacterResult::hp> ();
   regenData = res.GetProto<CharacterResult::regendata> ();
   busy = res.Get<CharacterResult::busy> ();
+  inv = res.GetProto<CharacterResult::inventory> ();
   data = res.GetProto<CharacterResult::proto> ();
   attackRange = res.Get<CharacterResult::attackrange> ();
   oldCanRegen = res.Get<CharacterResult::canregen> ();
@@ -68,7 +69,7 @@ Character::~Character ()
   if (hp.IsDirty () || regenData.IsDirty ())
     canRegen = ComputeCanRegen ();
 
-  if (isNew || regenData.IsDirty () || data.IsDirty ())
+  if (isNew || regenData.IsDirty () || inv.IsDirty () || data.IsDirty ())
     {
       VLOG (1)
           << "Character " << id
@@ -81,7 +82,7 @@ Character::~Character ()
            `busy`,
            `faction`,
            `ismoving`, `attackrange`, `canregen`, `hastarget`,
-           `regendata`, `proto`)
+           `regendata`, `inventory`, `proto`)
           VALUES
           (?1,
            ?2, ?3, ?4,
@@ -89,7 +90,7 @@ Character::~Character ()
            ?7,
            ?101,
            ?102, ?103, ?104, ?105,
-           ?106, ?107)
+           ?106, ?107, ?108)
       )");
 
       BindFieldValues (stmt);
@@ -99,7 +100,8 @@ Character::~Character ()
       stmt.Bind (104, canRegen);
       stmt.Bind (105, data.Get ().has_target ());
       stmt.BindProto (106, regenData);
-      stmt.BindProto (107, data);
+      stmt.BindProto (107, inv.GetProtoForBinding ());
+      stmt.BindProto (108, data);
       stmt.Execute ();
 
       return;

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -22,6 +22,7 @@
 #include "coord.hpp"
 #include "database.hpp"
 #include "faction.hpp"
+#include "inventory.hpp"
 #include "lazyproto.hpp"
 
 #include "hexagonal/coord.hpp"
@@ -48,10 +49,11 @@ struct CharacterResult : public ResultWithFaction, public ResultWithCoord
   RESULT_COLUMN (pxd::proto::HP, hp, 4);
   RESULT_COLUMN (pxd::proto::RegenData, regendata, 5);
   RESULT_COLUMN (int64_t, busy, 6);
-  RESULT_COLUMN (pxd::proto::Character, proto, 7);
-  RESULT_COLUMN (int64_t, attackrange, 8);
-  RESULT_COLUMN (bool, canregen, 9);
-  RESULT_COLUMN (bool, hastarget, 10);
+  RESULT_COLUMN (pxd::proto::Inventory, inventory, 7);
+  RESULT_COLUMN (pxd::proto::Character, proto, 8);
+  RESULT_COLUMN (int64_t, attackrange, 9);
+  RESULT_COLUMN (bool, canregen, 10);
+  RESULT_COLUMN (bool, hastarget, 11);
 };
 
 /**
@@ -99,6 +101,9 @@ private:
 
   /** The number of blocks (or zero) the character is still busy.  */
   int busy;
+
+  /** The character's inventory.  */
+  Inventory inv;
 
   /** All other data in the protocol buffer.  */
   LazyProto<proto::Character> data;
@@ -268,6 +273,18 @@ public:
   {
     busy = b;
     dirtyFields = true;
+  }
+
+  const Inventory&
+  GetInventory () const
+  {
+    return inv;
+  }
+
+  Inventory&
+  GetInventory ()
+  {
+    return inv;
   }
 
   const proto::Character&

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -177,6 +177,23 @@ TEST_F (CharacterTests, ModificationFieldsOnly)
   EXPECT_EQ (c->GetBusy (), 42);
 }
 
+TEST_F (CharacterTests, Inventory)
+{
+  auto h = tbl.CreateNew ("domob", Faction::RED);
+  const auto id = h->GetId ();
+  h->GetInventory ().SetFungibleCount ("foo", 10);
+  h.reset ();
+
+  h = tbl.GetById (id);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 10);
+  h->GetInventory ().SetFungibleCount ("foo", 0);
+  h.reset ();
+
+  h = tbl.GetById (id);
+  EXPECT_TRUE (h->GetInventory ().IsEmpty ());
+  h.reset ();
+}
+
 TEST_F (CharacterTests, HasTarget)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -80,6 +80,9 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- that need to be processed for combat damage.
   `hastarget` INTEGER NOT NULL,
 
+  -- The character's inventory encoded as Inventory proto.
+  `inventory` BLOB NOT NULL,
+
   -- Additional data encoded as a Character protocol buffer.
   `proto` BLOB NOT NULL
 

--- a/gametest/loot.py
+++ b/gametest/loot.py
@@ -50,6 +50,103 @@ class LootTest (PXTest):
       },
     ])
 
+    self.mainLogger.info ("Picking up loot with a character...")
+    self.initAccount ("red", "r")
+    self.createCharacters ("red")
+    self.generate (1)
+    self.moveCharactersTo ({"red": {"x": 1, "y": 2}})
+    self.generate (1)
+    self.getCharacters ()["red"].sendMove ({"pu": {"f": {"foo": 1000}}})
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["red"].getFungibleInventory (), {
+      "foo": 10,
+    })
+    self.assertEqual (self.getRpc ("getgroundloot"), [
+      {
+        "position": {"x": -1, "y": 20},
+        "inventory":
+          {
+            "fungible": {"foo": 5},
+          },
+      },
+      {
+        "position": {"x": 1, "y": 2},
+        "inventory":
+          {
+            "fungible": {"bar": 10},
+          },
+      },
+    ])
+
+    self.mainLogger.info ("Dropping loot with a character...")
+    self.moveCharactersTo ({"red": {"x": -1, "y": 20}})
+    self.getCharacters ()["red"].sendMove ({"drop": {"f": {"foo": 1}}})
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["red"].getFungibleInventory (), {
+      "foo": 9,
+    })
+    self.assertEqual (self.getRpc ("getgroundloot"), [
+      {
+        "position": {"x": -1, "y": 20},
+        "inventory":
+          {
+            "fungible": {"foo": 6},
+          },
+      },
+      {
+        "position": {"x": 1, "y": 2},
+        "inventory":
+          {
+            "fungible": {"bar": 10},
+          },
+      },
+    ])
+
+    self.mainLogger.info ("Death drops of character inventories...")
+    self.initAccount ("green", "g")
+    self.createCharacters ("green")
+    self.generate (1)
+    self.moveCharactersTo ({
+      "red": {"x": 100, "y": 100},
+      "green": {"x": 100, "y": 100},
+    })
+    self.setCharactersHP ({
+      "red": {"a": 1, "s": 0},
+    })
+    self.assertEqual (self.getCharacters ()["red"].getFungibleInventory (), {
+      "foo": 9,
+    })
+    self.getCharacters ()["green"].sendMove ({"pu": {"f": {"foo": 5}}})
+    self.generate (1)
+    chars = self.getCharacters ()
+    assert "red" not in chars
+    self.assertEqual (chars["green"].getFungibleInventory (), {
+      "foo": 5,
+    })
+    self.assertEqual (self.getRpc ("getgroundloot"), [
+      {
+        "position": {"x": -1, "y": 20},
+        "inventory":
+          {
+            "fungible": {"foo": 6},
+          },
+      },
+      {
+        "position": {"x": 1, "y": 2},
+        "inventory":
+          {
+            "fungible": {"bar": 10},
+          },
+      },
+      {
+        "position": {"x": 100, "y": 100},
+        "inventory":
+          {
+            "fungible": {"foo": 4},
+          },
+      },
+    ])
+
 
 if __name__ == "__main__":
   LootTest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -80,6 +80,9 @@ class Character (object):
       return self.data["busy"]
     return None
 
+  def getFungibleInventory (self):
+    return self.data["inventory"]["fungible"]
+
   def sendMove (self, mv):
     """
     Sends a move to update the given character with the given data.

--- a/src/combat.hpp
+++ b/src/combat.hpp
@@ -23,6 +23,7 @@
 
 #include "database/damagelists.hpp"
 #include "database/database.hpp"
+#include "database/inventory.hpp"
 #include "mapdata/basemap.hpp"
 #include "proto/combat.pb.h"
 
@@ -49,7 +50,7 @@ std::vector<proto::TargetId> DealCombatDamage (Database& db, DamageLists& dl,
  * Processes killed fighers from the given list, actually performing the
  * necessary database changes for having them dead.
  */
-void ProcessKills (Database& db, DamageLists& dl,
+void ProcessKills (Database& db, DamageLists& dl, GroundLootTable& loot,
                    const std::vector<proto::TargetId>& dead,
                    const BaseMap& map);
 

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -23,6 +23,7 @@
 #include "database/damagelists.hpp"
 #include "database/dbtest.hpp"
 #include "database/faction.hpp"
+#include "database/inventory.hpp"
 #include "database/schema.hpp"
 #include "hexagonal/coord.hpp"
 #include "mapdata/basemap.hpp"
@@ -95,9 +96,10 @@ void
 UpdateHP (Database& db, xaya::Random& rnd, const BaseMap& map)
 {
   DamageLists dl(db, 0);
+  GroundLootTable loot(db);
 
   const auto dead = DealCombatDamage (db, dl, rnd);
-  ProcessKills (db, dl, dead, map);
+  ProcessKills (db, dl, loot, dead, map);
   RegenerateHP (db);
 }
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -208,6 +208,20 @@ GetBusyJsonObject (const BaseMap& map, const Character& c)
 
 template <>
   Json::Value
+  GameStateJson::Convert<Inventory> (const Inventory& inv) const
+{
+  Json::Value fungible(Json::objectValue);
+  for (const auto& entry : inv.GetFungible ())
+    fungible[entry.first] = IntToJson (entry.second);
+
+  Json::Value res(Json::objectValue);
+  res["fungible"] = fungible;
+
+  return res;
+}
+
+template <>
+  Json::Value
   GameStateJson::Convert<Character> (const Character& c) const
 {
   Json::Value res(Json::objectValue);
@@ -217,6 +231,7 @@ template <>
   res["position"] = CoordToJson (c.GetPosition ());
   res["combat"] = GetCombatJsonObject (c, dl);
   res["speed"] = c.GetProto ().speed ();
+  res["inventory"] = Convert (c.GetInventory ());
 
   const Json::Value mv = GetMovementJsonObject (c);
   if (!mv.empty ())
@@ -238,20 +253,6 @@ template <>
   res["faction"] = FactionToString (a.GetFaction ());
   res["kills"] = IntToJson (a.GetKills ());
   res["fame"] = IntToJson (a.GetFame ());
-
-  return res;
-}
-
-template <>
-  Json::Value
-  GameStateJson::Convert<Inventory> (const Inventory& inv) const
-{
-  Json::Value fungible(Json::objectValue);
-  for (const auto& entry : inv.GetFungible ())
-    fungible[entry.first] = IntToJson (entry.second);
-
-  Json::Value res(Json::objectValue);
-  res["fungible"] = fungible;
 
   return res;
 }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -336,6 +336,30 @@ TEST_F (CharacterJsonTests, HP)
   })");
 }
 
+TEST_F (CharacterJsonTests, Inventory)
+{
+  auto h = tbl.CreateNew ("domob", Faction::RED);
+  h->GetInventory ().SetFungibleCount ("foo", 5);
+  h->GetInventory ().SetFungibleCount ("bar", 10);
+  h.reset ();
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "inventory":
+            {
+              "fungible":
+                {
+                  "foo": 5,
+                  "bar": 10
+                }
+            }
+        }
+      ]
+  })");
+}
+
 TEST_F (CharacterJsonTests, DamageLists)
 {
   const auto id1 = tbl.CreateNew ("domob", Faction::RED)->GetId ();

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -203,6 +203,17 @@ private:
   void MaybeStartProspecting (Character& c, const Json::Value& upd);
 
   /**
+   * Processes a command to drop loot from the character's inventory
+   * onto the ground.
+   */
+  void MaybeDropLoot (Character& c, const Json::Value& cmd);
+
+  /**
+   * Processes a command to pick up loot from the ground.
+   */
+  void MaybePickupLoot (Character& c, const Json::Value& cmd);
+
+  /**
    * Tries to handle an account initialisation (choosing faction) from
    * the given move.
    */


### PR DESCRIPTION
This adds an inventory of items to characters, and allows them to interact with loot on the ground (pick stuff up or drop items).  Also, if a character is killed, their inventory will be dropped to the ground.  For now, there is no cargo-space restriction.

This is the second step towards implementing #42.

The new moves for picking up or dropping fungible items from a character's inventory are as follows:

    {"pu": {"f": {"foo": 10, "bar": 1}}}
    {"drop": {"f": {"foo": 5}}}