### PR TITLE
Randomise mining rate, update resources

### DIFF
--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -288,7 +288,7 @@ TEST_F (CharacterTableTests, QueryMoving)
 TEST_F (CharacterTableTests, QueryMining)
 {
   tbl.CreateNew ("domob", Faction::RED)
-    ->MutableProto ().mutable_mining ()->set_rate (10);
+    ->MutableProto ().mutable_mining ()->mutable_rate ();
   tbl.CreateNew ("andy", Faction::RED)
     ->MutableProto ().mutable_mining ()->set_active (true);
 

--- a/gametest/loot.py
+++ b/gametest/loot.py
@@ -30,22 +30,22 @@ class LootTest (PXTest):
     self.collectPremine ()
 
     self.mainLogger.info ("Dropping loot in god mode...")
-    self.dropLoot ({"x": 1, "y": 2}, {"foo": 5, "bar": 10})
-    self.dropLoot ({"x": 1, "y": 2}, {"foo": 5})
-    self.dropLoot ({"x": -1, "y": 20}, {"foo": 5})
+    self.dropLoot ({"x": 1, "y": 2}, {"zerospace": 5, "bar": 10})
+    self.dropLoot ({"x": 1, "y": 2}, {"zerospace": 5})
+    self.dropLoot ({"x": -1, "y": 20}, {"zerospace": 5})
     self.assertEqual (self.getRpc ("getgroundloot"), [
       {
         "position": {"x": -1, "y": 20},
         "inventory":
           {
-            "fungible": {"foo": 5},
+            "fungible": {"zerospace": 5},
           },
       },
       {
         "position": {"x": 1, "y": 2},
         "inventory":
           {
-            "fungible": {"bar": 10, "foo": 10},
+            "fungible": {"bar": 10, "zerospace": 10},
           },
       },
     ])
@@ -56,17 +56,17 @@ class LootTest (PXTest):
     self.generate (1)
     self.moveCharactersTo ({"red": {"x": 1, "y": 2}})
     self.generate (1)
-    self.getCharacters ()["red"].sendMove ({"pu": {"f": {"foo": 1000}}})
+    self.getCharacters ()["red"].sendMove ({"pu": {"f": {"zerospace": 1000}}})
     self.generate (1)
     self.assertEqual (self.getCharacters ()["red"].getFungibleInventory (), {
-      "foo": 10,
+      "zerospace": 10,
     })
     self.assertEqual (self.getRpc ("getgroundloot"), [
       {
         "position": {"x": -1, "y": 20},
         "inventory":
           {
-            "fungible": {"foo": 5},
+            "fungible": {"zerospace": 5},
           },
       },
       {
@@ -80,17 +80,17 @@ class LootTest (PXTest):
 
     self.mainLogger.info ("Dropping loot with a character...")
     self.moveCharactersTo ({"red": {"x": -1, "y": 20}})
-    self.getCharacters ()["red"].sendMove ({"drop": {"f": {"foo": 1}}})
+    self.getCharacters ()["red"].sendMove ({"drop": {"f": {"zerospace": 1}}})
     self.generate (1)
     self.assertEqual (self.getCharacters ()["red"].getFungibleInventory (), {
-      "foo": 9,
+      "zerospace": 9,
     })
     self.assertEqual (self.getRpc ("getgroundloot"), [
       {
         "position": {"x": -1, "y": 20},
         "inventory":
           {
-            "fungible": {"foo": 6},
+            "fungible": {"zerospace": 6},
           },
       },
       {
@@ -104,26 +104,22 @@ class LootTest (PXTest):
 
     self.mainLogger.info ("Cargo limit for picking loot up...")
     self.initAccount ("cargo", "r")
-    self.dropLoot ({"x": 0, "y": 0}, {"foo": 95})
+    self.dropLoot ({"x": 0, "y": 0}, {"foo": 10})
     self.createCharacters ("cargo", 1)
     self.generate (1)
     self.moveCharactersTo ({"cargo": {"x": 0, "y": 0}})
     self.getCharacters ()["cargo"].sendMove ({"pu": {"f": {"foo": 100}}})
     self.generate (1)
-    self.moveCharactersTo ({"cargo": {"x": 1, "y": 2}})
-    self.getCharacters ()["cargo"].sendMove ({"pu": {"f": {"bar": 100}}})
-    self.generate (1)
     c = self.getCharacters ()["cargo"]
     self.assertEqual (c.getFungibleInventory (), {
-      "foo": 95,
-      "bar": 2,
+      "foo": 2,
     })
     c.expectPartial ({
       "cargospace":
         {
-          "total": 1000,
-          "used": 990,
-          "free": 10,
+          "total": 20,
+          "used": 20,
+          "free": 0,
         },
     })
     self.assertEqual (self.getRpc ("getgroundloot"), [
@@ -131,14 +127,21 @@ class LootTest (PXTest):
         "position": {"x": -1, "y": 20},
         "inventory":
           {
-            "fungible": {"foo": 6},
+            "fungible": {"zerospace": 6},
+          },
+      },
+      {
+        "position": {"x": 0, "y": 0},
+        "inventory":
+          {
+            "fungible": {"foo": 8},
           },
       },
       {
         "position": {"x": 1, "y": 2},
         "inventory":
           {
-            "fungible": {"bar": 8},
+            "fungible": {"bar": 10},
           },
       },
     ])
@@ -155,35 +158,42 @@ class LootTest (PXTest):
       "red": {"a": 1, "s": 0},
     })
     self.assertEqual (self.getCharacters ()["red"].getFungibleInventory (), {
-      "foo": 9,
+      "zerospace": 9,
     })
-    self.getCharacters ()["green"].sendMove ({"pu": {"f": {"foo": 5}}})
+    self.getCharacters ()["green"].sendMove ({"pu": {"f": {"zerospace": 5}}})
     self.generate (1)
     chars = self.getCharacters ()
     assert "red" not in chars
     self.assertEqual (chars["green"].getFungibleInventory (), {
-      "foo": 5,
+      "zerospace": 5,
     })
     self.assertEqual (self.getRpc ("getgroundloot"), [
       {
         "position": {"x": -1, "y": 20},
         "inventory":
           {
-            "fungible": {"foo": 6},
+            "fungible": {"zerospace": 6},
+          },
+      },
+      {
+        "position": {"x": 0, "y": 0},
+        "inventory":
+          {
+            "fungible": {"foo": 8},
           },
       },
       {
         "position": {"x": 1, "y": 2},
         "inventory":
           {
-            "fungible": {"bar": 8},
+            "fungible": {"bar": 10},
           },
       },
       {
         "position": {"x": 100, "y": 100},
         "inventory":
           {
-            "fungible": {"foo": 4},
+            "fungible": {"zerospace": 4},
           },
       },
     ])

--- a/gametest/mining.py
+++ b/gametest/mining.py
@@ -45,10 +45,24 @@ class MiningTest (PXTest):
       "domob 2": self.pos[1],
     })
     self.getCharacters ()["domob"].sendMove ({"prospect": {}})
-    self.generate (15)
+    self.generate (10)
+    self.assertEqual (self.getCharacters ()["domob"].getBusy ()["blocks"], 1)
 
-    typ, self.amount = self.getRegionAt (self.pos[0]).getResource ()
-    self.log.info ("Found %d of %s at the region" % (self.amount, typ))
+    # We need at least 15 of the resource in the region in order to allow
+    # the remaining parts of the test to work as expected.  Thus we try
+    # to re-roll prospection as needed in order to achieve that.
+    while True:
+      self.generate (1)
+      typ, self.amount = self.getRegionAt (self.pos[0]).getResource ()
+      self.log.info ("Found %d of %s at the region" % (self.amount, typ))
+
+      if self.amount > 15:
+        break
+
+      self.log.warning ("Too little resources, retrying...")
+      self.rpc.xaya.invalidateblock (self.rpc.xaya.getbestblockhash ())
+
+    self.generate (1)
     self.reorgBlock = self.rpc.xaya.getbestblockhash ()
 
     self.mainLogger.info ("Starting to mine...")

--- a/gametest/prospecting_resources.py
+++ b/gametest/prospecting_resources.py
@@ -39,7 +39,7 @@ class ProspectingResourcesTest (PXTest):
     r = self.getRegionAt (pos)
     self.assertEqual (r.data["prospection"]["name"], "domob")
     typ, amount = r.getResource ()
-    assert typ in ["sand", "cryptonite"]
+    assert typ in ["raw a", "raw b"]
     assert amount > 0
 
     # FIXME: For now, this test is super limited.  We should extend it

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -44,8 +44,23 @@ message OngoingProspection
 message MiningData
 {
 
-  /** The mining speed, in units per block.  */
-  optional uint64 rate = 1;
+  /**
+   * Stats about the speed for mining (which is random based on a distribution
+   * from these parameters).
+   */
+  message Speed
+  {
+
+    /** The minimum units per block.  */
+    optional uint64 min = 1;
+
+    /** The maximum units per block.  */
+    optional uint64 max = 2;
+
+  }
+
+  /** The mining speed parameters.  */
+  optional Speed rate = 1;
 
   /** Set to true if the character is currently mining.  */
   optional bool active = 2;

--- a/proto/roconfig.pb.text
+++ b/proto/roconfig.pb.text
@@ -14,18 +14,50 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Resource types in the game.
-# FIXME: For now these are just dummy values used in tests of the basic
-# prospecting / mining logic.  Add in real ones once determined together
-# with their proper cargo space.
+# Raw resources in the game.
 fungible_items:
   {
-    key: "sand"
-    value: { space: 50 }
+    key: "raw a"
+    value: { space: 1 }
   }
 fungible_items:
   {
-    key: "cryptonite"
+    key: "raw b"
+    value: { space: 1 }
+  }
+fungible_items:
+  {
+    key: "raw c"
+    value: { space: 1 }
+  }
+fungible_items:
+  {
+    key: "raw d"
+    value: { space: 1 }
+  }
+fungible_items:
+  {
+    key: "raw e"
+    value: { space: 1 }
+  }
+fungible_items:
+  {
+    key: "raw f"
+    value: { space: 1 }
+  }
+fungible_items:
+  {
+    key: "raw g"
+    value: { space: 1 }
+  }
+fungible_items:
+  {
+    key: "raw h"
+    value: { space: 1 }
+  }
+fungible_items:
+  {
+    key: "raw i"
     value: { space: 1 }
   }
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -231,8 +231,12 @@ GetMiningJsonObject (const BaseMap& map, const Character& c)
     return Json::Value ();
   const auto& pb = c.GetProto ().mining ();
 
+  Json::Value rate(Json::objectValue);
+  rate["min"] = IntToJson (pb.rate ().min ());
+  rate["max"] = IntToJson (pb.rate ().max ());
+
   Json::Value res(Json::objectValue);
-  res["rate"] = IntToJson (pb.rate ());
+  res["rate"] = rate;
   res["active"] = pb.active ();
   if (pb.active ())
     res["region"] = IntToJson (map.Regions ().GetRegionId (c.GetPosition ()));

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -392,12 +392,14 @@ TEST_F (CharacterJsonTests, Mining)
   tbl.CreateNew ("without mining", Faction::RED);
 
   auto h = tbl.CreateNew ("inactive mining", Faction::RED);
-  h->MutableProto ().mutable_mining ()->set_rate (12);
+  h->MutableProto ().mutable_mining ()->mutable_rate ()->set_min (0);
+  h->MutableProto ().mutable_mining ()->mutable_rate ()->set_max (5);
   h.reset ();
 
   h = tbl.CreateNew ("active mining", Faction::RED);
   h->SetPosition (pos);
-  h->MutableProto ().mutable_mining ()->set_rate (1);
+  h->MutableProto ().mutable_mining ()->mutable_rate ()->set_min (10);
+  h->MutableProto ().mutable_mining ()->mutable_rate ()->set_max (11);
   h->MutableProto ().mutable_mining ()->set_active (true);
   h.reset ();
 
@@ -412,7 +414,11 @@ TEST_F (CharacterJsonTests, Mining)
           "owner": "inactive mining",
           "mining":
             {
-              "rate": 12,
+              "rate":
+                {
+                  "min": 0,
+                  "max": 5
+                },
               "active": false,
               "region": null
             }
@@ -421,7 +427,11 @@ TEST_F (CharacterJsonTests, Mining)
           "owner": "active mining",
           "mining":
             {
-              "rate": 1,
+              "rate":
+                {
+                  "min": 10,
+                  "max": 11
+                },
               "active": true,
               "region": 350146
             }

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -116,7 +116,7 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
   mvProc.ProcessAdmin (blockData["admin"]);
   mvProc.ProcessAll (blockData["moves"]);
 
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   ProcessAllMovement (db, dyn, ctx);
 
   FindCombatTargets (db, rnd);

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -615,7 +615,8 @@ TEST_F (PXLogicTests, MiningRightAfterProspecting)
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos);
   c->MutableProto ().mutable_combat_data ();
-  c->MutableProto ().mutable_mining ()->set_rate (1);
+  c->MutableProto ().mutable_mining ()->mutable_rate ()->set_min (1);
+  c->MutableProto ().mutable_mining ()->mutable_rate ()->set_max (1);
   c->MutableProto ().set_cargo_space (100);
   c.reset ();
 
@@ -658,7 +659,8 @@ TEST_F (PXLogicTests, MiningAndDropping)
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos);
   c->MutableProto ().mutable_combat_data ();
-  c->MutableProto ().mutable_mining ()->set_rate (10);
+  c->MutableProto ().mutable_mining ()->mutable_rate ()->set_min (10);
+  c->MutableProto ().mutable_mining ()->mutable_rate ()->set_max (10);
   c->MutableProto ().mutable_mining ()->set_active (true);
   c->MutableProto ().set_cargo_space (1000);
   c->GetInventory ().SetFungibleCount ("foo", 95);
@@ -711,7 +713,8 @@ TEST_F (PXLogicTests, MiningWhenReprospected)
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos);
   c->MutableProto ().mutable_combat_data ();
