### PR TITLE
Overhaul prospecting of regions

### DIFF
--- a/database/region.hpp
+++ b/database/region.hpp
@@ -20,6 +20,7 @@
 #define DATABASE_REGION_HPP
 
 #include "database.hpp"
+#include "inventory.hpp"
 #include "lazyproto.hpp"
 
 #include "mapdata/regionmap.hpp"
@@ -34,7 +35,8 @@ namespace pxd
 struct RegionResult : public Database::ResultType
 {
   RESULT_COLUMN (int64_t, id, 1);
-  RESULT_COLUMN (pxd::proto::RegionData, proto, 2);
+  RESULT_COLUMN (int64_t, resourceleft, 2);
+  RESULT_COLUMN (pxd::proto::RegionData, proto, 3);
 };
 
 /**
@@ -54,8 +56,14 @@ private:
   /** The ID of the region.  */
   RegionMap::IdT id;
 
+  /** The amount of mine-able resources left.  */
+  Inventory::QuantityT resourceLeft;
+
   /** Generic data stored in the proto BLOB.  */
   LazyProto<proto::RegionData> data;
+
+  /** Whether or not just the non-proto fields have been updated.  */
+  bool dirtyFields;
 
   /**
    * Constructs an instance with "default / empty" data for the given ID.
@@ -101,6 +109,19 @@ public:
   {
     return data.Mutable ();
   }
+
+  /**
+   * Returns the amount of mine-able resource left in this region.  This must
+   * only be called when the region has been prospected already.  The type of
+   * resource can be found in the proto data.
+   */
+  Inventory::QuantityT GetResourceLeft () const;
+
+  /**
+   * Sets the amount of mine-able resource left.  This must only be called
+   * when the region has been prospected.
+   */
+  void SetResourceLeft (Inventory::QuantityT value);
 
 };
 

--- a/database/region_tests.cpp
+++ b/database/region_tests.cpp
@@ -48,16 +48,34 @@ TEST_F (RegionTests, DefaultData)
   EXPECT_FALSE (r->GetProto ().has_prospecting_character ());
 }
 
-TEST_F (RegionTests, Update)
+TEST_F (RegionTests, UpdateWithProto)
 {
-  tbl.GetById (42)->MutableProto ().set_prospecting_character (100);
-
   auto r = tbl.GetById (42);
-  EXPECT_EQ (r->GetProto ().prospecting_character (), 100);
+  r->MutableProto ().mutable_prospection ()->set_resource ("foo");
+  r->SetResourceLeft (100);
+  r.reset ();
+
+  r = tbl.GetById (42);
+  EXPECT_EQ (r->GetProto ().prospection ().resource (), "foo");
+  EXPECT_EQ (r->GetResourceLeft (), 100);
 
   r = tbl.GetById (100);
   EXPECT_EQ (r->GetId (), 100);
   EXPECT_FALSE (r->GetProto ().has_prospecting_character ());
+}
+
+TEST_F (RegionTests, UpdateOnlyFields)
+{
+  auto r = tbl.GetById (42);
+  r->MutableProto ().mutable_prospection ()->set_resource ("foo");
+  r->SetResourceLeft (100);
+  r.reset ();
+
+  tbl.GetById (42)->SetResourceLeft (80);
+
+  r = tbl.GetById (42);
+  EXPECT_EQ (r->GetProto ().prospection ().resource (), "foo");
+  EXPECT_EQ (r->GetResourceLeft (), 80);
 }
 
 TEST_F (RegionTests, IdZero)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -158,6 +158,15 @@ CREATE TABLE IF NOT EXISTS `regions` (
   -- all values are real regions.
   `id` INTEGER PRIMARY KEY,
 
+  -- The amount of resources left to be mined.  The type of resource is
+  -- defined in the region proto.  The value is undefined for regions that
+  -- have not been prospected yet.
+  --
+  -- This is not stored in the proto, because it may be changed frequently
+  -- (on every turn) while the region is being mined actively.  Thus we avoid
+  -- frequent updates of the proto by keeping it directly in the DB.
+  `resourceleft` INTEGER NOT NULL,
+
   -- Additional data encoded as a RegionData protocol buffer.
   `proto` BLOB NOT NULL
 

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -18,6 +18,7 @@ REGTESTS = \
   pending.py \
   prospecting_basic.py \
   prospecting_prizes.py \
+  prospecting_resources.py \
   splitstaterpcs.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -16,7 +16,8 @@ REGTESTS = \
   multiupdate.py \
   nullstate.py \
   pending.py \
-  prospecting.py \
+  prospecting_basic.py \
+  prospecting_prizes.py \
   splitstaterpcs.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/gametest/prospecting.py
+++ b/gametest/prospecting.py
@@ -310,7 +310,7 @@ class ProspectingTest (PXTest):
     for nm, val in self.getRpc ("getprizestats").iteritems ():
       self.assertEqual (prizesInRegions[nm], val["found"])
     self.log.info ("Found prizes:\n%s" % prizesInRegions)
-    self.assertEqual (prizesInRegions["bronze"], 0)
+    self.assertEqual (prizesInRegions["bronze"], 1)
     assert prizesInRegions["silver"] > 0
 
   def testReorg (self):

--- a/gametest/prospecting_basic.py
+++ b/gametest/prospecting_basic.py
@@ -17,22 +17,14 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
-Tests prospecting with characters and various interactions of that with
-movement and combat.
+Tests basic rules for prospecting with characters and various interactions of
+that with movement and combat.
 """
 
 from pxtest import PXTest, offsetCoord
 
-# Timestamps when the competition is still active and when it is
-# already over.  Note that for some reason we cannot be exact to the
-# second here, since the mined block timestamps not always match the
-# mocktime exactly.  We verify the correct behaviour with respect to the
-# timestamp in unit tests, though.
-COMPETITION_RUNNING = 1500000000
-COMPETITION_OVER = 1600000000
 
-
-class ProspectingTest (PXTest):
+class BasicProspectingTest (PXTest):
 
   def expectProspectedBy (self, pos, name):
     """
@@ -47,20 +39,7 @@ class ProspectingTest (PXTest):
     self.assertEqual (data, {"name": name})
 
   def run (self):
-    # Mine a couple of blocks to get a meaningful median time
-    # that is before the times we'll use in testing.
-    self.rpc.xaya.setmocktime (COMPETITION_RUNNING)
-    self.generate (10)
-
     self.collectPremine ()
-
-    # Somehow the test fails with the reorgs if we start off with just
-    # a single output of coins.  Thus split it up.
-    sendTo = {}
-    for _ in range (100):
-      sendTo[self.rpc.xaya.getnewaddress ()] = 1000
-    self.rpc.xaya.sendmany ("", sendTo)
-    self.generate (1)
 
     self.mainLogger.info ("Setting up test characters...")
     self.initAccount ("target", "r")
@@ -193,125 +172,7 @@ class ProspectingTest (PXTest):
                       None)
     self.expectProspectedBy (self.offset, self.prospectors[0])
 
