### PR TITLE
Implement basic mining logic

### DIFF
--- a/database/character.cpp
+++ b/database/character.cpp
@@ -170,6 +170,9 @@ Character::Validate () const
 
   CHECK_LE (UsedCargoSpace (), pb.cargo_space ());
 
+  CHECK (!pb.mining ().active () || !pb.has_movement ())
+      << "Character " << id << " is moving and mining at the same time";
+
 #endif // ENABLE_SLOW_ASSERTS
 }
 

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -83,7 +83,7 @@ Character::~Character ()
            `volatilemv`, `hp`,
            `busy`,
            `faction`,
-           `ismoving`, `attackrange`, `canregen`, `hastarget`,
+           `ismoving`, `ismining`, `attackrange`, `canregen`, `hastarget`,
            `regendata`, `inventory`, `proto`)
           VALUES
           (?1,
@@ -91,19 +91,20 @@ Character::~Character ()
            ?5, ?6,
            ?7,
            ?101,
-           ?102, ?103, ?104, ?105,
-           ?106, ?107, ?108)
+           ?102, ?103, ?104, ?105, ?106,
+           ?107, ?108, ?109)
       )");
 
       BindFieldValues (stmt);
       BindFactionParameter (stmt, 101, faction);
       stmt.Bind (102, data.Get ().has_movement ());
-      stmt.Bind (103, FindAttackRange (data.Get ().combat_data ()));
-      stmt.Bind (104, canRegen);
-      stmt.Bind (105, data.Get ().has_target ());
-      stmt.BindProto (106, regenData);
-      stmt.BindProto (107, inv.GetProtoForBinding ());
-      stmt.BindProto (108, data);
+      stmt.Bind (103, data.Get ().mining ().active ());
+      stmt.Bind (104, FindAttackRange (data.Get ().combat_data ()));
+      stmt.Bind (105, canRegen);
+      stmt.Bind (106, data.Get ().has_target ());
+      stmt.BindProto (107, regenData);
+      stmt.BindProto (108, inv.GetProtoForBinding ());
+      stmt.BindProto (109, data);
       stmt.Execute ();
 
       return;
@@ -279,6 +280,15 @@ CharacterTable::QueryMoving ()
 {
   auto stmt = db.Prepare (R"(
     SELECT * FROM `characters` WHERE `ismoving` ORDER BY `id`
+  )");
+  return stmt.Query<CharacterResult> ();
+}
+
+Database::Result<CharacterResult>
+CharacterTable::QueryMining ()
+{
+  auto stmt = db.Prepare (R"(
+    SELECT * FROM `characters` WHERE `ismining` ORDER BY `id`
   )");
   return stmt.Query<CharacterResult> ();
 }

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -387,6 +387,11 @@ public:
   Database::Result<CharacterResult> QueryMoving ();
 
   /**
+   * Queries for all characters that are currently mining.
+   */
+  Database::Result<CharacterResult> QueryMining ();
+
+  /**
    * Queries for all characters with attacks.
    */
   Database::Result<CharacterResult> QueryWithAttacks ();

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -285,6 +285,19 @@ TEST_F (CharacterTableTests, QueryMoving)
   ASSERT_FALSE (res.Step ());
 }
 