-  c->MutableProto ().mutable_mining ()->set_rate (1);
+  c->MutableProto ().mutable_mining ()->mutable_rate ()->set_min (1);
+  c->MutableProto ().mutable_mining ()->mutable_rate ()->set_max (1);
   c->MutableProto ().mutable_mining ()->set_active (true);
   c->MutableProto ().set_cargo_space (1000);
   c.reset ();

--- a/src/mining.hpp
+++ b/src/mining.hpp
@@ -23,13 +23,15 @@
 
 #include "database/database.hpp"
 
+#include <xayautil/random.hpp>
+
 namespace pxd
 {
 
 /**
  * Processes all mining of characters in the current turn.
  */
-void ProcessAllMining (Database& db, const Context& ctx);
+void ProcessAllMining (Database& db, xaya::Random& rnd, const Context& ctx);
 
 } // namespace pxd
 

--- a/src/mining_tests.cpp
+++ b/src/mining_tests.cpp
@@ -26,6 +26,8 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 namespace pxd
 {
 namespace
@@ -39,6 +41,7 @@ protected:
   CharacterTable characters;
   RegionsTable regions;
 
+  TestRandom rnd;
   ContextForTesting ctx;
 
   const HexCoord pos;
@@ -50,9 +53,11 @@ protected:
   {
     auto c = GetTest ();
     c->SetPosition (pos);
-    c->MutableProto ().mutable_mining ()->set_rate (10);
-    c->MutableProto ().mutable_mining ()->set_active (true);
-    c->MutableProto ().set_cargo_space (1000);
+    auto& pb = c->MutableProto ();
+    pb.mutable_mining ()->mutable_rate ()->set_min (10);
+    pb.mutable_mining ()->mutable_rate ()->set_max (10);
+    pb.mutable_mining ()->set_active (true);
+    pb.set_cargo_space (1000);
     c.reset ();
 
     auto r = GetRegion ();
@@ -89,7 +94,7 @@ protected:
 
 TEST_F (MiningTests, Basic)
 {
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
   EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 10);
   EXPECT_EQ (GetRegion ()->GetResourceLeft (), 90);
@@ -98,7 +103,7 @@ TEST_F (MiningTests, Basic)
 TEST_F (MiningTests, NoMiningData)
 {
   GetTest ()->MutableProto ().clear_mining ();
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   EXPECT_TRUE (GetTest ()->GetInventory ().IsEmpty ());
   EXPECT_EQ (GetRegion ()->GetResourceLeft (), 100);
 }
@@ -106,7 +111,7 @@ TEST_F (MiningTests, NoMiningData)
 TEST_F (MiningTests, MiningNotActive)
 {
   GetTest ()->MutableProto ().mutable_mining ()->set_active (false);
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   EXPECT_TRUE (GetTest ()->GetInventory ().IsEmpty ());
   EXPECT_EQ (GetRegion ()->GetResourceLeft (), 100);
 }
@@ -114,7 +119,7 @@ TEST_F (MiningTests, MiningNotActive)
 TEST_F (MiningTests, RegionNotProspected)
 {
   GetRegion ()->MutableProto ().clear_prospection ();
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   EXPECT_FALSE (GetTest ()->GetProto ().mining ().active ());
   EXPECT_TRUE (GetTest ()->GetInventory ().IsEmpty ());
 }
@@ -123,12 +128,12 @@ TEST_F (MiningTests, ResourceUsedUp)
 {
   GetRegion ()->SetResourceLeft (5);
 
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
   EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 5);
   EXPECT_EQ (GetRegion ()->GetResourceLeft (), 0);
 
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   EXPECT_FALSE (GetTest ()->GetProto ().mining ().active ());
   EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 5);
   EXPECT_EQ (GetRegion ()->GetResourceLeft (), 0);
@@ -138,15 +143,75 @@ TEST_F (MiningTests, CargoFull)
 {
   GetTest ()->GetInventory ().SetFungibleCount ("foo", 95);
 
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
   EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 100);
   EXPECT_EQ (GetRegion ()->GetResourceLeft (), 95);
 
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
   EXPECT_FALSE (GetTest ()->GetProto ().mining ().active ());
   EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 100);
   EXPECT_EQ (GetRegion ()->GetResourceLeft (), 95);