-    self.testPrizes ()
     self.testReorg ()
-
-  def testPrizes (self):
-    """
-    Tests allocation of prizes for prospecting.
-    """
-
-    # First test:  Try and retry (with a reorg) prospecting in the
-    # same region to get both no prize and a silver tier.
-    self.mainLogger.info ("Testing randomisation of prizes...")
-
-    self.initAccount ("prize trier", "r")
-    c = self.createCharacters ("prize trier")
-    self.generate (1)
-    pos = {"x": -1000, "y": 1000}
-    self.moveCharactersTo ({"prize trier": pos})
-    stillNeedNone = True
-    stillNeedSilver = True
-    blk = None
-    self.getCharacters ()["prize trier"].sendMove ({"prospect": {}})
-    self.generate (9)
-    while stillNeedNone or stillNeedSilver:
-      self.generate (1)
-      blk = self.rpc.xaya.getbestblockhash ()
-      self.generate (1)
-
-      prosp = self.getRegionAt (pos).data["prospection"]
-      self.assertEqual (prosp["name"], "prize trier")
-      if not "prize" in prosp:
-        stillNeedNone = False
-      elif prosp["prize"] == "silver":
-        stillNeedSilver = False
-
-      self.rpc.xaya.invalidateblock (blk)
-
-    assert blk is not None
-    blkOldTime = blk
-
-    # Test the impact of the block time onto received prizes.  After
-    # the competition is over, no prizes should be found anymore.  It
-    # is possible to have a "beyond" block and then an earlier block with
-    # prizes, though.  Thus we mine the block before prospecting ends
-    # always after the competition.
-    self.mainLogger.info ("Testing time and prizes...")
-
-    self.rpc.xaya.setmocktime (COMPETITION_OVER)
-    self.generate (1)
-
-    # There's a 12% chance that we will simply not find a silver prize
-    # (with 10% chance) in 20 trials even if we could, but we are fine
-    # with that.
-    for _ in range (20):
-      self.generate (1)
-      blk = self.rpc.xaya.getbestblockhash ()
-
-      prosp = self.getRegionAt (pos).data["prospection"]
-      self.assertEqual (prosp["name"], "prize trier")
-      assert "prize" not in prosp
-
-      self.rpc.xaya.invalidateblock (blk)
-
-    self.rpc.xaya.setmocktime (COMPETITION_RUNNING)
-    stillNeedPrize = True
-    while stillNeedPrize:
-      self.generate (1)
-      blk = self.rpc.xaya.getbestblockhash ()
-
-      prosp = self.getRegionAt (pos).data["prospection"]
-      self.assertEqual (prosp["name"], "prize trier")
-      if "prize" in prosp:
-        stillNeedPrize = False
-
-      self.rpc.xaya.invalidateblock (blk)
-
-    # Restore the last randomised attempt.  Else we might end up with
-    # a long invalid chain, which can confuse the reorg test.
-    self.rpc.xaya.reconsiderblock (blkOldTime)
-
-    # Prospect in some regions and verify some basic expectations
-    # on the number of prizes found.
-    self.mainLogger.info ("Testing prize numbers...")
-
-    sendTo = {}
-    regionIds = set ()
-    nextInd = 2
-    for i in range (2):
-      for j in range (10):
-        pos = {"x": 20 * i, "y": 20 * j}
-        region = self.getRegionAt (pos)
-        assert "prospection" not in region.data
-        assert region.getId () not in regionIds
-        regionIds.add (region.getId ())
-
-        self.createCharacters ("prize trier")
-        nm = "prize trier %d" % nextInd
-        nextInd += 1
-        sendTo[nm] = pos
-    self.generate (1)
-    self.moveCharactersTo (sendTo)
-
-    chars = self.getCharacters ()
-    for nm in sendTo:
-      chars[nm].sendMove ({"prospect": {}})
-    self.generate (11)
-
-    prizesInRegions = {
-      "gold": 0,
-      "silver": 0,
-      "bronze": 0,
-    }
-    for r in self.getRpc ("getregions"):
-      if ("prospection" in r) and "prize" in r["prospection"]:
-        prizesInRegions[r["prospection"]["prize"]] += 1
-    for nm, val in self.getRpc ("getprizestats").iteritems ():
-      self.assertEqual (prizesInRegions[nm], val["found"])
-    self.log.info ("Found prizes:\n%s" % prizesInRegions)
-    self.assertEqual (prizesInRegions["bronze"], 1)
-    assert prizesInRegions["silver"] > 0
 
   def testReorg (self):
     """
@@ -346,4 +207,4 @@ class ProspectingTest (PXTest):
 
 
 if __name__ == "__main__":
-  ProspectingTest ().main ()
+  BasicProspectingTest ().main ()

--- a/gametest/prospecting_basic.py
+++ b/gametest/prospecting_basic.py
@@ -33,10 +33,7 @@ class BasicProspectingTest (PXTest):
     """
 
     region = self.getRegionAt (pos)
-    data = region.data["prospection"]
-    if "prize" in data:
-      del data["prize"]
-    self.assertEqual (data, {"name": name})
+    self.assertEqual (region.data["prospection"]["name"], name)
 
   def run (self):
     self.collectPremine ()
@@ -97,7 +94,10 @@ class BasicProspectingTest (PXTest):
     c = self.getCharacters ()["target"]
     self.assertEqual (c.getPosition (), pos)
     self.assertEqual (c.getBusy (), None)
-    self.expectProspectedBy (pos, "target")
+    region = self.getRegionAt (pos)
+    self.assertEqual (region.data["prospection"]["name"], "target")
+    self.assertEqual (region.data["prospection"]["height"],
+                      self.rpc.xaya.getblockcount ())
 
     # Move towards attackers and prospect there, but have the character
     # killed before it is done.

