### PR TITLE
Add cargo-space concept/limit

### DIFF
--- a/database/character.hpp
+++ b/database/character.hpp
@@ -316,6 +316,11 @@ public:
    */
   bool HasTarget () const;
 
+  /**
+   * Returns the used cargo space for the character's inventory.
+   */
+  uint64_t UsedCargoSpace () const;
+
 };
 
 /**

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -181,6 +181,7 @@ TEST_F (CharacterTests, Inventory)
 {
   auto h = tbl.CreateNew ("domob", Faction::RED);
   const auto id = h->GetId ();
+  h->MutableProto ().set_cargo_space (100);
   h->GetInventory ().SetFungibleCount ("foo", 10);
   h.reset ();
 
@@ -230,6 +231,15 @@ TEST_F (CharacterTests, AttackRange)
   c.reset ();
 
   EXPECT_EQ (tbl.GetById (id)->GetAttackRange (), 0);
+}
+
+TEST_F (CharacterTests, UsedCargoSpace)
+{
+  auto c = tbl.CreateNew ("domob", Faction::RED);
+  c->MutableProto ().set_cargo_space (1000);
+  c->GetInventory ().SetFungibleCount ("foo", 10);
+  c->GetInventory ().SetFungibleCount ("bar", 3);
+  EXPECT_EQ (c->UsedCargoSpace (), 100 + 60);
 }
 
 /* ************************************************************************** */

--- a/database/inventory.cpp
+++ b/database/inventory.cpp
@@ -23,6 +23,12 @@
 namespace pxd
 {
 
+/* Make sure that the product of item quantity and dual value (according to
+   the respective limits) can be computed safely.  */
+static_assert ((MAX_ITEM_QUANTITY * MAX_ITEM_DUAL) / MAX_ITEM_DUAL
+                  == MAX_ITEM_QUANTITY,
+               "item quantity and dual limits overflow multiplication");
+
 /* ************************************************************************** */
 
 Inventory::Inventory ()
@@ -70,6 +76,18 @@ Inventory::SetFungibleCount (const std::string& type, const QuantityT count)
     fungible.erase (type); 
   else
     fungible[type] = count;
+}
+
+int64_t
+Inventory::Product (const QuantityT amount, const int64_t dual)
+{
+  CHECK_GE (amount, -MAX_ITEM_QUANTITY);
+  CHECK_LE (amount, MAX_ITEM_QUANTITY);
+
+  CHECK_GE (dual, -MAX_ITEM_DUAL);
+  CHECK_LE (dual, MAX_ITEM_DUAL);
+
+  return amount * dual;
 }
 
 /* ************************************************************************** */

--- a/database/inventory.hpp
+++ b/database/inventory.hpp
@@ -46,7 +46,15 @@ namespace pxd
  * A value of one billion allows multiplication with another value in that
  * range (e.g. cargo per item or price per unit) without overflowing 64 bits.
  */
-static constexpr uint64_t MAX_ITEM_QUANTITY = 1'000'000'000;
+static constexpr int64_t MAX_ITEM_QUANTITY = 1'000'000'000;
+
+/**
+ * The maximum value any "dual variables" for item quantities can have.
+ * These are things that are multiplied with them, for instance per-unit
+ * value/weight or cost.  By limiting this value, we ensure that the product
+ * can always be safely computed in 64 bits.
+ */
+static constexpr int64_t MAX_ITEM_DUAL = 1'000'000'000;
 
 /**
  * Wrapper class around the state of an inventory.  This is what game-logic
@@ -130,6 +138,13 @@ public:
   {
     return data;
   }
+
+  /**
+   * Computes the product of a quantity value with a dual value.  Both
+   * must be within the limits, or else the function CHECK-fails.  They may
+   * be signed, though.
+   */
+  static int64_t Product (QuantityT amount, int64_t dual);
 
 };
 

--- a/database/inventory_tests.cpp
+++ b/database/inventory_tests.cpp
@@ -107,6 +107,13 @@ TEST_F (InventoryTests, Modification)
   EXPECT_TRUE (inv.IsDirty ());
 }
 
