### PR TITLE
Support area-based attacks

### DIFF
--- a/proto/character.proto
+++ b/proto/character.proto
@@ -49,7 +49,13 @@ message Character
   /** Active movement of the character, if any.  */
   optional Movement movement = 1;
 
-  /** The attacked target (if any).  */
+  /**
+   * The attacked target (if any).  The presence of this field also tells us
+   * that there are enemies in range, which is important for area attacks.
+   * So even if e.g. a character has just area attacks, we need to select
+   * one target for them nevertheless, as we later on only process attacks
+   * of characters with a selected target.
+   */
   optional TargetId target = 2;
 
   /**

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -59,10 +59,16 @@ message Attack
   /** The range of the attack (as L1 distance on our hex grid).  */
   optional uint32 range = 1;
 
+  /**
+   * If true, then the attack applies to all enemies in range (rather than
+   * just the single selected target).
+   */
+  optional bool area = 2;
+
   /* Maximum and minimum damage of the attack.  The actual damage will be
      chosen uniformly from the both-inclusive range.  */
-  optional uint32 min_damage = 2;
-  optional uint32 max_damage = 3;
+  optional uint32 min_damage = 3;
+  optional uint32 max_damage = 4;
 
 }
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -152,6 +152,7 @@ GetCombatJsonObject (const Character& c, const DamageLists& dl)
     {
       Json::Value obj(Json::objectValue);
       obj["range"] = IntToJson (attack.range ());
+      obj["area"] = attack.area ();
       obj["mindamage"] = IntToJson (attack.min_damage ());
       obj["maxdamage"] = IntToJson (attack.max_damage ());
       attacks.append (obj);

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -285,6 +285,7 @@ TEST_F (CharacterJsonTests, Attacks)
   attack->set_max_damage (10);
   attack = cd->add_attacks ();
   attack->set_range (1);
+  attack->set_area (true);
   attack->set_min_damage (0);
   attack->set_max_damage (1);
   c.reset ();
@@ -297,8 +298,8 @@ TEST_F (CharacterJsonTests, Attacks)
             {
               "attacks":
                 [
-                  {"range": 5, "mindamage": 2, "maxdamage": 10},
-                  {"range": 1, "mindamage": 0, "maxdamage": 1}
+                  {"range": 5, "area": false, "mindamage": 2, "maxdamage": 10},
+                  {"range": 1, "area": true, "mindamage": 0, "maxdamage": 1}
                 ]
             }
         }

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -163,8 +163,10 @@ Params::InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const
   attack->set_range (10);
   attack->set_min_damage (1);
   attack->set_max_damage (20);
+
   attack = cd->add_attacks ();
   attack->set_range (1);
+  attack->set_area (true);
   attack->set_min_damage (5);
   attack->set_max_damage (30);
 


### PR DESCRIPTION
This adds the ability to define attacks that are area- rather than target-based (and the short-range attack of the default characters is made area based).  This means that all enemies in range take damage (based on the same random roll) rather than just the selected target.

We still perform normal target selection, because the presence of a target tells us that there are some enemies in range and we need to perform damaging logic.  But if the attacker has only area-based attacks, then the exact selected target does not matter.

The JSON returned for attacks has now a new boolean field, `area`, which is `true` for area-based attacks and `false` for traditional target-based ones.

This implements #47.