--- a/gametest/prospecting_prizes.py
+++ b/gametest/prospecting_prizes.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests distribution of prizes for prospecting.
+"""
+
+from pxtest import PXTest
+
+# Timestamps when the competition is still active and when it is
+# already over.  Note that for some reason we cannot be exact to the
+# second here, since the mined block timestamps not always match the
+# mocktime exactly.  We verify the correct behaviour with respect to the
+# timestamp in unit tests, though.
+COMPETITION_RUNNING = 1500000000
+COMPETITION_OVER = 1600000000
+
+
+class ProspectingPrizesTest (PXTest):
+
+  def run (self):
+    # Mine a couple of blocks to get a meaningful median time
+    # that is before the times we'll use in testing.
+    self.rpc.xaya.setmocktime (COMPETITION_RUNNING)
+    self.generate (10)
+
+    self.collectPremine ()
+
+    # First test:  Try and retry (with a reorg) prospecting in the
+    # same region to get both a silver tier and not silver.
+    self.mainLogger.info ("Testing randomisation of prizes...")
+
+    self.initAccount ("prize trier", "r")
+    c = self.createCharacters ("prize trier")
+    self.generate (1)
+    pos = {"x": -1000, "y": 1000}
+    self.moveCharactersTo ({"prize trier": pos})
+    stillNeedNoSilver = True
+    stillNeedSilver = True
+    blk = None
+    self.getCharacters ()["prize trier"].sendMove ({"prospect": {}})
+    self.generate (9)
+    while stillNeedNoSilver or stillNeedSilver:
+      self.generate (1)
+      blk = self.rpc.xaya.getbestblockhash ()
+      self.generate (1)
+
+      prosp = self.getRegionAt (pos).data["prospection"]
+      self.assertEqual (prosp["name"], "prize trier")
+      if (not "prize" in prosp) or prosp["prize"] != "silver":
+        stillNeedNoSilver = False
+      elif prosp["prize"] == "silver":
+        stillNeedSilver = False
+
+      self.rpc.xaya.invalidateblock (blk)
+
+    assert blk is not None
+    blkOldTime = blk
+
+    # Test the impact of the block time onto received prizes.  After
+    # the competition is over, no prizes should be found anymore.  It
+    # is possible to have a "beyond" block and then an earlier block with
+    # prizes, though.  Thus we mine the block before prospecting ends
+    # always after the competition.
+    self.mainLogger.info ("Testing time and prizes...")
+
+    self.rpc.xaya.setmocktime (COMPETITION_OVER)
+    self.generate (1)
+
+    # There's a 12% chance that we will simply not find a silver prize
+    # (with 10% chance) in 20 trials even if we could, but we are fine
+    # with that.
+    for _ in range (20):
+      self.generate (1)
+      blk = self.rpc.xaya.getbestblockhash ()
+
+      prosp = self.getRegionAt (pos).data["prospection"]
+      self.assertEqual (prosp["name"], "prize trier")
+      assert "prize" not in prosp
+
+      self.rpc.xaya.invalidateblock (blk)
+
+    self.rpc.xaya.setmocktime (COMPETITION_RUNNING)
+    stillNeedPrize = True
+    while stillNeedPrize:
+      self.generate (1)
+      blk = self.rpc.xaya.getbestblockhash ()
+
+      prosp = self.getRegionAt (pos).data["prospection"]
+      self.assertEqual (prosp["name"], "prize trier")
+      if "prize" in prosp:
+        stillNeedPrize = False
+
+      self.rpc.xaya.invalidateblock (blk)
+
+    # Restore the last randomised attempt.  Else we might end up with
+    # a long invalid chain, which can confuse the reorg test.
+    self.rpc.xaya.reconsiderblock (blkOldTime)
+
+    # Prospect in some regions and verify some basic expectations
+    # on the number of prizes found.
+    self.mainLogger.info ("Testing prize numbers...")
+
+    sendTo = {}
+    regionIds = set ()
+    nextInd = 2
+    for i in range (2):
+      for j in range (10):
+        pos = {"x": 20 * i, "y": 20 * j}
+        region = self.getRegionAt (pos)
+        assert "prospection" not in region.data
+        assert region.getId () not in regionIds
+        regionIds.add (region.getId ())
+
+        self.createCharacters ("prize trier")
+        nm = "prize trier %d" % nextInd
+        nextInd += 1
+        sendTo[nm] = pos
+    self.generate (1)
+    self.moveCharactersTo (sendTo)
+
+    chars = self.getCharacters ()
+    for nm in sendTo:
+      chars[nm].sendMove ({"prospect": {}})
+    self.generate (11)
+
+    prizesInRegions = {
+      "gold": 0,
+      "silver": 0,
+      "bronze": 0,
+    }
+    for r in self.getRpc ("getregions"):
+      if ("prospection" in r) and "prize" in r["prospection"]:
+        prizesInRegions[r["prospection"]["prize"]] += 1
+    for nm, val in self.getRpc ("getprizestats").iteritems ():
+      self.assertEqual (prizesInRegions[nm], val["found"])
+    self.log.info ("Found prizes:\n%s" % prizesInRegions)
+    self.assertEqual (prizesInRegions["bronze"], 1)
+    assert prizesInRegions["silver"] > 0
+
+
+if __name__ == "__main__":
+  ProspectingPrizesTest ().main ()

--- a/gametest/prospecting_resources.py
+++ b/gametest/prospecting_resources.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests prospecting with detection of resources.
+"""
+
+from pxtest import PXTest
+
+
+class ProspectingResourcesTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.initAccount ("domob", "r")
+    c = self.createCharacters ("domob")
+    self.generate (1)
+    pos = {"x": -1000, "y": 1000}
+    self.moveCharactersTo ({"domob": pos})
+    self.getCharacters ()["domob"].sendMove ({"prospect": {}})
+    self.generate (11)
+
+    r = self.getRegionAt (pos)
+    self.assertEqual (r.data["prospection"]["name"], "domob")
+    typ, amount = r.getResource ()
+    assert typ in ["sand", "cryptonite"]
+    assert amount > 0
+
+    # FIXME: For now, this test is super limited.  We should extend it
+    # and maybe test that different places on the map give different resources
+    # (at least in a simple form).
+
+
+if __name__ == "__main__":
+  ProspectingResourcesTest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -128,6 +128,14 @@ class Region (object):
   def getId (self):
     return self.data["id"]
 
