### PR TITLE
Track "start mining" pending moves

### DIFF
--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -543,6 +543,13 @@ MoveProcessor::MaybeStartMining (Character& c, const Json::Value& upd)
       return;
     }
 
+  if (c.GetBusy () > 0)
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId () << " is busy, can't mine";
+      return;
+    }
+
   if (c.GetProto ().has_movement ())
     {
       LOG (WARNING)

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -268,6 +268,74 @@ BaseMoveProcessor::ParseCharacterProspecting (const Character& c,
   return CanProspectRegion (c, *regions.GetById (regionId), ctx);
 }
 
+bool
+BaseMoveProcessor::ParseCharacterMining (const Character& c,
+                                         const Json::Value& upd,
+                                         Database::IdT& regionId)
+{
+  CHECK (upd.isObject ());
+  const auto& cmd = upd["mine"];
+  if (!cmd.isObject ())
+    return false;
+
+  if (!cmd.empty ())
+    {
+      LOG (WARNING)
+          << "Invalid mining command for character " << c.GetId ()
+          << ": " << cmd;
+      return false;
+    }
+
+  const auto& pos = c.GetPosition ();
+  regionId = ctx.Map ().Regions ().GetRegionId (pos);
+  VLOG (1)
+      << "Character " << c.GetId ()
+      << " wants to start mining region " << regionId;
+
+  if (!c.GetProto ().has_mining ())
+    {
+      LOG (WARNING) << "Character " << c.GetId () << " can't mine";
+      return false;
+    }
+
+  if (c.GetBusy () > 0)
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId () << " is busy, can't mine";
+      return false;
+    }
+
+  if (c.GetProto ().has_movement ())
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId () << " can't mine while it is moving";
+      return false;
+    }
+
+  auto r = regions.GetById (regionId);
+  const auto& pbRegion = r->GetProto ();
+  if (!pbRegion.has_prospection ())
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId ()
+          << " can't mine in region " << regionId << " which is not prospected";
+      return false;
+    }
+
+  const auto left = r->GetResourceLeft ();
+  if (left == 0)
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId ()
+          << " can't mine in region " << regionId
+          << " which has no resource left";
+      return false;
+    }
+  CHECK_GT (left, 0);
+
+  return true;
+}
+
 /* ************************************************************************** */
 
 void
