### PR TITLE
Track pending drop/pickup moves

### DIFF
--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -93,6 +93,7 @@ class PendingTest (PXTest):
     self.createCharacters ("domob")
     self.createCharacters ("andy")
     c1.sendMove ({"wp": [{"x": 5, "y": -5}]})
+    c1.sendMove ({"pu": {"f": {"foo": 2}}})
 
     sleepSome ()
     self.assertEqual (self.getPendingState (), {
@@ -102,7 +103,7 @@ class PendingTest (PXTest):
             "id": c1.getId (),
             "waypoints": [{"x": 5, "y": -5}],
             "drop": False,
-            "pickup": False,
+            "pickup": True,
           }
         ],
       "newcharacters":
@@ -113,6 +114,7 @@ class PendingTest (PXTest):
     })
 
     c1.sendMove ({"prospect": {}})
+    c1.sendMove ({"drop": {"f": {"foo": 2}}})
     c2 = self.getCharacters ()["miner"]
     c2.sendMove ({"mine": {}})
     sleepSome ()
@@ -122,8 +124,8 @@ class PendingTest (PXTest):
         [
           {
             "id": c1.getId (),
-            "drop": False,
-            "pickup": False,
+            "drop": True,
+            "pickup": True,
             "prospecting": regionProspect,
           },
           {

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -80,6 +80,8 @@ class PendingTest (PXTest):
           {
             "id": c1.getId (),
             "waypoints": [],
+            "drop": False,
+            "pickup": False,
           }
         ],
       "newcharacters":
@@ -99,6 +101,8 @@ class PendingTest (PXTest):
           {
             "id": c1.getId (),
             "waypoints": [{"x": 5, "y": -5}],
+            "drop": False,
+            "pickup": False,
           }
         ],
       "newcharacters":
@@ -118,10 +122,14 @@ class PendingTest (PXTest):
         [
           {
             "id": c1.getId (),
+            "drop": False,
+            "pickup": False,
             "prospecting": regionProspect,
           },
           {
             "id": c2.getId (),
+            "drop": False,
+            "pickup": False,
             "mining": regionMining,
           },
         ],