+}
+
+TEST_F (MiningTests, ZeroRolls)
+{
+  auto c = GetTest ();
+  auto* rate = c->MutableProto ().mutable_mining ()->mutable_rate ();
+  rate->set_min (0);
+  rate->set_max (1);
+  c.reset ();
+
+  Inventory::QuantityT last = 0;
+  while (true)
+    {
+      ProcessAllMining (db, rnd, ctx);
+      const auto amount = GetTest ()->GetInventory ().GetFungibleCount ("foo");
+      if (amount == last)
+        break;
+      last = amount;
+    }
+
+  /* Even if we rolled a zero, we should not have triggered the "stop mining"
+     logic in the update function.  */
+  EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
+}
+
+TEST_F (MiningTests, Randomisation)
+{
+  constexpr unsigned trials = 1000;
+  constexpr unsigned lower = 10;
+  constexpr unsigned upper = 15;
+  constexpr auto threshold = (trials * 80) / (100 * (upper - lower + 1));
+
+  auto c = GetTest ();
+  auto* rate = c->MutableProto ().mutable_mining ()->mutable_rate ();
+  rate->set_min (lower);
+  rate->set_max (upper);
+  c.reset ();
+
+  std::vector<unsigned> counts(upper + 1, 0);
+  for (unsigned i = 0; i < trials; ++i)
+    {
+      GetRegion ()->SetResourceLeft (100);
+      GetTest ()->GetInventory ().SetFungibleCount ("foo", 0);
+
+      ProcessAllMining (db, rnd, ctx);
+      const auto amount = GetTest ()->GetInventory ().GetFungibleCount ("foo");
+
+      ASSERT_GE (amount, lower);
+      ASSERT_LE (amount, upper);
+      ++counts[amount];
+    }
+
+  unsigned total = 0;
+  for (unsigned i = lower; i <= upper; ++i)
+    {
+      LOG (INFO) << "Found " << i << ": " << counts[i] << " times";
+      ASSERT_GE (counts[i], threshold);
+      total += counts[i];
+    }
+  EXPECT_EQ (total, trials);
 }
 
 TEST_F (MiningTests, MultipleMiners)
