### PR TITLE
Implement banking

### DIFF
--- a/database/account.hpp
+++ b/database/account.hpp
@@ -21,6 +21,7 @@
 
 #include "database.hpp"
 #include "faction.hpp"
+#include "inventory.hpp"
 
 #include <memory>
 #include <string>
@@ -36,6 +37,8 @@ struct AccountResult : public ResultWithFaction
   RESULT_COLUMN (std::string, name, 1);
   RESULT_COLUMN (int64_t, kills, 2);
   RESULT_COLUMN (int64_t, fame, 3);
+  RESULT_COLUMN (pxd::proto::Inventory, banked, 4);
+  RESULT_COLUMN (int64_t, banking_points, 5);
 };
 
 /**
@@ -61,6 +64,12 @@ private:
 
   /** The account's fame value.  */
   unsigned fame;
+
+  /** The account's banked stuff.  */
+  Inventory banked;
+
+  /** Banking points from complete sets of resources.  */
+  unsigned bankingPoints;
 
   /**
    * Set to true if any modification has been made and we need to write
@@ -132,6 +141,31 @@ public:
   {
     dirty = true;
     fame = val;
+  }
+
+  const Inventory&
+  GetBanked () const
+  {
+    return banked;
+  }
+
+  Inventory&
+  GetBanked ()
+  {
+    return banked;
+  }
+
+  unsigned
+  GetBankingPoints () const
+  {
+    return bankingPoints;
+  }
+
+  void
+  AddBankingPoints (const unsigned added)
+  {
+    dirty = true;
+    bankingPoints += added;
   }
 
 };

--- a/database/account_tests.cpp
+++ b/database/account_tests.cpp
@@ -47,6 +47,8 @@ TEST_F (AccountTests, DefaultData)
   EXPECT_EQ (a->GetFaction (), Faction::BLUE);
   EXPECT_EQ (a->GetKills (), 0);
   EXPECT_EQ (a->GetFame (), 100);
+  EXPECT_TRUE (a->GetBanked ().IsEmpty ());
+  EXPECT_EQ (a->GetBankingPoints (), 0);
 }
 
 TEST_F (AccountTests, Update)
@@ -54,12 +56,31 @@ TEST_F (AccountTests, Update)
   auto a = tbl.CreateNew ("foobar", Faction::RED);
   a->SetKills (50);
   a->SetFame (200);
+  a->AddBankingPoints (10);
+  a->AddBankingPoints (10);
   a.reset ();
 
   a = tbl.GetByName ("foobar");
   EXPECT_EQ (a->GetName (), "foobar");
   EXPECT_EQ (a->GetKills (), 50);
   EXPECT_EQ (a->GetFame (), 200);
+  EXPECT_EQ (a->GetBankingPoints (), 20);
+}
+
+TEST_F (AccountTests, UpdateBanked)
+{
+  auto a = tbl.CreateNew ("foobar", Faction::RED);
+  a->GetBanked ().SetFungibleCount ("raw a", 5);
+  a.reset ();
+
+  a = tbl.GetByName ("foobar");
+  a->GetBanked ().AddFungibleCount ("raw a", 1);
+  a->GetBanked ().SetFungibleCount ("raw b", 1);
+  a.reset ();
+
+  a = tbl.GetByName ("foobar");
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw a"), 6);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw b"), 1);
 }
 
 using AccountsTableTests = AccountTests;

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -336,7 +336,9 @@ namespace
 {
 
 struct PositionResult : public ResultWithFaction, public ResultWithCoord
-{};
+{
+  RESULT_COLUMN (int64_t, id, 1);
+};
 
 } // anonymous namespace
 
@@ -344,7 +346,7 @@ void
 CharacterTable::ProcessAllPositions (const PositionFcn& cb)
 {
   auto stmt = db.Prepare (R"(
-    SELECT `x`, `y`, `faction`
+    SELECT `id`, `x`, `y`, `faction`
       FROM `characters`
       ORDER BY `id`
   )");
@@ -352,9 +354,10 @@ CharacterTable::ProcessAllPositions (const PositionFcn& cb)
   auto res = stmt.Query<PositionResult> ();
   while (res.Step ())
     {
+      const Database::IdT id = res.Get<PositionResult::id> ();
       const HexCoord pos = GetCoordFromColumn (res);
       const Faction f = GetFactionFromColumn (res);
-      cb (pos, f);
+      cb (id, pos, f);
     }
 }
 

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -342,7 +342,8 @@ public:
   using Handle = std::unique_ptr<Character>;
 
   /** Callback function for processing positions and factions of characters.  */