+  def getResource (self):
+    """
+    Returns the type and remaining amount of mine-able resource at
+    the current region.
+    """
+
+    return self.data["resource"]["type"], self.data["resource"]["amount"]
+
 
 class PXTest (XayaGameTest):
   """

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -134,6 +134,9 @@ class Region (object):
     the current region.
     """
 
+    if "resource" not in self.data:
+      return None
+
     return self.data["resource"]["type"], self.data["resource"]["amount"]
 
 

--- a/proto/region.proto
+++ b/proto/region.proto
@@ -23,14 +23,20 @@ package pxd.proto;
 /**
  * Data about the prospecting outcome of a region.
  */
-message ProspectionOutcome
+message ProspectionData
 {
 
-  /** The Xaya name of the user who prospected the region.  */
+  /**
+   * The Xaya name of the user who prospected the region.  This has no impact
+   * on the game play, but can be useful for display purposes.
+   */
   optional string name = 1;
 
   /** The prize won, if any.  */
   optional string prize = 2;
+
+  /** The block height at which the region was prospected.  */
+  optional uint32 height = 3;
 
 }
 
@@ -44,6 +50,6 @@ message RegionData
   optional uint64 prospecting_character = 1;
 
   /** If already prospected, the outcome.  */
-  optional ProspectionOutcome prospection = 2;
+  optional ProspectionData prospection = 2;
 
 }

--- a/proto/region.proto
+++ b/proto/region.proto
@@ -32,11 +32,8 @@ message ProspectionData
    */
   optional string name = 1;
 
-  /** The prize won, if any.  */
-  optional string prize = 2;
-
   /** The block height at which the region was prospected.  */
-  optional uint32 height = 3;
+  optional uint32 height = 2;
 
 }
 

--- a/proto/region.proto
+++ b/proto/region.proto
@@ -35,6 +35,17 @@ message ProspectionData
   /** The block height at which the region was prospected.  */
   optional uint32 height = 2;
 