@@ -156,16 +221,18 @@ TEST_F (MiningTests, MultipleMiners)
   auto c = characters.CreateNew ("andy", Faction::BLUE);
   ASSERT_EQ (c->GetId (), 2);
   c->SetPosition (pos);
-  c->MutableProto ().mutable_mining ()->set_rate (10);
-  c->MutableProto ().mutable_mining ()->set_active (true);
-  c->MutableProto ().set_cargo_space (1000);
+  auto& pb = c->MutableProto ();
+  pb.mutable_mining ()->mutable_rate ()->set_min (10);
+  pb.mutable_mining ()->mutable_rate ()->set_max (10);
+  pb.mutable_mining ()->set_active (true);
+  pb.set_cargo_space (1000);
   c.reset ();
 
   /* In the first turn, both miners will be able to mine at their rate.  In the
      second, the resource will get used up and only the first one will get
      something (but not at full rate).  */
-  ProcessAllMining (db, ctx);
-  ProcessAllMining (db, ctx);
+  ProcessAllMining (db, rnd, ctx);
+  ProcessAllMining (db, rnd, ctx);
 
   EXPECT_TRUE (GetTest ()->GetProto ().mining ().active ());
   EXPECT_EQ (GetTest ()->GetInventory ().GetFungibleCount ("foo"), 15);

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1232,12 +1232,17 @@ protected:
        at its current position.  Tests that want to make mining impossible can
        then selectively undo some of these.  */
 
