### PR TITLE
Remove competition end time for prizes

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -93,13 +93,6 @@ Params::ProspectionExpiryBlocks () const
     }
 }
 
-int64_t
-Params::CompetitionEndTime () const
-{
-  /* 2019-10-15, 14:00 UTC */
-  return 1571148000;
-}
-
 namespace
 {
 

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -132,11 +132,6 @@ public:
   unsigned ProspectionExpiryBlocks () const;
 
   /**
-   * UNIX timestamp of the end time when prospecting prizes are given out.
-   */
-  int64_t CompetitionEndTime () const;
-
-  /**
    * Returns the ordered list of available prizes for prospecting in the
    * demo competition.
    */

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -117,12 +117,6 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
   prosp->set_resource (type);
   r->SetResourceLeft (amount);
 
-  if (ctx.Timestamp () > ctx.Params ().CompetitionEndTime ())
-    {
-      LOG (INFO) << "Competition is over, no prizes can be found";
-      return;
-    }
-
   if (!ctx.Params ().CanWinPrizesAt (pos))
     {
       LOG (INFO) << "No prizes can be won at " << pos;

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -34,11 +34,6 @@ namespace pxd
 namespace
 {
 
-/** Timestamp before the competition end.  */
-constexpr int64_t TIME_IN_COMPETITION = 1571148000;
-/** Timestamp after the competition end.  */
-constexpr int64_t TIME_AFTER_COMPETITION = TIME_IN_COMPETITION + 1;
-
 /** Position where prizes can be won.  */
 const HexCoord POS_WITH_PRIZES(3'000, 0);
 /** Positions where prizes cannot be won.  */
@@ -131,7 +126,6 @@ protected:
   FinishProspectingTests ()
     : characters(db), regions(db)
   {
-    ctx.SetTimestamp (TIME_IN_COMPETITION);
     ctx.SetChain (xaya::Chain::REGTEST);
     InitialisePrizes (db, ctx.Params ());
 
@@ -270,21 +264,6 @@ TEST_F (FinishProspectingTests, Prizes)
   EXPECT_GE (foundMap["silver"], 50);
   EXPECT_LE (foundMap["silver"], 150);
   EXPECT_EQ (foundMap["bronze"], 1);
-}
-
-TEST_F (FinishProspectingTests, NoPrizesAfterEnd)
-{
-  constexpr unsigned trials = 1'000;
-
-  ctx.SetTimestamp (TIME_AFTER_COMPETITION);
-  const auto id = characters.CreateNew ("domob", Faction::RED)->GetId ();
-
-  for (unsigned i = 0; i < trials; ++i)
-    ProspectAndClear (characters.GetById (id), POS_WITH_PRIZES);
-
-  Prizes prizeTable(db);
-  for (const auto& p : ctx.Params ().ProspectingPrizes ())
-    EXPECT_EQ (prizeTable.GetFound (p.name), 0);
 }
 
 TEST_F (FinishProspectingTests, NoPrizesInCentre)


### PR DESCRIPTION
For the first competition, we introduced an "end time" in the GSP, after which no prizes could be found anymore.  For the second competition, this is mostly irrelevant, since banking the prizes is what counts (not finding them).

For simplicity this change removes the end-time concept completely.  We will use a snapshot of the exact game state at the competition end block anyway to determine the outcome.