+  /**
+   * The type of resources that can be mined on the current region.  The amount
+   * left is stored directly in a DB column (because it may be updated
+   * frequently while the region is being mined).
+   *
+   * Every prospected region has some type of resource assigned, although
+   * there may be very little of it minable (or all might already have
+   * been taken).
+   */
+  optional string resource = 3;
+
 }
 
 /**

--- a/proto/roconfig.pb.text
+++ b/proto/roconfig.pb.text
@@ -14,6 +14,24 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+# Items corresponding to competition prizes that can be found.  They all
+# have zero cargo space.
+fungible_items:
+  {
+    key: "gold prize"
+    value: { space: 0 }
+  }
+fungible_items:
+  {
+    key: "silver prize"
+    value: { space: 0 }
+  }
+fungible_items:
+  {
+    key: "bronze prize"
+    value: { space: 0 }
+  }
+
 # The following items are used only for tests.  They are defined also
 # in the real game, but since they are never generated (except through
 # god-mode or direct intervention in tests), that has no effect.

--- a/proto/roconfig.pb.text
+++ b/proto/roconfig.pb.text
@@ -14,6 +14,21 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+# Resource types in the game.
+# FIXME: For now these are just dummy values used in tests of the basic
+# prospecting / mining logic.  Add in real ones once determined together
+# with their proper cargo space.
+fungible_items:
+  {
+    key: "sand"
+    value: { space: 50 }
+  }
+fungible_items:
+  {
+    key: "cryptonite"
+    value: { space: 1 }
+  }
+
 # Items corresponding to competition prizes that can be found.  They all
 # have zero cargo space.
 fungible_items:
@@ -38,24 +53,15 @@ fungible_items:
 fungible_items:
   {
     key: "foo"
-    value:
-      {
-        space: 10
-      }
+    value: { space: 10 }
   }
 fungible_items:
   {
     key: "bar"
-    value:
-      {
-        space: 20
-      }
+    value: { space: 20 }
   }
 fungible_items:
   {
     key: "zerospace"
-    value:
-      {
-        space: 0
-      }
+    value: { space: 0 }
   }

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -307,6 +307,15 @@ template <>
   if (!prospection.empty ())
     res["prospection"] = prospection;
 
+  if (pb.has_prospection ())
+    {
+      Json::Value resource(Json::objectValue);
+      resource["type"] = pb.prospection ().resource ();
+      resource["amount"] = IntToJson (r.GetResourceLeft ());
+
+      res["resource"] = resource;
+    }
+
   return res;
 }
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -301,6 +301,7 @@ template <>
   if (pb.has_prospection ())
     {
       prospection["name"] = pb.prospection ().name ();
+      prospection["height"] = pb.prospection ().height ();
       if (pb.prospection ().has_prize ())
         prospection["prize"] = pb.prospection ().prize ();
     }

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -302,8 +302,6 @@ template <>
     {
       prospection["name"] = pb.prospection ().name ();
       prospection["height"] = pb.prospection ().height ();
-      if (pb.prospection ().has_prize ())
-        prospection["prize"] = pb.prospection ().prize ();
     }
 
   if (!prospection.empty ())

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -577,29 +577,25 @@ TEST_F (RegionJsonTests, Empty)
 TEST_F (RegionJsonTests, Prospection)
 {
   tbl.GetById (20)->MutableProto ().set_prospecting_character (42);
-  tbl.GetById (10)->MutableProto ().mutable_prospection ()->set_name ("foo");
 
-  auto r = tbl.GetById (30);
+  auto r = tbl.GetById (10);
   auto* prosp = r->MutableProto ().mutable_prospection ();
   prosp->set_name ("bar");
   prosp->set_height (107);
-  prosp->set_prize ("gold");
   r.reset ();
 
   ExpectStateJson (R"({
     "regions":
       [
-        {"id": 10, "prospection": {"name": "foo", "prize": null}},
-        {"id": 20, "prospection": {"inprogress": 42}},
         {
-          "id": 30,
+          "id": 10,
           "prospection":
             {
               "name": "bar",
-              "height": 107,
-              "prize": "gold"
+              "height": 107
             }
-        }
+        },
+        {"id": 20, "prospection": {"inprogress": 42}}
       ]
   })");
 }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -582,6 +582,7 @@ TEST_F (RegionJsonTests, Prospection)
   auto r = tbl.GetById (30);
   auto* prosp = r->MutableProto ().mutable_prospection ();
   prosp->set_name ("bar");
+  prosp->set_height (107);
   prosp->set_prize ("gold");
   r.reset ();
 
@@ -590,7 +591,15 @@ TEST_F (RegionJsonTests, Prospection)
       [
         {"id": 10, "prospection": {"name": "foo", "prize": null}},
         {"id": 20, "prospection": {"inprogress": 42}},
-        {"id": 30, "prospection": {"name": "bar", "prize": "gold"}}
+        {
+          "id": 30,
+          "prospection":
+            {
+              "name": "bar",
+              "height": 107,
+              "prize": "gold"
+            }
+        }
       ]
   })");
 }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -569,7 +569,11 @@ TEST_F (RegionJsonTests, Empty)
   ExpectStateJson (R"({
     "regions":
       [
-        {"id": 20}
+        {
+          "id": 20,
+          "prospection": null,
+          "resource": null
+        }
       ]
   })");
 }
@@ -596,6 +600,28 @@ TEST_F (RegionJsonTests, Prospection)
             }
         },
         {"id": 20, "prospection": {"inprogress": 42}}
+      ]
+  })");
+}
+
+TEST_F (RegionJsonTests, MiningResource)
+{
+  auto r = tbl.GetById (10);
+  r->MutableProto ().mutable_prospection ()->set_resource ("sand");
+  r->SetResourceLeft (150);
+  r.reset ();
+
+  ExpectStateJson (R"({
+    "regions":
+      [
+        {
+          "id": 10,
+          "resource":
+            {
+              "type": "sand",
+              "amount": 150
+            }
+        }
       ]
   })");
 }

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -53,7 +53,8 @@ namespace
  */
 void
 ProcessBusy (Database& db, xaya::Random& rnd,
-             const int64_t timestamp, const Params& params, const BaseMap& map)
+             const unsigned blockHeight, const int64_t timestamp,
+             const Params& params, const BaseMap& map)
 {
   CharacterTable characters(db);
   RegionsTable regions(db);
@@ -66,7 +67,8 @@ ProcessBusy (Database& db, xaya::Random& rnd,
       switch (c->GetProto ().busy_case ())
         {
         case proto::Character::kProspection:
-          FinishProspecting (*c, db, regions, rnd, timestamp, params, map);
+          FinishProspecting (*c, db, regions, rnd,
+                             blockHeight, timestamp, params, map);
           break;
 
         default:
@@ -107,11 +109,14 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
   const auto& timestampVal = block["timestamp"];
   CHECK (timestampVal.isInt64 ());
   const int64_t timestamp = timestampVal.asInt64 ();
+  const auto& heightVal = block["height"];
+  CHECK (heightVal.isUInt64 ());
+  const unsigned blockHeight = heightVal.asUInt64 ();
 
   fame.GetDamageLists ().RemoveOld (params.DamageListBlocks ());
 
   AllHpUpdates (db, fame, rnd, map);
-  ProcessBusy (db, rnd, timestamp, params, map);
+  ProcessBusy (db, rnd, blockHeight, timestamp, params, map);
 
   DynObstacles dyn(db);
   MoveProcessor mvProc(db, dyn, rnd, params, map);

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -119,7 +119,7 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
   ProcessBusy (db, rnd, blockHeight, timestamp, params, map);
 
   DynObstacles dyn(db);
-  MoveProcessor mvProc(db, dyn, rnd, params, map);
+  MoveProcessor mvProc(db, dyn, rnd, params, map, blockHeight);
   mvProc.ProcessAdmin (blockData["admin"]);
   mvProc.ProcessAll (blockData["moves"]);
 

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -20,6 +20,7 @@
 
 #include "jsonutils.hpp"
 #include "movement.hpp"
+#include "prospecting.hpp"
 #include "protoutils.hpp"
 #include "spawn.hpp"
 
@@ -255,26 +256,7 @@ BaseMoveProcessor::ParseCharacterProspecting (const Character& c,
       << "Character " << c.GetId ()
       << " is trying to prospect region " << regionId;
 
-  auto r = regions.GetById (regionId);
-  const auto& rpb = r->GetProto ();
-  if (rpb.has_prospecting_character ())
-    {
-      LOG (WARNING)
-          << "Region " << regionId
-          << " is already being prospected by character "
-          << rpb.prospecting_character ()
-          << ", can't be prospected by " << c.GetId ();
-      return false;
-    }
-  if (rpb.has_prospection ())
-    {
-      LOG (WARNING)
-          << "Region " << regionId
-          << " is already prospected, can't be prospected by " << c.GetId ();
-      return false;
-    }
-
-  return true;
+  return CanProspectRegion (c, *regions.GetById (regionId));
 }
 
 /* ************************************************************************** */

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -256,7 +256,7 @@ BaseMoveProcessor::ParseCharacterProspecting (const Character& c,
       << "Character " << c.GetId ()
       << " is trying to prospect region " << regionId;
 
-  return CanProspectRegion (c, *regions.GetById (regionId), height);
+  return CanProspectRegion (c, *regions.GetById (regionId), params, height);
 }
 
 /* ************************************************************************** */
@@ -481,6 +481,10 @@ MoveProcessor::MaybeStartProspecting (Character& c, const Json::Value& upd)
 
   auto r = regions.GetById (regionId);
   r->MutableProto ().set_prospecting_character (c.GetId ());
+
+  /* If the region was already prospected and is now being reprospected,
+     remove the old result.  */
+  r->MutableProto ().clear_prospection ();
 
   StopCharacter (c);
   c.SetBusy (params.ProspectingBlocks ());

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -256,7 +256,7 @@ BaseMoveProcessor::ParseCharacterProspecting (const Character& c,
       << "Character " << c.GetId ()
       << " is trying to prospect region " << regionId;
 
-  return CanProspectRegion (c, *regions.GetById (regionId));
+  return CanProspectRegion (c, *regions.GetById (regionId), height);
 }
 
 /* ************************************************************************** */

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -62,6 +62,12 @@ protected:
   const BaseMap& map;
 
   /**
+   * Block height for which the moves are parsed.  If this is used for pending
+   * moves, then it is the assumed next block height (i.e. current plus one).
+   */
+  const unsigned height;
+
+  /**
    * The Database handle we use for making any changes (and looking up the
    * current state while validating moves).
    */
@@ -79,8 +85,9 @@ protected:
   /** Access to the regions table.  */
   RegionsTable regions;
 
-  explicit BaseMoveProcessor (Database& d, const Params& p, const BaseMap& m)
-    : params(p), map(m), db(d),
+  explicit BaseMoveProcessor (Database& d, const Params& p, const BaseMap& m,
+                              const unsigned h)
+    : params(p), map(m), height(h), db(d),
       accounts(db), characters(db), groundLoot(db), regions(db)
   {}
 
@@ -232,8 +239,8 @@ protected:
 public:
 
   explicit MoveProcessor (Database& d, DynObstacles& dyo, xaya::Random& r,
-                          const Params& p, const BaseMap& m)
-    : BaseMoveProcessor(d, p, m),
+                          const Params& p, const BaseMap& m, const unsigned h)
+    : BaseMoveProcessor(d, p, m, h),
       dyn(dyo), rnd(r)
   {}
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1126,7 +1126,7 @@ TEST_F (ProspectingMoveTests, Invalid)
   EXPECT_FALSE (r->GetProto ().has_prospection ());
 }
 
-TEST_F (ProspectingMoveTests, RegionAlreadyProspected)
+TEST_F (ProspectingMoveTests, CannotProspectRegion)
 {
   auto r = regions.GetById (region);
   r->MutableProto ().mutable_prospection ()->set_name ("foo");

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -72,6 +72,21 @@ Params::ProspectingBlocks () const
   return 10;
 }
 
+unsigned
+Params::ProspectionExpiryBlocks () const
+{
+  switch (chain)
+    {
+    case xaya::Chain::MAIN:
+    case xaya::Chain::TEST:
+      return 5'000;
+    case xaya::Chain::REGTEST:
+      return 100;
+    default:
+      LOG (FATAL) << "Invalid chain value: " << static_cast<int> (chain);
+    }
+}
+
 int64_t
 Params::CompetitionEndTime () const
 {

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -88,22 +88,6 @@ const std::vector<Params::PrizeData> PRIZES =
     {"gold", 5, 150000},
     {"silver", 50, 4000},
     {"bronze", 2000, 100},
-
-    /* The odds for the extra pizes are chosen so that we expect a 90%
-       probability to find all of them with 150k trials.  This can be computed
-       with the script in contrib/competition/findOdds.m.  */
-    {"shr", 60, 2139},
-    {"spirit clash", 730, 196},
-    {"dio", 50, 2532},
-    {"1up", 20, 5791},
-    {"battle racers", 3, 28184},
-    {"divi", 20, 5791},
-    {"dft", 50, 2532},
-    {"9la necklace", 30, 4033},
-    {"9la miner", 10, 10559},
-    {"9la yellow", 10, 10559},
-    {"9la horned", 10, 10559},
-    {"snails", 20, 5791},
   };
 
 /** Prospecting prizes for regtest (easier to find / exhaust).  */
@@ -111,7 +95,7 @@ const std::vector<Params::PrizeData> PRIZES_REGTEST =
   {
     {"gold", 3, 100},
     {"silver", 1000, 10},
-    {"bronze", 0, 1},
+    {"bronze", 1, 1},
   };
 
 } // anonymous namespace

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -115,6 +115,21 @@ Params::ProspectingPrizes () const
     }
 }
 