+TEST_F (CharacterTableTests, QueryMining)
+{
+  tbl.CreateNew ("domob", Faction::RED)
+    ->MutableProto ().mutable_mining ()->set_rate (10);
+  tbl.CreateNew ("andy", Faction::RED)
+    ->MutableProto ().mutable_mining ()->set_active (true);
+
+  auto res = tbl.QueryMining ();
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "andy");
+  ASSERT_FALSE (res.Step ());
+}
+
 TEST_F (CharacterTableTests, QueryWithAttacks)
 {
   tbl.CreateNew ("domob", Faction::RED);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -64,6 +64,11 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- moving when we do move updates.
   `ismoving` INTEGER NOT NULL,
 
+  -- Flag indicating if the character is currently mining.  This is set
+  -- based on the protocol buffer, but also has an index so that we can
+  -- efficiently retrieve only characters that are mining.
+  `ismining` INTEGER NOT NULL,
+
   -- The range of the longest attack this character has or NULL if there
   -- is no attack at all.  This is used to speed up target finding without
   -- the need to look through the character's attacks (and parse the
@@ -93,6 +98,7 @@ CREATE INDEX IF NOT EXISTS `characters_owner` ON `characters` (`owner`);
 CREATE INDEX IF NOT EXISTS `characters_pos` ON `characters` (`x`, `y`);
 CREATE INDEX IF NOT EXISTS `characters_busy` ON `characters` (`busy`);
 CREATE INDEX IF NOT EXISTS `characters_ismoving` ON `characters` (`ismoving`);
+CREATE INDEX IF NOT EXISTS `characters_ismining` ON `characters` (`ismining`);
 CREATE INDEX IF NOT EXISTS `characters_attackrange`
   ON `characters` (`attackrange`);
 CREATE INDEX IF NOT EXISTS `characters_canregen` ON `characters` (`canregen`);

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -12,6 +12,7 @@ REGTESTS = \
   getregionat.py \
   godmode.py \
   loot.py \
+  mining.py \
   movement.py \
   multiupdate.py \
   nullstate.py \

--- a/gametest/mining.py
+++ b/gametest/mining.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests mining of resources by characters.
+"""
+
+from pxtest import PXTest, offsetCoord
+
+
+class MiningTest (PXTest):
+
+  def isMining (self, charName):
+    return self.getCharacters ()[charName].data["mining"]["active"]
+
+  def run (self):
+    self.collectPremine ()
+
+    self.pos = [{"x": 10, "y": 100}]
+    self.pos.append (offsetCoord (self.pos[0], {"x": 1, "y": 0}, False))
+    self.assertEqual (self.getRegionAt (self.pos[0]).getId (),
+                      self.getRegionAt (self.pos[1]).getId ())
+
+    self.mainLogger.info ("Prospecting a test region...")
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob", 2)
+    self.generate (1)
+    self.moveCharactersTo ({
+      "domob": self.pos[0],
+      "domob 2": self.pos[1],
+    })
+    self.getCharacters ()["domob"].sendMove ({"prospect": {}})
+    self.generate (15)
+
+    typ, self.amount = self.getRegionAt (self.pos[0]).getResource ()
+    self.log.info ("Found %d of %s at the region" % (self.amount, typ))
+    self.reorgBlock = self.rpc.xaya.getbestblockhash ()
+
+    self.mainLogger.info ("Starting to mine...")
+    self.getCharacters ()["domob"].sendMove ({"mine": {}})
+    self.generate (1)
+    self.assertEqual (self.isMining ("domob"), True)
+    self.assertEqual (self.isMining ("domob 2"), False)
+
+    self.mainLogger.info ("Movement stops mining...")
+    self.getCharacters ()["domob"].sendMove ({"wp": []})
+    self.generate (1)
+    self.assertEqual (self.isMining ("domob"), False)
+    self.assertEqual (self.isMining ("domob 2"), False)
+
+    self.mainLogger.info ("Mining with two characters...")
+    for c in self.getCharacters ().values ():
+      c.sendMove ({"mine": {}})
+    self.generate (1)
+    self.assertEqual (self.isMining ("domob"), True)
+    self.assertEqual (self.isMining ("domob 2"), True)
+
+    self.mainLogger.info ("Using up all resources...")
+    while True:
+      _, remaining = self.getRegionAt (self.pos[0]).getResource ()
+      if remaining == 0:
+        break
+      for c in self.getCharacters ().values ():
+        c.sendMove ({
+          "drop": {"f": {typ: 1000}},
+          "mine": {},
+        })
+      self.generate (50)
+    for c in self.getCharacters ().values ():
+      c.sendMove ({
+        "drop": {"f": {typ: 1000}},
+      })
+    self.generate (1)
+    self.assertEqual (self.isMining ("domob"), False)
+    self.assertEqual (self.isMining ("domob 2"), False)
+
+    total = 0
+    for loot in self.getRpc ("getgroundloot"):
+      inv = loot["inventory"]["fungible"]
+      self.assertEqual (len (inv), 1)
+      total += inv[typ]
+    self.assertEqual (total, self.amount)
+
+    self.testReorg ()
+
+  def testReorg (self):
+    self.mainLogger.info ("Testing a reorg...")
+    oldState = self.getGameState ()
+
+    self.rpc.xaya.invalidateblock (self.reorgBlock)
+    self.generate (20)
+
+    self.assertEqual (self.isMining ("domob"), False)
+    self.assertEqual (self.isMining ("domob 2"), False)
+    for c in self.getCharacters ().values ():
+      self.assertEqual (c.getFungibleInventory (), {})
+
+    _, remaining = self.getRegionAt (self.pos[0]).getResource ()
+    self.assertEqual (remaining, self.amount)
+
+    self.rpc.xaya.reconsiderblock (self.reorgBlock)
+    self.expectGameState (oldState)
+
+
+if __name__ == "__main__":
+  MiningTest ().main ()

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -39,6 +39,20 @@ message OngoingProspection
 }
 
 /**
+ * Data about the mining state of a character.
+ */
+message MiningData
+{
+
+  /** The mining speed, in units per block.  */
+  optional uint64 rate = 1;
+
+  /** Set to true if the character is currently mining.  */
+  optional bool active = 2;
+
+}
+
+/**
  * The state of one character in the game.  Note that this does not include
  * data fields that are stored directly in database columns, namely those on
  * which the database keeps indices.
@@ -75,11 +89,14 @@ message Character
     OngoingProspection prospection = 4;
   }
 
+  /** The character's mining data, if it can mine.  */
+  optional MiningData mining = 5;
+
   /** Movement speed of the character.  */
-  optional uint32 speed = 5;
+  optional uint32 speed = 6;
 
   /** Total cargo space the character has.  */
-  optional uint64 cargo_space = 6;
+  optional uint64 cargo_space = 7;
 
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:
@@ -92,6 +109,7 @@ message Character
      - current HP proto
      - HP regeneration data proto
      - number of blocks the character is still "busy"
+     - inventory proto
   */
 
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,7 @@ libtaurion_la_SOURCES = \
   gamestatejson.cpp \
   jsonutils.cpp \
   logic.cpp \
+  mining.cpp \
   movement.cpp \
   moveprocessor.cpp \
   params.cpp \
@@ -40,6 +41,7 @@ libtaurionheaders = \
   gamestatejson.hpp \
   jsonutils.hpp \
   logic.hpp \
+  mining.hpp \
   movement.hpp \
   moveprocessor.hpp \
   params.hpp \
@@ -105,6 +107,7 @@ tests_SOURCES = \
   gamestatejson_tests.cpp \
   jsonutils_tests.cpp \
   logic_tests.cpp \
+  mining_tests.cpp \
   movement_tests.cpp \
   moveprocessor_tests.cpp \
   pending_tests.cpp \

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -44,7 +44,7 @@ private:
   const BaseMap& map;
 
   /** The chain we are on.  */
-  const xaya::Chain chain;
+  xaya::Chain chain;
 
   /**
    * Basic parameters dependant on the chain.  This is a pointer so that we

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -221,6 +221,25 @@ GetCargoSpaceJsonObject (const Character& c)
   return res;
 }
 
+/**
+ * Constructs the JSON representation of the mining data of a character.
+ */
+Json::Value
+GetMiningJsonObject (const BaseMap& map, const Character& c)
+{
+  if (!c.GetProto ().has_mining ())
+    return Json::Value ();
+  const auto& pb = c.GetProto ().mining ();
+
+  Json::Value res(Json::objectValue);
+  res["rate"] = IntToJson (pb.rate ());
+  res["active"] = pb.active ();
+  if (pb.active ())
+    res["region"] = IntToJson (map.Regions ().GetRegionId (c.GetPosition ()));
+
+  return res;
+}
+
 } // anonymous namespace
 
 template <>
@@ -258,6 +277,10 @@ template <>
   const Json::Value busy = GetBusyJsonObject (map, c);
   if (!busy.isNull ())
     res["busy"] = busy;
+
+  const Json::Value mining = GetMiningJsonObject (map, c);
+  if (!mining.isNull ())
+    res["mining"] = mining;
 
   return res;
 }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -384,6 +384,52 @@ TEST_F (CharacterJsonTests, CargoSpace)
   })");
 }
 
+TEST_F (CharacterJsonTests, Mining)
+{
+  const HexCoord pos(10, -5);
+  ASSERT_EQ (map.Regions ().GetRegionId (pos), 350146);
+
+  tbl.CreateNew ("without mining", Faction::RED);
+
+  auto h = tbl.CreateNew ("inactive mining", Faction::RED);
+  h->MutableProto ().mutable_mining ()->set_rate (12);
+  h.reset ();
+
+  h = tbl.CreateNew ("active mining", Faction::RED);
+  h->SetPosition (pos);
+  h->MutableProto ().mutable_mining ()->set_rate (1);
+  h->MutableProto ().mutable_mining ()->set_active (true);
+  h.reset ();
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "owner": "without mining",
+          "mining": null
+        },
+        {
+          "owner": "inactive mining",
+          "mining":
+            {
+              "rate": 12,
+              "active": false,
+              "region": null
+            }
+        },
+        {
+          "owner": "active mining",
+          "mining":
+            {
+              "rate": 1,
+              "active": true,
+              "region": 350146
+            }
+        }
+      ]
+  })");
+}
+
 TEST_F (CharacterJsonTests, DamageLists)
 {
   const auto id1 = tbl.CreateNew ("domob", Faction::RED)->GetId ();

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -20,6 +20,7 @@
 
 #include "combat.hpp"
 #include "dynobstacles.hpp"
+#include "mining.hpp"
 #include "movement.hpp"
 #include "moveprocessor.hpp"
 #include "prospecting.hpp"
@@ -115,7 +116,9 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
   mvProc.ProcessAdmin (blockData["admin"]);
   mvProc.ProcessAll (blockData["moves"]);
 
+  ProcessAllMining (db, ctx);
   ProcessAllMovement (db, dyn, ctx);
+
   FindCombatTargets (db, rnd);
 
 #ifdef ENABLE_SLOW_ASSERTS

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -1,0 +1,120 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "mining.hpp"
+
+#include "database/character.hpp"
+#include "database/inventory.hpp"
+#include "database/region.hpp"
+#include "proto/roconfig.hpp"
+
+namespace pxd
+{
+
+void
+ProcessAllMining (Database& db, const Context& ctx)
+{
+  CharacterTable characters(db);
+  RegionsTable regions(db);
+
+  const auto& itemData = RoConfigData ().fungible_items ();
+
+  auto res = characters.QueryMining ();
+  while (res.Step ())
+    {
+      auto c = characters.GetFromResult (res);
+      const auto pos = c->GetPosition ();
+      const auto regionId = ctx.Map ().Regions ().GetRegionId (pos);
+      VLOG (1)
+          << "Processing mining of character " << c->GetId ()
+          << " in region " << regionId << "...";
+      auto r = regions.GetById (regionId);
+
+      const auto& pb = c->GetProto ();
+      CHECK (pb.has_mining ());
+
+      /* It can happen that the region has (no longer) an active prospection
+         entry.  For instance, if all resources were used up in the previous
+         block and it is being re-prospected right away, then the previous
+         prospection is cleared already when we process mining.  Thus, we need
+         to handle this situation gracefully, and just stop mining.  */
+      if (!r->GetProto ().has_prospection ())
+        {
+          LOG (WARNING)
+              << "Region " << regionId
+              << " is being mined by character " << c->GetId ()
+              << " but is not prospected; stopping the mining operation";
+          c->MutableProto ().mutable_mining ()->clear_active ();
+          continue;
+        }
+
+      const auto& type = r->GetProto ().prospection ().resource ();
+      Inventory::QuantityT mined = pb.mining ().rate ();
+      CHECK_GT (mined, 0);
+      VLOG (1) << "Trying to mine " << mined << " of " << type;
+
+      /* Restrict the quantity by what is left in the region.  */
+      Inventory::QuantityT left = r->GetResourceLeft ();
+      CHECK_GE (left, 0);
+      if (mined > left)
+        {
+          VLOG (1) << "Only " << left << " is left for mining";
+          mined = left;
+        }
+
+      /* Restrict the quantity by cargo space.  */
+      const int64_t freeCargo = pb.cargo_space () - c->UsedCargoSpace ();
+      CHECK_GE (freeCargo, 0);
+
+      const auto mitItem = itemData.find (type);
+      CHECK (mitItem != itemData.end ())
+          << "Unknown resource type to be mined: " << type;
+      CHECK_GT (mitItem->second.space (), 0)
+          << "Minable resource " << type << " has zero space";
+
+      const auto maxForSpace = freeCargo / mitItem->second.space ();
+      if (mined > maxForSpace)
+        {
+          VLOG (1)
+              << "Character " << c->GetId ()
+              << " has only cargo space " << freeCargo
+              << " left, which allows for " << maxForSpace << " of " << type;
+          mined = maxForSpace;
+        }
+
+      /* Apply the updates.  */
+      if (mined > 0)
+        {
+          left -= mined;
+          r->SetResourceLeft (left);
+          c->GetInventory ().AddFungibleCount (type, mined);
+          VLOG (1)
+              << "Mined " << mined << " of " << type
+              << " with character " << c->GetId ();
+        }
+      else
+        {
+          VLOG (1)
+              << "Character " << c->GetId ()
+              << " cannot mine any more currently, stopping the operation";
+          c->MutableProto ().mutable_mining ()->clear_active ();
+        }
+    }
+}
+
+} // namespace pxd

--- a/src/mining.hpp
+++ b/src/mining.hpp
@@ -1,0 +1,36 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_MINING_HPP
+#define PXD_MINING_HPP
+
+#include "context.hpp"
+
+#include "database/database.hpp"
+
+namespace pxd
+{
+
+/**
+ * Processes all mining of characters in the current turn.
+ */
+void ProcessAllMining (Database& db, const Context& ctx);
+
+} // namespace pxd
+
+#endif // PXD_MINING_HPP

--- a/src/mining_tests.cpp
+++ b/src/mining_tests.cpp
@@ -1,0 +1,182 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "mining.hpp"
+
+#include "testutils.hpp"
+
+#include "database/character.hpp"
+#include "database/dbtest.hpp"
+#include "database/region.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+class MiningTests : public DBTestWithSchema
+{
+
+protected:
+
+  CharacterTable characters;
+  RegionsTable regions;
+
+  ContextForTesting ctx;
+
+  const HexCoord pos;
+  const RegionMap::IdT region;
+
+  MiningTests ()
+    : characters(db), regions(db),
+      pos(-10, 42), region(ctx.Map ().Regions ().GetRegionId (pos))
+  {
+    auto c = GetTest ();
+    c->SetPosition (pos);
+    c->MutableProto ().mutable_mining ()->set_rate (10);
+    c->MutableProto ().mutable_mining ()->set_active (true);
+    c->MutableProto ().set_cargo_space (1000);
+    c.reset ();
+
+    auto r = GetRegion ();
+    r->MutableProto ().mutable_prospection ()->set_resource ("foo");
+    r->SetResourceLeft (100);
+    r.reset ();
+  }
+
+  /**
+   * Returns a test character (with ID 1).
+   */
+  CharacterTable::Handle
+  GetTest ()
+  {
+    auto c = characters.GetById (1);
+    if (c != nullptr)
+      return c;
+
+    c = characters.CreateNew ("domob", Faction::RED);
+    CHECK_EQ (c->GetId (), 1);
+    return c;
+  }
+
+  /**
+   * Returns a handle to our test region.
+   */
+  RegionsTable::Handle
+  GetRegion ()
+  {
+    return regions.GetById (region);
+  }
+
+};
+
+TEST_F (MiningTests, Basic)
+{
+  ProcessAllMining (db, ctx);
+  EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
+  EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 10);
+  EXPECT_EQ (GetRegion ()->GetResourceLeft (), 90);
+}
+
+TEST_F (MiningTests, NoMiningData)
+{
+  GetTest ()->MutableProto ().clear_mining ();
+  ProcessAllMining (db, ctx);
+  EXPECT_TRUE (GetTest ()->GetInventory ().IsEmpty ());
+  EXPECT_EQ (GetRegion ()->GetResourceLeft (), 100);
+}
+
+TEST_F (MiningTests, MiningNotActive)
+{
+  GetTest ()->MutableProto ().mutable_mining ()->set_active (false);
+  ProcessAllMining (db, ctx);
+  EXPECT_TRUE (GetTest ()->GetInventory ().IsEmpty ());
+  EXPECT_EQ (GetRegion ()->GetResourceLeft (), 100);
+}
+
+TEST_F (MiningTests, RegionNotProspected)
+{
+  GetRegion ()->MutableProto ().clear_prospection ();
+  ProcessAllMining (db, ctx);
+  EXPECT_FALSE (GetTest ()->GetProto ().mining ().active ());
+  EXPECT_TRUE (GetTest ()->GetInventory ().IsEmpty ());
+}
+
+TEST_F (MiningTests, ResourceUsedUp)
+{
+  GetRegion ()->SetResourceLeft (5);
+
+  ProcessAllMining (db, ctx);
+  EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
+  EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 5);
+  EXPECT_EQ (GetRegion ()->GetResourceLeft (), 0);
+
+  ProcessAllMining (db, ctx);
+  EXPECT_FALSE (GetTest ()->GetProto ().mining ().active ());
+  EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 5);
+  EXPECT_EQ (GetRegion ()->GetResourceLeft (), 0);
+}
+
+TEST_F (MiningTests, CargoFull)
+{
+  GetTest ()->GetInventory ().SetFungibleCount ("foo", 95);
+
+  ProcessAllMining (db, ctx);
+  EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
+  EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 100);
+  EXPECT_EQ (GetRegion ()->GetResourceLeft (), 95);
+
+  ProcessAllMining (db, ctx);
+  EXPECT_FALSE (GetTest ()->GetProto ().mining ().active ());
+  EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 100);
+  EXPECT_EQ (GetRegion ()->GetResourceLeft (), 95);
+}
+
+TEST_F (MiningTests, MultipleMiners)
+{
+  GetRegion ()->SetResourceLeft (25);
+
+  auto c = characters.CreateNew ("andy", Faction::BLUE);
+  ASSERT_EQ (c->GetId (), 2);
+  c->SetPosition (pos);
+  c->MutableProto ().mutable_mining ()->set_rate (10);
+  c->MutableProto ().mutable_mining ()->set_active (true);
+  c->MutableProto ().set_cargo_space (1000);
+  c.reset ();
+
+  /* In the first turn, both miners will be able to mine at their rate.  In the
+     second, the resource will get used up and only the first one will get
+     something (but not at full rate).  */
+  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, ctx);
+
+  EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
+  EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 15);
+
+  c = characters.GetById (2);
+  EXPECT_FALSE (c->GetProto ().mining ().active ());
+  EXPECT_EQ (c->GetInventory ().GetFungibleCount ("foo"), 10);
+  c.reset ();
+
+  EXPECT_EQ (GetRegion ()->GetResourceLeft (), 0);
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -200,6 +200,11 @@ private:
   void MaybeStartProspecting (Character& c, const Json::Value& upd);
 
   /**
+   * Processes a command to start mining at the current location.
+   */
+  void MaybeStartMining (Character& c, const Json::Value& upd);
+
+  /**
    * Processes a command to drop loot from the character's inventory
    * onto the ground.
    */

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -172,6 +172,8 @@ Params::InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const
   pb.set_speed (3000);
   pb.set_cargo_space (1000);
 
+  pb.mutable_mining ()->set_rate (1);
+
   auto* cd = pb.mutable_combat_data ();
   auto* attack = cd->add_attacks ();
   attack->set_range (10);

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -60,8 +60,11 @@ CanProspectRegion (const Character& c, const Region& r, const Context& ctx)
                         + ctx.Params ().ProspectionExpiryBlocks ())
     {
       LOG (WARNING)
-          << "It is too early to reprospect region " << r.GetId ()
-          << " by " << c.GetId ();
+          << "Height " << ctx.Height ()
+          << " is too early to reprospect region " << r.GetId ()
+          << " by " << c.GetId ()
+          << "; the region was prospected last at height "
+          << rpb.prospection ().height ();
       return false;
     }
 

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -36,7 +36,8 @@ void
 ContextForTesting::SetChain (const xaya::Chain c)
 {
   LOG (INFO) << "Setting context chain to " << xaya::ChainToString (c);
-  params = std::make_unique<pxd::Params> (c);
+  chain = c;
+  params = std::make_unique<pxd::Params> (chain);
 }
 
 void


### PR DESCRIPTION
This implements mining as described in #55.  To start mining at the current position, a user can send a move like this:

    {"c": {"42": {"mine": {}}}}

Mining is then stopped either if waypoints are set, the cargo gets full or the resources on the region are used up.  A new field `mining` in the character state JSON also gives information about whether the character is mining at the moment and what their mining rate (units per block) is.