-  using PositionFcn = std::function<void (const HexCoord& pos, Faction f)>;
+  using PositionFcn
+      = std::function<void (Database::IdT id, const HexCoord& pos, Faction f)>;
 
   explicit CharacterTable (Database& d)
     : db(d)

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -418,16 +418,38 @@ TEST_F (CharacterTableTests, ProcessAllPositions)
   tbl.CreateNew ("red", Faction::RED)->SetPosition (HexCoord (-1, -5));
   tbl.CreateNew ("blue", Faction::BLUE)->SetPosition (HexCoord (0, 0));
 
-  using Entry = std::pair<Faction, HexCoord>;
-  std::vector<Entry> entries;
-  tbl.ProcessAllPositions ([&entries] (const HexCoord& pos, const Faction f)
+  struct Entry
+  {
+
+    Database::IdT id;
+    Faction fact;
+    HexCoord pos;
+
+    Entry () = default;
+    Entry (const Entry&) = default;
+
+    Entry (const Database::IdT i, const Faction f, const HexCoord& p)
+      : id(i), fact(f), pos(p)
+    {}
+
+    bool
+    operator== (const Entry& o) const
     {
-      entries.emplace_back (f, pos);
+      return id == o.id && fact == o.fact && pos == o.pos;
+    }
+
+  };
+
+  std::vector<Entry> entries;
+  tbl.ProcessAllPositions ([&entries] (const Database::IdT id,
+                                       const HexCoord& pos, const Faction f)
+    {
+      entries.emplace_back (id, f, pos);
     });
 
-  EXPECT_THAT (entries, ElementsAre (Entry (Faction::RED, HexCoord (1, 5)),
-                                     Entry (Faction::RED, HexCoord (-1, -5)),
-                                     Entry (Faction::BLUE, HexCoord (0, 0))));
+  EXPECT_THAT (entries, ElementsAre (Entry (1, Faction::RED, HexCoord (1, 5)),
+                                     Entry (2, Faction::RED, HexCoord (-1, -5)),
+                                     Entry (3, Faction::BLUE, HexCoord (0, 0))));
 }
 
 TEST_F (CharacterTableTests, DeleteById)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -148,7 +148,13 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   `kills` INTEGER NOT NULL,
 
   -- The fame of this account.
-  `fame` INTEGER NOT NULL
+  `fame` INTEGER NOT NULL,
+
+  -- Inventory of banked items (as serialised proto).
+  `banked` BLOB NOT NULL,
+
+  -- "Points" from banking complete sets of resources.
+  `banking_points` INTEGER NOT NULL
 
 );
 

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -3,6 +3,7 @@ TEST_LIBRARY = \
 
 REGTESTS = \
   accounts.py \
+  banking.py \
   character_limit.py \
   characters.py \
   combat_damage.py \