+TEST_F (InventoryTests, DualProduct)
+{
+  const auto val = Inventory::Product (MAX_ITEM_QUANTITY, -MAX_ITEM_DUAL);
+  EXPECT_EQ (val % MAX_ITEM_DUAL, 0);
+  EXPECT_EQ (val / MAX_ITEM_QUANTITY, -MAX_ITEM_DUAL);
+}
+
 /* ************************************************************************** */
 
 struct CountResult : public Database::ResultType

--- a/gametest/loot.py
+++ b/gametest/loot.py
@@ -102,6 +102,47 @@ class LootTest (PXTest):
       },
     ])
 
+    self.mainLogger.info ("Cargo limit for picking loot up...")
+    self.initAccount ("cargo", "r")
+    self.dropLoot ({"x": 0, "y": 0}, {"foo": 95})
+    self.createCharacters ("cargo", 1)
+    self.generate (1)
+    self.moveCharactersTo ({"cargo": {"x": 0, "y": 0}})
+    self.getCharacters ()["cargo"].sendMove ({"pu": {"f": {"foo": 100}}})
+    self.generate (1)
+    self.moveCharactersTo ({"cargo": {"x": 1, "y": 2}})
+    self.getCharacters ()["cargo"].sendMove ({"pu": {"f": {"bar": 100}}})
+    self.generate (1)
+    c = self.getCharacters ()["cargo"]
+    self.assertEqual (c.getFungibleInventory (), {
+      "foo": 95,
+      "bar": 2,
+    })
+    c.expectPartial ({
+      "cargospace":
+        {
+          "total": 1000,
+          "used": 990,
+          "free": 10,
+        },
+    })
+    self.assertEqual (self.getRpc ("getgroundloot"), [
+      {
+        "position": {"x": -1, "y": 20},
+        "inventory":
+          {
+            "fungible": {"foo": 6},
+          },
+      },
+      {
+        "position": {"x": 1, "y": 2},
+        "inventory":
+          {
+            "fungible": {"bar": 8},
+          },
+      },
+    ])
+
     self.mainLogger.info ("Death drops of character inventories...")
     self.initAccount ("green", "g")
     self.createCharacters ("green")