+void
+Params::DetectResource (const HexCoord& pos, xaya::Random& rnd,
+                        std::string& type, Inventory::QuantityT& amount) const
+{
+  /* FIXME: This is just some arbitrary logic for now so we can test the
+     general prospecting and mining logic.  We need to replace this with
+     a proper implementation based on how we want to distribute resources.  */
+
+  const std::vector<std::string> types = {"sand", "cryptonite"};
+  const auto ind = rnd.SelectByWeight ({10, 1});
+
+  type = types[ind];
+  amount = 1 + rnd.NextInt (100);
+}
+
 HexCoord
 Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
 {

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -23,9 +23,11 @@
 
 #include "hexagonal/coord.hpp"
 #include "database/faction.hpp"
+#include "database/inventory.hpp"
 #include "proto/character.pb.h"
 
 #include <xayagame/gamelogic.hpp>
+#include <xayautil/random.hpp>
 
 #include <string>
 #include <vector>
@@ -122,6 +124,13 @@ public:
    * demo competition.
    */
   const std::vector<PrizeData>& ProspectingPrizes () const;
+
+  /**
+   * Determines the type and initial amount of resource mine-able that should
+   * be found by prospecting in the given coordinate.
+   */
+  void DetectResource (const HexCoord& pos, xaya::Random& rnd,
+                       std::string& type, Inventory::QuantityT& amount) const;
 
   /**
    * Returns the spawn centre and radius for the given faction.

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -115,6 +115,12 @@ public:
   unsigned ProspectingBlocks () const;
 
   /**
+   * Returns the number of blocks after which a region can be reprospected
+   * (if there are no other factors preventing it).
+   */
+  unsigned ProspectionExpiryBlocks () const;
+
+  /**
    * UNIX timestamp of the end time when prospecting prizes are given out.
    */
   int64_t CompetitionEndTime () const;

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -253,8 +253,10 @@ PendingMoves::AddPendingMove (const Json::Value& mv)
   SQLiteGameDatabase dbObj(rules);
 
   const Params params(GetChain ());
+  const unsigned height = GetConfirmedHeight () + 1;
 
-  PendingStateUpdater updater(dbObj, state, params, rules.GetBaseMap ());
+  PendingStateUpdater updater(dbObj, state,
+                              params, rules.GetBaseMap (), height);
   updater.ProcessMove (mv);
 }
 

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -172,9 +172,15 @@ protected:
 
 public:
 