--- a/gametest/banking.py
+++ b/gametest/banking.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests banking of resources / items.
+"""
+
+from pxtest import PXTest
+
+
+class BankingTest (PXTest):
+
+  def addArguments (self, parser):
+    parser.add_argument ("--bank_set", default=False, action="store_true",
+                         help="bank a full set of resources (slow)")
+
+  def run (self):
+    self.collectPremine ()
+
+    self.bankPos = {"x": -175, "y": 810}
+    self.noBankPos = {"x": -176, "y": 810}
+
+    self.mainLogger.info ("Creating test character...")
+    self.dropLoot (self.noBankPos, {"gold prize": 1, "silver prize": 2})
+    self.initAccount ("domob", "g")
+    self.createCharacters ("domob")
+    self.generate (1)
+    self.moveCharactersTo ({
+      "domob": self.noBankPos,
+    })
+    self.getCharacters ()["domob"].sendMove ({
+      "pu":
+        {
+          "f":
+            {
+              "gold prize": 10,
+              "silver prize": 10,
+            }
+        }
+    })
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["domob"].getFungibleInventory (), {
+      "gold prize": 1,
+      "silver prize": 2,
+    })
+    self.assertEqual (self.getAccounts ()["domob"].getFungibleBanked (), {})
+
+    # Generate a block we will invalidate later.  Also make sure that we have
+    # some blocks to make this chain longest.
+    self.generate (1)
+    self.reorgBlock = self.rpc.xaya.getbestblockhash ()
+    self.generate (10)
+
+    self.mainLogger.info ("Banking prizes by movement...")
+    self.getCharacters ()["domob"].sendMove ({"wp": [self.bankPos]})
+    self.generate (1)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.getPosition (), self.bankPos)
+    self.assertEqual (c.getFungibleInventory (), {})
+    self.assertEqual (self.getAccounts ()["domob"].getFungibleBanked (), {
+      "gold prize": 1,
+      "silver prize": 2,
+    })
+
+    if self.args.bank_set:
+      self.testResourceSets ()
+    self.testReorg ()
+
+  def testResourceSets (self):
+    self.mainLogger.info ("Banking resources for sets...")
+    self.dropLoot (self.bankPos, {
+      "raw a": 205,
+      "raw b": 200,
+      "raw c": 200,
+      "raw d": 200,
+      "raw e": 200,
+      "raw f": 200,
+      "raw g": 200,
+      "raw h": 200,
+      "raw i": 200,
+    })
+    self.generate (1)
+
+    while self.getRpc ("getgroundloot"):
+      c = self.getCharacters ()["domob"]
+      c.sendMove ({
+        "pu":
+          {
+            "f":
+              {
+                "raw a": 1000,
+                "raw b": 1000,
+                "raw c": 1000,
+                "raw d": 1000,
+                "raw e": 1000,
+                "raw f": 1000,
+                "raw g": 1000,
+                "raw h": 1000,
+                "raw i": 1000,
+              }
+          }
+      })
+      self.generate (1)
+
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.getFungibleInventory (), {})
+
+    a = self.getAccounts ()["domob"]
+    self.assertEqual (a.data["bankingpoints"], 1)
+    self.assertEqual (a.getFungibleBanked (), {
+      "gold prize": 1,
+      "silver prize": 2,
+      "raw a": 5,
+    })
+
+  def testReorg (self):
+    self.mainLogger.info ("Testing reorg...")
+
+    oldState = self.getGameState ()
+
+    # Invalidate the first banking and leave the character out of
+    # the banking area instead.
+    self.rpc.xaya.invalidateblock (self.reorgBlock)
+    self.assertEqual (self.rpc.xaya.name_pending ("domob"), [])
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isMoving (), False)
+    self.assertEqual (c.getPosition (), self.noBankPos)
+    self.generate (10)
+
+    a = self.getAccounts ()["domob"]
+    self.assertEqual (a.getFungibleBanked (), {})
+    self.assertEqual (a.data["bankingpoints"], 0)
+
+    # Reconsider the previous chain to restore the state.
+    self.rpc.xaya.reconsiderblock (self.reorgBlock)
+    self.expectGameState (oldState)
+    assert len (self.getAccounts ()["domob"].getFungibleBanked ()) > 0
+
+
+if __name__ == "__main__":
+  BankingTest ().main ()

--- a/gametest/prospecting_prizes.py
+++ b/gametest/prospecting_prizes.py
@@ -33,13 +33,17 @@ COMPETITION_OVER = 1600000000
 
 class ProspectingPrizesTest (PXTest):
 
-  def getCharacterPrizes (self, char):
+  def getPrizes (self, nm):
     """
