### PR TITLE
Update character stats per faction

### DIFF
--- a/gametest/combat_targets.py
+++ b/gametest/combat_targets.py
@@ -95,7 +95,7 @@ class CombatTargetTest (PXTest):
     self.mainLogger.info ("Testing target selection when moving into range...")
     c = self.getCharacters ()["red"]
     self.moveCharactersTo ({
-      "red": offsetCoord ({"x": 13, "y": 0}, self.offset, False),
+      "red": offsetCoord ({"x": 12, "y": 0}, self.offset, False),
     })
     assert self.getTargetCharacter ("green") is None
     # Note that we can move a directly to the offset coordinate (where also

--- a/gametest/fame.py
+++ b/gametest/fame.py
@@ -62,9 +62,9 @@ class FameTest (PXTest):
     self.generate (1)
     self.moveCharactersTo ({
       "blue": {"x": 0, "y": 0},
-      "red": {"x": 10, "y": 0},
-      "red 2": {"x": 0, "y": 10},
-      "green": {"x": -10, "y": 0},
+      "red": {"x": 5, "y": 0},
+      "red 2": {"x": 0, "y": 5},
+      "green": {"x": -5, "y": 0},
     })
     self.setCharactersHP ({
       "blue": {"a": 1, "s": 0},

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -95,7 +95,7 @@ class MovementTest (PXTest):
     self.collectPremine ()
 
     self.mainLogger.info ("Creating test character...")
-    self.initAccount ("domob", "r")
+    self.initAccount ("domob", "g")
     self.createCharacters ("domob")
     self.generate (1)
 
@@ -106,18 +106,18 @@ class MovementTest (PXTest):
 
     self.mainLogger.info ("Setting basic path for character...")
     wp = [
-      {"x": 12, "y": 0},
-      {"x": 3, "y": 3},
-      {"x": 3, "y": 3},
+      {"x": 6, "y": 0},
+      {"x": 2, "y": 2},
+      {"x": 2, "y": 2},
       {"x": 0, "y": 0},
-      {"x": -9, "y": -6},
-      {"x": -9, "y": -6},
+      {"x": -6, "y": -4},
+      {"x": -6, "y": -4},
     ]
     self.setWaypoints ("domob", wp)
     self.generate (1)
     pos, mv = self.getMovement ("domob")
     self.assertEqual (mv["partialstep"], 0)
-    self.assertEqual (pos, {"x": 3, "y": 0})
+    self.assertEqual (pos, {"x": 2, "y": 0})
     self.reorgBlock = self.rpc.xaya.getbestblockhash ()
 
     self.mainLogger.info ("Finishing the movement...")
@@ -165,13 +165,13 @@ class MovementTest (PXTest):
     self.assertEqual (pos, {"x": 10, "y": 0})
     self.assertEqual (mv["chosenspeed"], 1000)
 
-    # Adjust the speed to be higher than the natural speed of 3000,
+    # Adjust the speed to be higher than the natural speed of 2'000,
     # and expect movement with the natural speed.
     c = self.getCharacters ()["domob"]
     c.sendMove ({"speed": 10000})
     self.generate (10)
     pos, mv = self.getMovement ("domob")
-    self.assertEqual (pos, {"x": 40, "y": 0})
+    self.assertEqual (pos, {"x": 30, "y": 0})
     self.assertEqual (mv["chosenspeed"], 10000)
 
     # Sending another movement in-between without speed will revert it to
@@ -180,7 +180,7 @@ class MovementTest (PXTest):
     c.sendMove ({"wp": wp, "speed": 1000})
     self.generate (10)
     pos, _ = self.getMovement ("domob")
-    self.assertEqual (pos, {"x": 50, "y": 0})
+    self.assertEqual (pos, {"x": 40, "y": 0})
     self.setWaypoints ("domob", [{"x": 0, "y": 0}])
     self.generate (10)
     pos, mv = self.getMovement ("domob")
@@ -200,7 +200,7 @@ class MovementTest (PXTest):
     self.setWaypoints ("domob", [{"x": 0, "y": 0}])
     self.generate (10)
     pos, mv = self.getMovement ("domob")
-    self.assertEqual (pos, {"x": 70, "y": 0})
+    self.assertEqual (pos, {"x": 80, "y": 0})
     assert "chosenspeed" not in mv
 
     # Stop the character to avoid confusing later tests.
@@ -215,7 +215,7 @@ class MovementTest (PXTest):
 
     self.mainLogger.info ("Testing blocking the path...")
 
-    self.initAccount ("blocker", "r")
+    self.initAccount ("blocker", "g")
     self.createCharacters ("blocker")
     self.generate (1)
 
@@ -228,7 +228,7 @@ class MovementTest (PXTest):
     self.setWaypoints ("domob", [{"x": 0, "y": 0}])
     self.generate (3)
     self.setWaypoints ("blocker", [{"x": 50, "y": 0}])
-    self.generate (5)
+    self.generate (10)
 
     # The character should be blocked by the obstacle.
     pos, mv = self.getMovement ("domob")

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -158,7 +158,8 @@ Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
 }
 
 void
-Params::InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const
+Params::InitCharacterStats (const Faction f,
+                            proto::RegenData& regen, proto::Character& pb) const
 {
   pb.set_speed (3000);
   pb.set_cargo_space (20);

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -161,29 +161,61 @@ void
 Params::InitCharacterStats (const Faction f,
                             proto::RegenData& regen, proto::Character& pb) const
 {
-  pb.set_speed (3000);
-  pb.set_cargo_space (20);
-
   auto* miningRate = pb.mutable_mining ()->mutable_rate ();
   miningRate->set_min (0);
   miningRate->set_max (5);
 
   auto* cd = pb.mutable_combat_data ();
-  auto* attack = cd->add_attacks ();
-  attack->set_range (10);
-  attack->set_min_damage (1);
-  attack->set_max_damage (20);
-
-  attack = cd->add_attacks ();
-  attack->set_range (1);
-  attack->set_area (true);
-  attack->set_min_damage (5);
-  attack->set_max_damage (30);
+  proto::Attack* attack;
 
   auto* maxHP = regen.mutable_max_hp ();
-  maxHP->set_armour (100);
   maxHP->set_shield (30);
-  regen.set_shield_regeneration_mhp (500);
+
+  switch (f)
+    {
+    case Faction::RED:
+      pb.set_speed (2'100);
+      pb.set_cargo_space (20);
+
+      maxHP->set_armour (75);
+      regen.set_shield_regeneration_mhp (500);
+
+      attack = cd->add_attacks ();
+      attack->set_range (7);
+      attack->set_area (true);
+      attack->set_min_damage (1);
+      attack->set_max_damage (20);
+      break;
+
+    case Faction::BLUE:
+      pb.set_speed (2'200);
+      pb.set_cargo_space (20);
+
+      maxHP->set_armour (50);
+      regen.set_shield_regeneration_mhp (1'000);
+
+      attack = cd->add_attacks ();
+      attack->set_range (10);
+      attack->set_min_damage (1);
+      attack->set_max_damage (12);
+      break;
+
+    case Faction::GREEN:
+      pb.set_speed (2'000);
+      pb.set_cargo_space (30);
+
+      maxHP->set_armour (150);
+      regen.set_shield_regeneration_mhp (200);
+
+      attack = cd->add_attacks ();
+      attack->set_range (10);
+      attack->set_min_damage (1);
+      attack->set_max_damage (20);
+      break;
+
+    default:
+      LOG (FATAL) << "Invalid faction: " << static_cast<int> (f);
+    }
 }
 
 bool

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -143,7 +143,8 @@ public:
    * Initialises the stats for a newly created character.  This fills in the
    * combat data and other fields in the protocol buffer as needed.
    */
-  void InitCharacterStats (proto::RegenData& regen, proto::Character& pb) const;
+  void InitCharacterStats (Faction f, proto::RegenData& regen,
+                           proto::Character& pb) const;
 
   /**
    * Returns true if god-mode commands are allowed (on regtest).

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -125,7 +125,7 @@ SpawnCharacter (const std::string& owner, const Faction f,
 
   auto& regen = c->MutableRegenData ();
   auto& pb = c->MutableProto ();
-  ctx.Params ().InitCharacterStats (regen, pb);
+  ctx.Params ().InitCharacterStats (f, regen, pb);
   c->MutableHP () = regen.max_hp ();
 
   return c;

--- a/src/spawn_tests.cpp
+++ b/src/spawn_tests.cpp
@@ -97,7 +97,26 @@ TEST_F (SpawnTests, DataInitialised)
   ASSERT_EQ (c->GetOwner (), "domob");
 
   EXPECT_TRUE (c->GetProto ().has_combat_data ());
-  EXPECT_EQ (c->GetProto ().combat_data ().attacks_size (), 2);
+  EXPECT_FALSE (c->GetProto ().combat_data ().attacks ().empty ());
+}
+
+TEST_F (SpawnTests, PerFactionStats)
+{
+  const auto idRed = Spawn ("red", Faction::RED)->GetId ();
+  const auto idGreen = Spawn ("green", Faction::GREEN)->GetId ();
+  const auto idBlue = Spawn ("blue", Faction::BLUE)->GetId ();
+
+  auto c = tbl.GetById (idRed);
+  ASSERT_EQ (c->GetFaction (), Faction::RED);
+  EXPECT_EQ (c->GetProto ().speed (), 2'100);
+
+  c = tbl.GetById (idGreen);
+  ASSERT_EQ (c->GetFaction (), Faction::GREEN);
+  EXPECT_EQ (c->GetProto ().speed (), 2'000);
+
+  c = tbl.GetById (idBlue);
+  ASSERT_EQ (c->GetFaction (), Faction::BLUE);
+  EXPECT_EQ (c->GetProto ().speed (), 2'200);
 }
 
 class SpawnLocationTests : public SpawnTests


### PR DESCRIPTION
This change enables the default character stats to depend on faction, we we use that to actually set data (speed, cargo, HP/regen, attacks) differently for the three factions.  This should make them more differentiated and interesting for the upcoming competition.

Values for the stats per @xaya.