@@ -518,69 +586,13 @@ MoveProcessor::MaybeStartProspecting (Character& c, const Json::Value& upd)
 void
 MoveProcessor::MaybeStartMining (Character& c, const Json::Value& upd)
 {
-  CHECK (upd.isObject ());
-  const auto& cmd = upd["mine"];
-  if (!cmd.isObject ())
+  Database::IdT regionId;
+  if (!ParseCharacterMining (c, upd, regionId))
     return;
 
-  if (!cmd.empty ())
-    {
-      LOG (WARNING)
-          << "Invalid mining command for character " << c.GetId ()
-          << ": " << cmd;
-      return;
-    }
-
-  const auto& pos = c.GetPosition ();
-  const auto regionId = ctx.Map ().Regions ().GetRegionId (pos);
   VLOG (1)
-      << "Character " << c.GetId ()
-      << " wants to start mining region " << regionId;
-
-  if (!c.GetProto ().has_mining ())
-    {
-      LOG (WARNING) << "Character " << c.GetId () << " can't mine";
-      return;
-    }
-
-  if (c.GetBusy () > 0)
-    {
-      LOG (WARNING)
-          << "Character " << c.GetId () << " is busy, can't mine";
-      return;
-    }
-
-  if (c.GetProto ().has_movement ())
-    {
-      LOG (WARNING)
-          << "Character " << c.GetId () << " can't mine while it is moving";
-      return;
-    }
-
-  auto r = regions.GetById (regionId);
-  const auto& pbRegion = r->GetProto ();
-  if (!pbRegion.has_prospection ())
-    {
-      LOG (WARNING)
-          << "Character " << c.GetId ()
-          << " can't mine in region " << regionId << " which is not prospected";
-      return;
-    }
-
-  const auto left = r->GetResourceLeft ();
-  if (left == 0)
-    {
-      LOG (WARNING)
-          << "Character " << c.GetId ()
-          << " can't mine in region " << regionId
-          << " which has no resource left";
-      return;
-    }
-  CHECK_GT (left, 0);
-
-  VLOG (1)
-      << "Starting to mine " << pbRegion.prospection ().resource ()
-      << " with character " << c.GetId ();
+      << "Starting to mine with character " << c.GetId ()
+      << " in region " << regionId;
   c.MutableProto ().mutable_mining ()->set_active (true);
 }
 

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -109,6 +109,13 @@ protected:
                                   Database::IdT& regionId);
 
   /**
+   * Parses and verifies a potential command to start mining.  Returns true
+   * if the character will start mining, i.e. all looks valid.
+   */
+  bool ParseCharacterMining (const Character& c, const Json::Value& upd,
+                             Database::IdT& regionId);
+
+  /**
    * Parses and verifies a potential character creation as part of the
    * given move.  For all valid creations, PerformCharacterCreation
    * is called with the relevant data.

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -619,6 +619,7 @@ TEST_F (CharacterUpdateTests, WhenBusy)
   auto h = GetTest ();
   h->SetBusy (2);
   h->MutableProto ().mutable_prospection ();
+  h->MutableProto ().mutable_mining ();
   h.reset ();
 
   Process (R"([
@@ -629,6 +630,10 @@ TEST_F (CharacterUpdateTests, WhenBusy)
     {
       "name": "domob",
       "move": {"c": {"1": {"prospect": {}}}}
+    },
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"mine": {}}}}
     }
   ])");
 
@@ -637,6 +642,7 @@ TEST_F (CharacterUpdateTests, WhenBusy)
      then busy would have been set to 10.  */
   EXPECT_EQ (h->GetBusy (), 2);
   EXPECT_FALSE (h->GetProto ().has_movement ());
+  EXPECT_FALSE (h->GetProto ().mining ().active ());
 }
 
 TEST_F (CharacterUpdateTests, BasicWaypoints)

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -249,6 +249,9 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
   if (ParseCharacterProspecting (c, upd, regionId))
     state.AddCharacterProspecting (c, regionId);
 
+  if (ParseCharacterMining (c, upd, regionId))
+    state.AddCharacterMining (c, regionId);
+
   std::vector<HexCoord> wp;
   if (ParseCharacterWaypoints (c, upd, wp))
     {

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -70,6 +70,12 @@ private:
     Database::IdT prospectingRegionId = RegionMap::OUT_OF_MAP;
 
     /**
+     * The ID of the region this character will start mining in.  Set to
+     * RegionMap::OUT_OF_MAP if no mining is being started.
+     */
+    Database::IdT miningRegionId = RegionMap::OUT_OF_MAP;
+
+    /**
      * Returns the JSON representation of the pending state.
      */
     Json::Value ToJson () const;
@@ -126,7 +132,8 @@ public:
    * Updates the state for waypoints found for a character in a pending move.
    *
    * If the character is already pending to start prospecting, then this
-   * will do nothing as a prospecting character cannot move.
+   * will do nothing as a prospecting character cannot move.  If the character
+   * is poised to start mining, then mining will be stopped.
    */
   void AddCharacterWaypoints (const Character& ch,
                               const std::vector<HexCoord>& wp);
@@ -139,6 +146,14 @@ public:
    * waypoints for it (if any).
    */
   void AddCharacterProspecting (const Character& ch, Database::IdT regionId);
+
+  /**
+   * Updates the state of a character to start mining in a given region.
+   *
+   * If the character is moving or going to prospect, then the change
+   * is ignored.
+   */
+  void AddCharacterMining (const Character& ch, Database::IdT regionId);
 
   /**
    * Updates the state for a new pending character creation.


### PR DESCRIPTION
This extends the pending move tracker to also support "start mining" moves.  That way, those can be reported in the frontend as well.

The pending state will also resolve conflicts between waypoints, prospection (i.e. busy) and mining.