-    Returns the prizes (if any) the character with the given "string name"
-    has won so far as a dictionary.
+    Returns the prizes (if any) the account with the given name as well as
+    its "first character" has won so far (based on what they have banked
+    and what the character has in its inventory).
     """
 
-    items = self.getCharacters ()[char].getFungibleInventory ()
+    char = self.getCharacters ()[nm].getFungibleInventory ()
+    acc = self.getAccounts ()[nm].getFungibleBanked ()
+    items = char + acc
+
     res = {}
     for item, amount in items.iteritems ():
       suffix = " prize"
@@ -84,7 +88,7 @@ class ProspectingPrizesTest (PXTest):
       prosp = self.getRegionAt (pos).data["prospection"]
       self.assertEqual (prosp["name"], "prize trier")
 
-      if "silver" in self.getCharacterPrizes ("prize trier"):
+      if "silver" in self.getPrizes ("prize trier"):
         stillNeedSilver = False
       else:
         stillNeedNoSilver = False
@@ -113,7 +117,7 @@ class ProspectingPrizesTest (PXTest):
 
       prosp = self.getRegionAt (pos).data["prospection"]
       self.assertEqual (prosp["name"], "prize trier")
-      self.assertEqual (self.getCharacterPrizes ("prize trier"), {})
+      self.assertEqual (self.getPrizes ("prize trier"), {})
 
       self.rpc.xaya.invalidateblock (blk)
 
@@ -125,7 +129,7 @@ class ProspectingPrizesTest (PXTest):
 
       prosp = self.getRegionAt (pos).data["prospection"]
       self.assertEqual (prosp["name"], "prize trier")
-      if self.getCharacterPrizes ("prize trier"):
+      if self.getPrizes ("prize trier"):
         stillNeedPrize = False
 
       self.rpc.xaya.invalidateblock (blk)
@@ -167,8 +171,8 @@ class ProspectingPrizesTest (PXTest):
       "silver": 0,
       "bronze": 0,
     }
-    for nm in self.getCharacters ():
-      thisPrizes = self.getCharacterPrizes (nm)
+    for nm in self.getAccounts ():
+      thisPrizes = self.getPrizes (nm)
       for prize, num in thisPrizes.iteritems ():
         prizesInRegions[prize] += num
 

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -16,6 +16,7 @@
 
 from xayagametest.testcase import XayaGameTest
 
+import collections
 import os
 import os.path
 
@@ -84,7 +85,7 @@ class Character (object):
     return None
 
   def getFungibleInventory (self):
-    return self.data["inventory"]["fungible"]
+    return collections.Counter (self.data["inventory"]["fungible"])
 
   def sendMove (self, mv):
     """
@@ -118,6 +119,9 @@ class Account (object):
 
   def getFaction (self):
     return self.data["faction"]