@@ -135,7 +176,7 @@ class LootTest (PXTest):
         "position": {"x": 1, "y": 2},
         "inventory":
           {
-            "fungible": {"bar": 10},
+            "fungible": {"bar": 8},
           },
       },
       {

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -99,7 +99,6 @@ class Character (object):
     """
 
     for key, val in expected.iteritems ():
-      assert key in self.data
       self.test.assertEqual (self.data[key], val)
 
 

--- a/proto/.gitignore
+++ b/proto/.gitignore
@@ -1,2 +1,6 @@
+roconfig.cpp
+
+tests
+*.trs
 *.pb.h
 *.pb.cc

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -3,19 +3,43 @@ noinst_LTLIBRARIES = libpxproto.la
 PROTOS = \
   character.proto \
   combat.proto \
+  config.proto \
   geometry.proto \
   inventory.proto \
   movement.proto \
   region.proto
-EXTRA_DIST = $(PROTOS)
+EXTRA_DIST = $(PROTOS) roconfig.pb.text roconfig_head.cpp roconfig_tail.cpp
 
 BUILT_SOURCES = $(PROTOS:.proto=.pb.h)
-CLEANFILES = $(PROTOS:.proto=.pb.h) $(PROTOS:.proto=.pb.cc)
+CLEANFILES = $(PROTOS:.proto=.pb.h) $(PROTOS:.proto=.pb.cc) roconfig.cpp
 
 libpxproto_la_CXXFLAGS = $(PROTOBUF_CFLAGS)
 libpxproto_la_LIBADD = $(PROTOBUF_LIBS)
-libpxproto_la_SOURCES = $(PROTOS:.proto=.pb.cc)
-noinst_HEADERS = $(PROTOS:.proto=.pb.h)
+libpxproto_la_SOURCES = \
+  roconfig.cpp \
+  \
+  $(PROTOS:.proto=.pb.cc)
+noinst_HEADERS = \
+  roconfig.hpp \
+  \
+  $(PROTOS:.proto=.pb.h)
+
+check_PROGRAMS = tests
+TESTS = tests
+
+tests_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(GTEST_MAIN_CFLAGS) \
+  $(GTEST_CFLAGS) $(GLOG_CFLAGS) $(PROTOBUF_CFLAGS)
+tests_LDADD = \
+  $(builddir)/libpxproto.la \
+  $(GTEST_MAIN_LIBS) \
+  $(GTEST_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
+tests_SOURCES = \
+  roconfig_tests.cpp
 
 %.pb.h %.pb.cc: $(srcdir)/%.proto
 	protoc -I$(srcdir) --cpp_out=. "$<"
+
+roconfig.cpp: roconfig_head.cpp roconfig.pb.text roconfig_tail.cpp
+	cat $^ >$@

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -72,6 +72,9 @@ message Character
   /** Movement speed of the character.  */
   optional uint32 speed = 5;
 
+  /** Total cargo space the character has.  */
+  optional uint64 cargo_space = 6;
+
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:
 

--- a/proto/roconfig.hpp
+++ b/proto/roconfig.hpp
@@ -1,0 +1,34 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PROTO_ROCONFIG_HPP
+#define PROTO_ROCONFIG_HPP
+
+#include "config.pb.h"
+
+namespace pxd
+{
+
+/**
+ * Returns the singleton, read-only instance of the global ConfigData proto.
+ */
+const proto::ConfigData& RoConfigData ();
+
+} // namespace pxd
+
+#endif // PROTO_ROCONFIG_HPP

--- a/proto/roconfig.pb.text
+++ b/proto/roconfig.pb.text
@@ -1,0 +1,43 @@
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# The following items are used only for tests.  They are defined also
+# in the real game, but since they are never generated (except through
+# god-mode or direct intervention in tests), that has no effect.
+fungible_items:
+  {
+    key: "foo"
+    value:
+      {
+        space: 10
+      }
+  }
+fungible_items:
+  {
+    key: "bar"
+    value:
+      {
+        space: 20
+      }
+  }
+fungible_items:
+  {
+    key: "zerospace"
+    value:
+      {
+        space: 0
+      }
+  }

--- a/proto/roconfig_head.cpp
+++ b/proto/roconfig_head.cpp
@@ -1,0 +1,32 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "roconfig.hpp"
+
+#include <google/protobuf/text_format.h>
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+namespace
+{
+
+using google::protobuf::TextFormat;
+
+constexpr const char* ROCONFIG_PROTO_TEXT = R"(

--- a/proto/roconfig_tail.cpp
+++ b/proto/roconfig_tail.cpp
@@ -1,0 +1,24 @@
+)";
+
+/** Singleton instance of the proto.  */
+proto::ConfigData instance;
+
+/** Whether or not the proto has been initialised from the text yet.  */
+bool initialised = false;
+
+} // anonymous namespace
+
+const proto::ConfigData&
+RoConfigData ()
+{
+  if (!initialised)
+    {
+      LOG (INFO) << "Initialising hard-coded ConfigData proto instance...";
+      CHECK (TextFormat::ParseFromString (ROCONFIG_PROTO_TEXT, &instance));
+      initialised = true;
+    }
+
+  return instance;
+}
+
+} // namespace pxd

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -1,0 +1,41 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "roconfig.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+TEST (RoConfigTests, Parses)
+{
+  RoConfigData ();
+}
+
+TEST (RoConfigTests, IsSingleton)
+{
+  const auto* ptr1 = &RoConfigData ();
+  const auto* ptr2 = &RoConfigData ();
+  EXPECT_EQ (ptr1, ptr2);
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -537,6 +537,7 @@ TEST_F (ProcessKillsTests, DropsInventory)
 
   auto c = characters.CreateNew ("domob", Faction::RED);
   const auto id = c->GetId ();
+  c->MutableProto ().set_cargo_space (1000);
   c->SetPosition (pos);
   c->GetInventory ().SetFungibleCount ("foo", 2);
   c->GetInventory ().SetFungibleCount ("bar", 10);

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -204,6 +204,22 @@ GetBusyJsonObject (const BaseMap& map, const Character& c)
   return res;
 }
 
+/**
+ * Constructs the JSON representation of a character's cargo space.
+ */
+Json::Value
+GetCargoSpaceJsonObject (const Character& c)
+{
+  const auto used = c.UsedCargoSpace ();
+
+  Json::Value res(Json::objectValue);
+  res["total"] = IntToJson (c.GetProto ().cargo_space ());
+  res["used"] = IntToJson (used);
+  res["free"] = IntToJson (c.GetProto ().cargo_space () - used);
+
+  return res;
+}
+
 } // anonymous namespace
 
 template <>
@@ -232,6 +248,7 @@ template <>
   res["combat"] = GetCombatJsonObject (c, dl);
   res["speed"] = c.GetProto ().speed ();
   res["inventory"] = Convert (c.GetInventory ());
+  res["cargospace"] = GetCargoSpaceJsonObject (c);
 
   const Json::Value mv = GetMovementJsonObject (c);
   if (!mv.empty ())

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -361,6 +361,28 @@ TEST_F (CharacterJsonTests, Inventory)
   })");
 }
 
+TEST_F (CharacterJsonTests, CargoSpace)
+{
+  auto h = tbl.CreateNew ("domob", Faction::RED);
+  h->MutableProto ().set_cargo_space (1000);
+  h->GetInventory ().SetFungibleCount ("foo", 35);
+  h.reset ();
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "cargospace":
+            {
+              "total": 1000,
+              "used": 350,
+              "free": 650
+            }
+        }
+      ]
+  })");
+}
+
 TEST_F (CharacterJsonTests, DamageLists)
 {
   const auto id1 = tbl.CreateNew ("domob", Faction::RED)->GetId ();

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -339,6 +339,7 @@ TEST_F (CharacterJsonTests, HP)
 TEST_F (CharacterJsonTests, Inventory)
 {
   auto h = tbl.CreateNew ("domob", Faction::RED);
+  h->MutableProto ().set_cargo_space (1000);
   h->GetInventory ().SetFungibleCount ("foo", 5);
   h->GetInventory ().SetFungibleCount ("bar", 10);
   h.reset ();

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -330,12 +330,14 @@ TEST_F (PXLogicTests, PickUpDeadDrop)
   const auto idAttacker = c->GetId ();
   ASSERT_EQ (idAttacker, 1);
   c->SetPosition (pos);
+  c->MutableProto ().set_cargo_space (1000);
   AddUnityAttack (*c, 1);
   c.reset ();
 
   c = CreateCharacter ("target", Faction::GREEN);
   const auto idTarget = c->GetId ();
   c->SetPosition (pos);
+  c->MutableProto ().set_cargo_space (1000);
   c->MutableProto ().mutable_combat_data ();
   c->GetInventory ().SetFungibleCount ("foo", 10);
   c.reset ();

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -794,6 +794,7 @@ protected:
   DropPickupMoveTests ()
     : loot(db), pos(1, 2)
   {
+    GetTest ()->MutableProto ().set_cargo_space (1000);
     GetTest ()->SetPosition (pos);
   }
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -156,6 +156,7 @@ void
 Params::InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const
 {
   pb.set_speed (3000);
+  pb.set_cargo_space (1000);
 
   auto* cd = pb.mutable_combat_data ();
   auto* attack = cd->add_attacks ();


### PR DESCRIPTION
This adds a concept of "cargo space" in the game.  We have a predefined list of items (just testing ones for now), and each has a per-unit cargo space.  Also characters have their available cargo space (just 1,000 fixed for now) in the game state.  When picking up items, we enforce that a character can only hold up to their cargo space.

The total, used and available cargo space of a character is returned in its game-state JSON in the `cargospace` field.

This is the final part of #42.