+  /**
+   * Constructs the updater for the given context.  The block height h should
+   * be the height of the next block, i.e. the current confirmed height plus
+   * one.  It is the height at which we assume the moves will be confirmed.
+   */
   explicit PendingStateUpdater (Database& d, PendingState& s,
-                                const Params& p, const BaseMap& m)
-    : BaseMoveProcessor(d, p, m), state(s)
+                                const Params& p, const BaseMap& m,
+                                const unsigned h)
+    : BaseMoveProcessor(d, p, m, h), state(s)
   {}
 
   /**

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -39,7 +39,8 @@ InitialisePrizes (Database& db, const Params& params)
 }
 
 bool
-CanProspectRegion (const Character& c, const Region& r, const unsigned height)
+CanProspectRegion (const Character& c, const Region& r,
+                   const Params& params, const unsigned height)
 {
   const auto& rpb = r.GetProto ();
 
@@ -53,13 +54,19 @@ CanProspectRegion (const Character& c, const Region& r, const unsigned height)
       return false;
     }
 
-  if (rpb.has_prospection ())
+  if (!rpb.has_prospection ())
+    return true;
+
+  if (height < rpb.prospection ().height () + params.ProspectionExpiryBlocks ())
     {
       LOG (WARNING)
-          << "Region " << r.GetId ()
-          << " is already prospected, can't be prospected by " << c.GetId ();
+          << "It is too early to reprospect region " << r.GetId ()
+          << " by " << c.GetId ();
       return false;
     }
+
+  /* FIXME: Also check for remaining resources and only allow re-prospecting
+     if there are none.  */
 
   return true;
 }

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -41,8 +41,8 @@ InitialisePrizes (Database& db, const Params& params)
 void
 FinishProspecting (Character& c, Database& db, RegionsTable& regions,
                    xaya::Random& rnd,
-                   const int64_t timestamp, const Params& params,
-                   const BaseMap& map)
+                   const unsigned blockHeight, const int64_t timestamp,
+                   const Params& params, const BaseMap& map)
 {
   const auto& pos = c.GetPosition ();
   const auto regionId = map.Regions ().GetRegionId (pos);
@@ -64,6 +64,7 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
   CHECK (!mpb.has_prospection ());
   auto* prosp = mpb.mutable_prospection ();
   prosp->set_name (c.GetOwner ());
+  prosp->set_height (blockHeight);
 
   if (timestamp > params.CompetitionEndTime ())
     {

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -73,7 +73,6 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
     }
 
   /* Check the prizes in order to see if we won any.  */
-  CHECK (!prosp->has_prize ());
   Prizes prizeTable(db);
   for (const auto& p : params.ProspectingPrizes ())
     {
@@ -90,7 +89,7 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
         << " found a prize of tier " << p.name
         << " prospecting region " << regionId;
       prizeTable.IncrementFound (p.name);
-      prosp->set_prize (p.name);
+      c.GetInventory ().AddFungibleCount (p.name + " prize", 1);
       break;
     }
 }

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -66,6 +66,13 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
   prosp->set_name (c.GetOwner ());
   prosp->set_height (blockHeight);
 
+  /* Determine the mine-able resource here.  */
+  std::string type;
+  Inventory::QuantityT amount;
+  params.DetectResource (pos, rnd, type, amount);
+  prosp->set_resource (type);
+  r->SetResourceLeft (amount);
+
   if (timestamp > params.CompetitionEndTime ())
     {
       LOG (INFO) << "Competition is over, no prizes can be found";

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -38,6 +38,32 @@ InitialisePrizes (Database& db, const Params& params)
     }
 }
 
+bool
+CanProspectRegion (const Character& c, const Region& r)
+{
+  const auto& rpb = r.GetProto ();
+
+  if (rpb.has_prospecting_character ())
+    {
+      LOG (WARNING)
+          << "Region " << r.GetId ()
+          << " is already being prospected by character "
+          << rpb.prospecting_character ()
+          << ", can't be prospected by " << c.GetId ();
+      return false;
+    }
+
+  if (rpb.has_prospection ())
+    {
+      LOG (WARNING)
+          << "Region " << r.GetId ()
+          << " is already prospected, can't be prospected by " << c.GetId ();
+      return false;
+    }
+
+  return true;
+}
+
 void
 FinishProspecting (Character& c, Database& db, RegionsTable& regions,
                    xaya::Random& rnd,

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -39,7 +39,7 @@ InitialisePrizes (Database& db, const Params& params)
 }
 
 bool
-CanProspectRegion (const Character& c, const Region& r)
+CanProspectRegion (const Character& c, const Region& r, const unsigned height)
 {
   const auto& rpb = r.GetProto ();
 

--- a/src/prospecting.hpp
+++ b/src/prospecting.hpp
@@ -44,8 +44,8 @@ void InitialisePrizes (Database& db, const Params& params);
  */
 void FinishProspecting (Character& c, Database& db, RegionsTable& regions,
                         xaya::Random& rnd,
-                        int64_t timestamp, const Params& params,
-                        const BaseMap& map);
+                        unsigned blockHeight, int64_t timestamp,
+                        const Params& params, const BaseMap& map);
 
 } // namespace pxd
 

--- a/src/prospecting.hpp
+++ b/src/prospecting.hpp
@@ -41,7 +41,8 @@ void InitialisePrizes (Database& db, const Params& params);
  * Checks if the given region can be prospected by the given character
  * at the moment.
  */
-bool CanProspectRegion (const Character& c, const Region& r, unsigned height);
+bool CanProspectRegion (const Character& c, const Region& r,
+                        const Params& params, unsigned height);
 
 /**
  * Finishes a done prospecting operation by the given character.  If the

--- a/src/prospecting.hpp
+++ b/src/prospecting.hpp
@@ -38,6 +38,12 @@ namespace pxd
 void InitialisePrizes (Database& db, const Params& params);
 
 /**
+ * Checks if the given region can be prospected by the given character
+ * at the moment.
+ */
+bool CanProspectRegion (const Character& c, const Region& r);
+
+/**
  * Finishes a done prospecting operation by the given character.  If the
  * competition is still active (not yet past the end time), then also
  * prizes can be won.

--- a/src/prospecting.hpp
+++ b/src/prospecting.hpp
@@ -41,7 +41,7 @@ void InitialisePrizes (Database& db, const Params& params);
  * Checks if the given region can be prospected by the given character
  * at the moment.
  */