+
+  def getFungibleBanked (self):
+    return collections.Counter (self.data["banked"]["fungible"])
 
 
 class Region (object):

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,7 @@ libtaurion_la_LIBADD = \
   $(top_builddir)/proto/libpxproto.la \
   $(XAYAGAME_LIBS) $(JSON_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
 libtaurion_la_SOURCES = \
+  banking.cpp \
   combat.cpp \
   context.cpp \
   dynobstacles.cpp \
@@ -35,6 +36,7 @@ libtaurion_la_SOURCES = \
   spawn.cpp
 libtaurionheaders = \
   amount.hpp \
+  banking.hpp \
   combat.hpp \
   context.hpp \
   dynobstacles.hpp dynobstacles.tpp \
@@ -103,6 +105,7 @@ tests_LDADD = \
   $(GTEST_MAIN_LIBS) \
   $(JSON_LIBS) $(GTEST_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
+  banking_tests.cpp \
   combat_tests.cpp \
   dynobstacles_tests.cpp \
   fame_tests.cpp \
@@ -119,6 +122,7 @@ tests_SOURCES = \
   spawn_tests.cpp \
   testutils_tests.cpp
 check_HEADERS = \
+  banking_tests.hpp \
   fame_tests.hpp \
   \
   testutils.hpp

--- a/src/banking.cpp
+++ b/src/banking.cpp
@@ -1,0 +1,118 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "banking.hpp"
+
+#include "database/account.hpp"
+#include "database/character.hpp"
+#include "database/inventory.hpp"
+
+#include <glog/logging.h>
+
+#include <vector>
+
+namespace pxd
+{
+
+namespace
+{
+
+/**
+ * Processes banking for a single character (for which we already know that
+ * it is in a banking area).
+ */
+void
+ProcessBanking (AccountsTable& accounts, const Context& ctx, Character& c)
+{
+  if (c.GetInventory ().IsEmpty ())
+    return;
+
+  const auto& nm = c.GetOwner ();
+  LOG (INFO)
+      << "Banking non-empty inventory of character " << c.GetId ()
+      << " at " << c.GetPosition () << " for user " << nm;
+
+  auto a = accounts.GetByName (nm);
+  auto& banked = a->GetBanked ();
+
+  /* While "moving" the inventory over to the banked one, we cannot right away
+     modify (i.e. clear) the character inventory as that would invalidate the
+     map we are iterating over.  Thus we keep track of all item types that were
+     there, so that we can clear them in a later step.  */
+  std::vector<std::string> types;
+  for (const auto& entry : c.GetInventory ().GetFungible ())
+    {
+      VLOG (1) << "Banking " << entry.second << " of " << entry.first;
+      banked.AddFungibleCount (entry.first, entry.second);
+      types.push_back (entry.first);
+    }
+  for (const auto& t : types)
+    c.GetInventory ().SetFungibleCount (t, 0);
+  CHECK (c.GetInventory ().IsEmpty ());
+
+  /* Try to find more completed "resource sets".  */
+  const auto& setData = ctx.Params ().BankingSet ();
+  int setsPossible = -1;
+  for (const auto& entry : setData)
+    {
+      const int possibleForThis
+          = banked.GetFungibleCount (entry.first) / entry.second;
+      if (setsPossible == -1 || setsPossible >= possibleForThis)
+        setsPossible = possibleForThis;
+      CHECK_GE (setsPossible, 0);
+      if (setsPossible == 0)
+        break;
+    }
+  CHECK_GE (setsPossible, 0);
+
+  if (setsPossible > 0)
+    {
+      VLOG (1)
+          << "User " << nm << " has " << setsPossible
+          << " more banking-sets completed";
+      a->AddBankingPoints (setsPossible);
+      for (const auto& entry : setData)
+        {
+          const Inventory::QuantityT reduced = setsPossible * entry.second;
+          const auto old = banked.GetFungibleCount (entry.first);
+          CHECK_GE (old, reduced);
+          banked.SetFungibleCount (entry.first, old - reduced);
+        }
+    }
+}
+
+} // anonymous namespace
+
+void
+ProcessBanking (Database& db, const Context& ctx)
+{
+  AccountsTable accounts(db);
+  CharacterTable characters(db);
+
+  characters.ProcessAllPositions ([&] (const Database::IdT id,
+                                       const HexCoord& pos, const Faction f)
+    {
+      if (!ctx.Params ().IsBankingArea (pos))
+        return;
+
+      auto c = characters.GetById (id);
+      ProcessBanking (accounts, ctx, *c);
+    });
+}
+
+} // namespace pxd

--- a/src/banking.hpp
+++ b/src/banking.hpp
@@ -1,0 +1,38 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_BANKING_HPP
+#define PXD_BANKING_HPP
+
+#include "context.hpp"
+
+#include "database/database.hpp"
+
+namespace pxd
+{
+
+/**
+ * Processes all updates due to banking.  In other words, bankings the inventory
+ * of all characters inside a banking area, and also updates their "points"
+ * for completed resource sets.
+ */
+void ProcessBanking (Database& db, const Context& ctx);
+
+} // namespace pxd
+
+#endif // PXD_BANKING_HPP

--- a/src/banking_tests.cpp
+++ b/src/banking_tests.cpp
@@ -1,0 +1,130 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "banking_tests.hpp"
+
+#include "testutils.hpp"
+
+#include "database/account.hpp"
+#include "database/character.hpp"
+#include "database/dbtest.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+
+const HexCoord BANKING_POS(-175, 810);
+const HexCoord NO_BANKING_POS(-176, 810);
+
+namespace
+{
+
+class BankingTests : public DBTestWithSchema
+{
+
+protected:
+
+  ContextForTesting ctx;
+
+  AccountsTable accounts;
+  CharacterTable characters;
+
+  BankingTests ()
+    : accounts(db), characters(db)
+  {
+    accounts.CreateNew ("domob", Faction::RED);
+  }
+
+};
+
+TEST_F (BankingTests, TestPositions)
+{
+  EXPECT_TRUE (ctx.Params ().IsBankingArea (BANKING_POS));
+  EXPECT_FALSE (ctx.Params ().IsBankingArea (NO_BANKING_POS));
+  EXPECT_EQ (HexCoord::DistanceL1 (BANKING_POS, NO_BANKING_POS), 1);
+}
+
+TEST_F (BankingTests, ItemsBanked)
+{
+  accounts.GetByName ("domob")->GetBanked ().AddFungibleCount ("foo", 10);
+
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  const auto id = c->GetId ();
+  c->SetPosition (BANKING_POS);
+  c->MutableProto ().set_cargo_space (100);
+  c->GetInventory ().SetFungibleCount ("foo", 1);
+  c->GetInventory ().SetFungibleCount ("bar", 2);
+  c.reset ();
+
+  ProcessBanking (db, ctx);
+
+  EXPECT_TRUE (characters.GetById (id)->GetInventory ().IsEmpty ());
+  auto a = accounts.GetByName ("domob");
+  EXPECT_EQ (a->GetBankingPoints (), 0);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("foo"), 11);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("bar"), 2);
+}
+
+TEST_F (BankingTests, OutsideBankingArea)
+{
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  const auto id = c->GetId ();
+  c->SetPosition (NO_BANKING_POS);
+  c->MutableProto ().set_cargo_space (100);
+  c->GetInventory ().SetFungibleCount ("foo", 3);
+  c.reset ();
+
+  ProcessBanking (db, ctx);
+
+  EXPECT_TRUE (accounts.GetByName ("domob")->GetBanked ().IsEmpty ());
+  EXPECT_EQ (characters.GetById (id)->GetInventory ().GetFungibleCount ("foo"),
+             3);
+}
+
+TEST_F (BankingTests, BankingPoints)
+{
+  auto a = accounts.GetByName ("domob");
+  a->AddBankingPoints (10);
+  a->GetBanked ().AddFungibleCount ("raw b", 1'000);
+  a->GetBanked ().AddFungibleCount ("raw c", 1'000);
+  a->GetBanked ().AddFungibleCount ("raw d", 1'000);
+  a->GetBanked ().AddFungibleCount ("raw e", 1'000);
+  a->GetBanked ().AddFungibleCount ("raw f", 1'000);
+  a->GetBanked ().AddFungibleCount ("raw g", 1'000);
+  a->GetBanked ().AddFungibleCount ("raw h", 1'000);
+  a.reset ();
+
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  c->SetPosition (BANKING_POS);
+  c->MutableProto ().set_cargo_space (5'000);
+  c->GetInventory ().SetFungibleCount ("raw a", 456);
+  c->GetInventory ().SetFungibleCount ("raw i", 987);
+  c.reset ();
+
+  ProcessBanking (db, ctx);
+
+  a = accounts.GetByName ("domob");
+  EXPECT_EQ (a->GetBankingPoints (), 12);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw a"), 56);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw b"), 600);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw i"), 587);
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/banking_tests.hpp
+++ b/src/banking_tests.hpp
@@ -1,0 +1,37 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_BANKING_TESTS_HPP
+#define PXD_BANKING_TESTS_HPP
+
+#include "banking.hpp"
+
+#include "hexagonal/coord.hpp"
+
+namespace pxd
+{
+
+/** A coordinate that is a banking area.  */
+extern const HexCoord BANKING_POS;
+
+/** A coordinate next to it but not a banking area itself.  */
+extern const HexCoord NO_BANKING_POS;
+
+} // namespace pxd
+
+#endif // PXD_BANKING_TESTS_HPP

--- a/src/dynobstacles.cpp
+++ b/src/dynobstacles.cpp
@@ -27,7 +27,8 @@ DynObstacles::DynObstacles (Database& db)
   : red(false), green(false), blue(false)
 {
   CharacterTable tbl(db);
-  tbl.ProcessAllPositions ([this] (const HexCoord& pos, const Faction f)
+  tbl.ProcessAllPositions ([this] (const Database::IdT id, const HexCoord& pos,
+                                   const Faction f)
     {
       AddVehicle (pos, f);
     });

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -298,6 +298,8 @@ template <>
   res["faction"] = FactionToString (a.GetFaction ());
   res["kills"] = IntToJson (a.GetKills ());
   res["fame"] = IntToJson (a.GetFame ());
+  res["banked"] = Convert (a.GetBanked ());
+  res["bankingpoints"] = IntToJson (a.GetBankingPoints ());
 
   return res;
 }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -532,6 +532,31 @@ TEST_F (AccountJsonTests, KillsAndFame)
   })");
 }
 
+TEST_F (AccountJsonTests, BankingData)
+{
+  auto a = tbl.CreateNew ("foo", Faction::RED);
+  a->AddBankingPoints (42);
+  a->GetBanked ().AddFungibleCount ("raw i", 5);
+  a.reset ();
+
+  ExpectStateJson (R"({
+    "accounts":
+      [
+        {
+          "name": "foo",
+          "bankingpoints": 42,
+          "banked":
+            {
+              "fungible":
+                {
+                  "raw i": 5
+                }
+            }
+        }
+      ]
+  })");
+}
+
 /* ************************************************************************** */
 
 class GroundLootJsonTests : public GameStateJsonTests

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -18,6 +18,7 @@
 
 #include "logic.hpp"
 
+#include "banking.hpp"
 #include "combat.hpp"
 #include "dynobstacles.hpp"
 #include "mining.hpp"
@@ -118,6 +119,8 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
 
   ProcessAllMining (db, rnd, ctx);
   ProcessAllMovement (db, dyn, ctx);
+
+  ProcessBanking (db, ctx);
 
   FindCombatTargets (db, rnd);
 

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -18,6 +18,7 @@
 
 #include "logic.hpp"
 
+#include "banking_tests.hpp"
 #include "fame_tests.hpp"
 #include "params.hpp"
 #include "prospecting.hpp"
@@ -29,6 +30,7 @@
 #include "database/damagelists.hpp"
 #include "database/dbtest.hpp"
 #include "database/faction.hpp"
+#include "database/inventory.hpp"
 #include "database/region.hpp"
 #include "hexagonal/coord.hpp"
 #include "mapdata/basemap.hpp"
@@ -65,10 +67,11 @@ protected:
 
   AccountsTable accounts;
   CharacterTable characters;
+  GroundLootTable groundLoot;
   RegionsTable regions;
 
   PXLogicTests ()
-    : accounts(db), characters(db), regions(db)
+    : accounts(db), characters(db), groundLoot(db), regions(db)
   {
     InitialisePrizes (db, ctx.Params ());
   }
@@ -743,6 +746,76 @@ TEST_F (PXLogicTests, MiningWhenReprospected)
   EXPECT_FALSE (c->GetProto ().mining ().active ());
   c.reset ();
   EXPECT_FALSE (regions.GetById (region)->GetProto ().has_prospection ());
+}
+
+TEST_F (PXLogicTests, BankingFromPickupOrMining)
+{
+  const auto region = ctx.Map ().Regions ().GetRegionId (BANKING_POS);
+  auto r = regions.GetById (region);
+  r->MutableProto ().mutable_prospection ()->set_resource ("foo");
+  r->SetResourceLeft (1);
+  r.reset ();
+
+  auto c = CreateCharacter ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 1);
+  c->SetPosition (BANKING_POS);
+  c->MutableProto ().mutable_combat_data ();
+  c->MutableProto ().mutable_mining ()->mutable_rate ()->set_min (1);
+  c->MutableProto ().mutable_mining ()->mutable_rate ()->set_max (1);
+  c->MutableProto ().mutable_mining ()->set_active (true);
+  c->MutableProto ().set_cargo_space (100);
+  c.reset ();
+
+  auto l = groundLoot.GetByCoord (BANKING_POS);
+  l->GetInventory ().AddFungibleCount ("bar", 2);
+  l.reset ();
+
+  UpdateState (R"([
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"pu": {"f": {"foo": 10, "bar": 10}}}}}
+    }
+  ])");
+
+  EXPECT_TRUE (characters.GetById (1)->GetInventory ().IsEmpty ());
+  EXPECT_EQ (regions.GetById (region)->GetResourceLeft (), 0);
+  EXPECT_TRUE (groundLoot.GetByCoord (BANKING_POS)->GetInventory ().IsEmpty ());
+
+  auto a = accounts.GetByName ("domob");
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("foo"), 1);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("bar"), 2);
+}
+
+TEST_F (PXLogicTests, BankingAndMovement)
+{
+  auto c = CreateCharacter ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 1);
+  c->GetInventory ().AddFungibleCount ("foo", 1);
+  c->SetPosition (NO_BANKING_POS);
+  c->MutableProto ().mutable_combat_data ();
+  c->MutableProto ().set_cargo_space (100);
+  c->MutableProto ().set_speed (2'000);
+  auto* wp = c->MutableProto ().mutable_movement ()->mutable_waypoints ();
+  SetRepeatedCoords ({BANKING_POS, NO_BANKING_POS}, *wp);
+  c.reset ();
+
+  /* This update should move the character briefly through the banking area,
+     but without pausing there.  No banking will take place.  */
+  UpdateState ("[]");
+  EXPECT_FALSE (characters.GetById (1)->GetInventory ().IsEmpty ());
+  EXPECT_TRUE (accounts.GetByName ("domob")->GetBanked ().IsEmpty ());
+
+  c = characters.GetById (1);
+  wp = c->MutableProto ().mutable_movement ()->mutable_waypoints ();
+  SetRepeatedCoords ({BANKING_POS}, *wp);
+  c.reset ();
+
+  /* Now we move into the banking area and stay there.  This should bank
+     right after processing movement.  */
+  UpdateState ("[]");
+  EXPECT_TRUE (characters.GetById (1)->GetInventory ().IsEmpty ());
+  auto a = accounts.GetByName ("domob");
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("foo"), 1);
 }
 
 /* ************************************************************************** */

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -136,6 +136,43 @@ Params::ProspectingPrizes () const
     }
 }
 