--- a/gametest/prospecting_basic.py
+++ b/gametest/prospecting_basic.py
@@ -206,7 +206,12 @@ class BasicProspectingTest (PXTest):
     c = self.getCharacters ()["target"]
     c.sendMove ({"prospect": {}})
     self.assertEqual (self.getPendingState ()["characters"], [
-      {"id": c.getId (), "prospecting": r.getId ()},
+      {
+        "id": c.getId (),
+        "drop": False,
+        "pickup": False,
+        "prospecting": r.getId (),
+      },
     ])
     self.generate (1)
     self.assertEqual (self.getCharacters ()["target"].getBusy ()["operation"],

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -255,13 +255,21 @@ ParseFungibleQuantities (const Json::Value& obj)
       CHECK (keyVal.isString ());
       const std::string key = keyVal.asString ();
 
-      if (!it->isUInt64 () || it->asUInt64 () > MAX_ITEM_QUANTITY)
+      if (!it->isUInt64 ())
         {
           LOG (WARNING)
               << "Invalid fungible amount for item " << key << ": " << *it;
           continue;
         }
       const Inventory::QuantityT cnt = it->asUInt64 ();
+
+      CHECK_GE (cnt, 0);
+      if (cnt == 0 || cnt > MAX_ITEM_QUANTITY)
+        {
+          LOG (WARNING)
+              << "Invalid fungible amount for item " << key << ": " << cnt;
+          continue;
+        }
 
       const auto ins = res.emplace (key, cnt);
       CHECK (ins.second) << "Duplicate key: " << key;

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -34,6 +34,9 @@
 
 #include <json/json.h>
 
+#include <map>
+#include <string>
+
 namespace pxd
 {
 
@@ -44,6 +47,9 @@ namespace pxd
  * large enough to not be a restriction in practice (1k tiles per block).
  */
 static constexpr unsigned MAX_CHOSEN_SPEED = 1'000'000;
+
+/** Amounts of fungible items.  */
+using FungibleAmountMap = std::map<std::string, Inventory::QuantityT>;
 
 /**
  * Base class for MoveProcessor (handling confirmed moves) and PendingProcessor
@@ -99,6 +105,12 @@ protected:
   static bool ParseCharacterWaypoints (const Character& c,
                                        const Json::Value& upd,
                                        std::vector<HexCoord>& wp);
+
+  /**
+   * Parses and validates the content of a drop or pick-up character command.
+   * Returns the fungible items and their quantities to drop or pick up.
+   */
+  static FungibleAmountMap ParseDropPickupFungible (const Json::Value& cmd);
 
   /**
    * Parses and verifies a potential prospecting command.  Returns true if the

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -82,6 +82,20 @@ PendingState::AddCharacterWaypoints (const Character& ch,
 }
 
 void
+PendingState::AddCharacterDrop (const Character& ch)
+{
+  VLOG (1) << "Adding pending item drop for character " << ch.GetId ();
+  GetCharacterState (ch).drop = true;
+}
+
+void
+PendingState::AddCharacterPickup (const Character& ch)
+{
+  VLOG (1) << "Adding pending item pickup for character " << ch.GetId ();
+  GetCharacterState (ch).pickup = true;
+}
+
+void
 PendingState::AddCharacterProspecting (const Character& ch,
                                        const Database::IdT regionId)
 {
@@ -182,6 +196,9 @@ PendingState::CharacterState::ToJson () const
 
       res["waypoints"] = wpJson;
     }
+
+  res["drop"] = drop;
+  res["pickup"] = pickup;
 
   if (prospectingRegionId != RegionMap::OUT_OF_MAP)
     res["prospecting"] = IntToJson (prospectingRegionId);

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -269,6 +269,14 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
   if (ParseCharacterMining (c, upd, regionId))
     state.AddCharacterMining (c, regionId);
 
+  FungibleAmountMap items;
+  items = ParseDropPickupFungible (upd["pu"]);
+  if (!items.empty ())
+    state.AddCharacterPickup (c);
+  items = ParseDropPickupFungible (upd["drop"]);
+  if (!items.empty ())
+    state.AddCharacterDrop (c);
+
   std::vector<HexCoord> wp;
   if (ParseCharacterWaypoints (c, upd, wp))
     {

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -63,6 +63,12 @@ private:
      */
     std::unique_ptr<std::vector<HexCoord>> wp;
 
+    /** Set to true if there is a pending pickup command.  */
+    bool pickup = false;
+
+    /** Set to true if there is a pending drop command.  */
+    bool drop = false;
+
     /**
      * The ID of the region this character is starting to prospect.  Set to
      * RegionMap::OUT_OF_MAP if no prospection is coming.
@@ -137,6 +143,16 @@ public:
    */
   void AddCharacterWaypoints (const Character& ch,
                               const std::vector<HexCoord>& wp);
+
+  /**
+   * Marks the character state as having a pending drop command.
+   */
+  void AddCharacterDrop (const Character& ch);
+
+  /**
+   * Marks the character state as having a pending pickup command.
+   */
+  void AddCharacterPickup (const Character& ch);
 
   /**
    * Updates the state of a character to include a pending prospecting

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -87,6 +87,8 @@ TEST_F (PendingStateTests, Clear)
 
   auto h = characters.CreateNew ("domob", Faction::RED);
   state.AddCharacterWaypoints (*h, {});
+  state.AddCharacterDrop (*h);
+  state.AddCharacterPickup (*h);
   h.reset ();
 
   ExpectStateJson (R"(
@@ -139,6 +141,38 @@ TEST_F (PendingStateTests, Waypoints)
           {
             "id": 3,
             "waypoints": []
+          }
+        ]
+    }
+  )");
+}
+
+TEST_F (PendingStateTests, DropPickup)
+{
+  auto c1 = characters.CreateNew ("domob", Faction::RED);
+  auto c2 = characters.CreateNew ("domob", Faction::RED);
+  ASSERT_EQ (c1->GetId (), 1);
+  ASSERT_EQ (c2->GetId (), 2);
+
+  state.AddCharacterDrop (*c1);
+  state.AddCharacterPickup (*c2);
+
+  c1.reset ();
+  c2.reset ();
+
+  ExpectStateJson (R"(
+    {
+      "characters":
+        [
+          {
+            "id": 1,
+            "drop": true,
+            "pickup": false
+          },
+          {
+            "id": 2,
+            "drop": false,
+            "pickup": true
           }
         ]
     }


### PR DESCRIPTION
Add tracking of drop and pickup moves to the pending processor.  For now, we only track whether or not a given character has some drop/pickup, but not the details (e.g. what is being dropped/picked up).  We also only validate the actual JSON move, but do not check e.g. if the item is there or cargo allows it.