-bool CanProspectRegion (const Character& c, const Region& r);
+bool CanProspectRegion (const Character& c, const Region& r, unsigned height);
 
 /**
  * Finishes a done prospecting operation by the given character.  If the

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -28,6 +28,7 @@
 #include <gtest/gtest.h>
 
 #include <set>
+#include <map>
 
 namespace pxd
 {
@@ -117,6 +118,35 @@ TEST_F (ProspectingTests, Basic)
   EXPECT_FALSE (r->GetProto ().has_prospecting_character ());
   EXPECT_EQ (r->GetProto ().prospection ().name (), "domob");
   EXPECT_EQ (r->GetProto ().prospection ().height (), 10);
+}
+
+TEST_F (ProspectingTests, Resources)
+{
+  std::map<std::string, unsigned> regionsForResource =
+    {
+      {"sand", 0},
+      {"cryptonite", 0},
+    };
+
+  for (unsigned i = 0; i < 100; ++i)
+    {
+      const HexCoord pos(0, 20 * i);
+      auto c = characters.CreateNew ("domob", Faction::RED);
+      const auto id = Prospect (std::move (c), pos, 10, TIME_IN_COMPETITION);
+
+      auto r = regions.GetById (id);
+      EXPECT_GT (r->GetResourceLeft (), 0);
+      ++regionsForResource[r->GetProto ().prospection ().resource ()];
+    }
+
+  for (const auto& entry : regionsForResource)
+    LOG (INFO)
+        << "Found resource " << entry.first
+        << " in " << entry.second << " regions";
+
+  ASSERT_EQ (regionsForResource.size (), 2);
+  EXPECT_GT (regionsForResource["sand"], regionsForResource["cryptonite"]);
+  EXPECT_GT (regionsForResource["cryptonite"], 0);
 }
 
 TEST_F (ProspectingTests, Prizes)

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -156,12 +156,12 @@ TEST_F (ProspectingTests, Prizes)
     }
 
   /* We should have found all gold prizes (since there are only a few),
-     no bronze ones (since there are none) and roughly the expected number
+     the one bronze prize and roughly the expected number
      of silver prizes by probability.  */
   EXPECT_EQ (foundMap["gold"], 3);
   EXPECT_GE (foundMap["silver"], 50);
   EXPECT_LE (foundMap["silver"], 150);
-  EXPECT_EQ (foundMap["bronze"], 0);
+  EXPECT_EQ (foundMap["bronze"], 1);
 }
 
 TEST_F (ProspectingTests, NoPrizesAfterEnd)

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -140,13 +140,25 @@ TEST_F (ProspectingTests, Prizes)
     }
 
   ASSERT_EQ (regionIds.size (), trials);
-  std::map<std::string, unsigned> foundMap;
   for (const auto id : regionIds)
     {
       auto r = regions.GetById (id);
       ASSERT_TRUE (r->GetProto ().has_prospection ());
-      if (r->GetProto ().prospection ().has_prize ())
-        ++foundMap[r->GetProto ().prospection ().prize ()];
+    }
+
+  std::map<std::string, unsigned> foundMap;
+  auto res = characters.QueryAll ();
+  while (res.Step ())
+    {
+      auto c = characters.GetFromResult (res);
+      for (const auto& item : c->GetInventory ().GetFungible ())
+        {
+          constexpr const char* suffix = " prize";
+          const auto ind = item.first.find (suffix);
+          if (ind == std::string::npos)
+            continue;
+          foundMap[item.first.substr (0, ind)] += item.second;
+        }
     }
 
   Prizes prizeTable(db);

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -86,7 +86,7 @@ protected:
    */
   RegionMap::IdT
   Prospect (CharacterTable::Handle c, const HexCoord& pos,
-            const int64_t timestamp)
+            const unsigned height, const int64_t timestamp)
   {
     const auto id = c->GetId ();
     c->SetPosition (pos);
@@ -98,7 +98,7 @@ protected:
     regions.GetById (region)->MutableProto ().set_prospecting_character (id);
 
     FinishProspecting (*characters.GetById (id), db, regions, rnd,
-                       timestamp, params, map);
+                       height, timestamp, params, map);
     return region;
   }
 
@@ -107,7 +107,7 @@ protected:
 TEST_F (ProspectingTests, Basic)
 {
   const auto region = Prospect (GetTest (), HexCoord (10, -20),
-                                TIME_IN_COMPETITION);
+                                10, TIME_IN_COMPETITION);
 
   auto c = GetTest ();
   EXPECT_EQ (c->GetBusy (), 0);
@@ -116,6 +116,7 @@ TEST_F (ProspectingTests, Basic)
   auto r = regions.GetById (region);
   EXPECT_FALSE (r->GetProto ().has_prospecting_character ());
   EXPECT_EQ (r->GetProto ().prospection ().name (), "domob");
+  EXPECT_EQ (r->GetProto ().prospection ().height (), 10);
 }
 
 TEST_F (ProspectingTests, Prizes)
@@ -132,7 +133,7 @@ TEST_F (ProspectingTests, Prizes)
           const HexCoord pos(x, 20 * j);
           auto c = characters.CreateNew ("domob", Faction::RED);
           const auto region = Prospect (std::move (c), pos,
-                                        TIME_IN_COMPETITION);
+                                        10, TIME_IN_COMPETITION);
           const auto res = regionIds.insert (region);
           ASSERT_TRUE (res.second);
         }
@@ -176,7 +177,7 @@ TEST_F (ProspectingTests, NoPrizesAfterEnd)
         {
           const HexCoord pos(x, 20 * j);
           auto c = characters.CreateNew ("domob", Faction::RED);
-          Prospect (std::move (c), pos, TIME_AFTER_COMPETITION);
+          Prospect (std::move (c), pos, 10, TIME_AFTER_COMPETITION);
         }
     }
 

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -68,7 +68,7 @@ TEST_F (CanProspectRegionTests, ProspectionInProgress)
   auto r = regions.GetById (region);
   r->MutableProto ().set_prospecting_character (10);
 
-  EXPECT_FALSE (CanProspectRegion (*c, *r));
+  EXPECT_FALSE (CanProspectRegion (*c, *r, 10));
 }
 
 TEST_F (CanProspectRegionTests, AlreadyProspected)
@@ -77,7 +77,7 @@ TEST_F (CanProspectRegionTests, AlreadyProspected)
   auto r = regions.GetById (region);
   r->MutableProto ().mutable_prospection ()->set_name ("foo");
 
-  EXPECT_FALSE (CanProspectRegion (*c, *r));
+  EXPECT_FALSE (CanProspectRegion (*c, *r, 10));
 }
 
 TEST_F (CanProspectRegionTests, EmptyRegion)
@@ -85,7 +85,7 @@ TEST_F (CanProspectRegionTests, EmptyRegion)
   auto c = characters.CreateNew ("domob", Faction::RED);
   auto r = regions.GetById (region);
 
-  EXPECT_TRUE (CanProspectRegion (*c, *r));
+  EXPECT_TRUE (CanProspectRegion (*c, *r, 10));
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
This is a general overhaul of the prospecting logic for the upcoming second competition, according to #50:

- Prizes are given out as items to the prospecting character's inventory instead of just being stored in the region state.
- In addition to prizes, we also randomly determine and assign mine-able resources for the prospected region.
- Prospecting stores the block height in the region data.
- After a certain amount of time (100 blocks on regtest, 5,000 on mainnet/testnet), a prospected region can be prospected again for another chance of prizes and different resources.