+bool
+Params::IsBankingArea (const HexCoord& pos) const
+{
+  static const HexCoord centres[] =
+    {
+      HexCoord (-125, 810),
+      HexCoord (-1'301, 902),
+      HexCoord (-637, -291),
+    };
+  static constexpr HexCoord::IntT maxDist = 50;
+
+  for (const auto& c : centres)
+    if (HexCoord::DistanceL1 (pos, c) <= maxDist)
+      return true;
+
+  return false;
+}
+
+const Params::BankingSetData&
+Params::BankingSet () const
+{
+  static const BankingSetData data =
+    {
+      {"raw a", 200},
+      {"raw b", 200},
+      {"raw c", 200},
+      {"raw d", 200},
+      {"raw e", 200},
+      {"raw f", 200},
+      {"raw g", 200},
+      {"raw h", 200},
+      {"raw i", 200},
+    };
+
+  return data;
+}
+
 HexCoord
 Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
 {

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -23,10 +23,12 @@
 
 #include "hexagonal/coord.hpp"
 #include "database/faction.hpp"
+#include "database/inventory.hpp"
 #include "proto/character.pb.h"
 
 #include <xayagame/gamelogic.hpp>
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -67,6 +69,12 @@ public:
     unsigned probability;
 
   };
+
+  /**
+   * Raw data representing the amounts of each resource needed to complete
+   * a "banking set".
+   */
+  using BankingSetData = std::unordered_map<std::string, Inventory::QuantityT>;
 
   /**
    * Constructs an instance based on the given situation.
@@ -133,6 +141,16 @@ public:
    * demo competition.
    */
   const std::vector<PrizeData>& ProspectingPrizes () const;
+
+  /**
+   * Returns true if the given location is a banking area.
+   */
+  bool IsBankingArea (const HexCoord& pos) const;
+
+  /**
+   * Returns the data about our banking set.
+   */
+  const BankingSetData& BankingSet () const;
 
   /**
    * Returns the spawn centre and radius for the given faction.


### PR DESCRIPTION
This implements banking as described in #60.  There are three banking areas (L1 balls of radius 50 around the obelisks on the map).  Whenever a character enters them or is inside at the end of block processing, all their inventory is moved to a "banked" inventory associated with the owner account.

When the banked inventory has one or more complete sets of resources (200 of each "raw" item), those are exchanged for a "banking point".