-    GetTest ()->MutableProto ().mutable_mining ()->set_rate (10);
-    GetTest ()->MutableProto ().set_speed (1000);
+    auto c = GetTest ();
+    auto& pb = c->MutableProto ();
+    pb.mutable_mining ()->mutable_rate ()->set_min (10);
+    pb.mutable_mining ()->mutable_rate ()->set_max (10);
+    pb.set_speed (1000);
+    c.reset ();
 
     auto r = regions.GetById (region);
     r->MutableProto ().mutable_prospection ()->set_resource ("foo");
     r->SetResourceLeft (42);
+    r.reset ();
   }
 
   /**

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -138,7 +138,7 @@ Params::DetectResource (const HexCoord& pos, xaya::Random& rnd,
      general prospecting and mining logic.  We need to replace this with
      a proper implementation based on how we want to distribute resources.  */
 
-  const std::vector<std::string> types = {"sand", "cryptonite"};
+  const std::vector<std::string> types = {"raw a", "raw b"};
   const auto ind = rnd.SelectByWeight ({10, 1});
 
   type = types[ind];
@@ -170,7 +170,7 @@ void
 Params::InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const
 {
   pb.set_speed (3000);
-  pb.set_cargo_space (1000);
+  pb.set_cargo_space (20);
 
   pb.mutable_mining ()->set_rate (1);
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -172,7 +172,9 @@ Params::InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const
   pb.set_speed (3000);
   pb.set_cargo_space (20);
 
-  pb.mutable_mining ()->set_rate (1);
+  auto* miningRate = pb.mutable_mining ()->mutable_rate ();
+  miningRate->set_min (0);
+  miningRate->set_max (5);
 
   auto* cd = pb.mutable_combat_data ();
   auto* attack = cd->add_attacks ();

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -187,8 +187,8 @@ TEST_F (FinishProspectingTests, Resources)
 {
   std::map<std::string, unsigned> regionsForResource =
     {
-      {"sand", 0},
-      {"cryptonite", 0},
+      {"raw a", 0},
+      {"raw b", 0},
     };
 
   for (unsigned i = 0; i < 100; ++i)
@@ -208,8 +208,8 @@ TEST_F (FinishProspectingTests, Resources)
         << " in " << entry.second << " regions";
 
   ASSERT_EQ (regionsForResource.size (), 2);
-  EXPECT_GT (regionsForResource["sand"], regionsForResource["cryptonite"]);
-  EXPECT_GT (regionsForResource["cryptonite"], 0);
+  EXPECT_GT (regionsForResource["raw a"], regionsForResource["raw b"]);
+  EXPECT_GT (regionsForResource["raw b"], 0);
 }
 
 TEST_F (FinishProspectingTests, Prizes)


### PR DESCRIPTION
This updates the basic resource/mining stats (see #53), except for the distribution of resources on the map.  We will have nine resources (code-named `raw a` to `raw i`).  Each takes up one cargo space per unit, and the default vehicle has 20 cargo space in total.

Also mining output is randomised, and set to 0-5 for the standard stats.