### PR TITLE
Adjust banking sets and resource base amounts

### DIFF
--- a/gametest/banking.py
+++ b/gametest/banking.py
@@ -25,10 +25,6 @@ from pxtest import PXTest
 
 class BankingTest (PXTest):
 
-  def addArguments (self, parser):
-    parser.add_argument ("--bank_set", default=False, action="store_true",
-                         help="bank a full set of resources (slow)")
-
   def run (self):
     self.collectPremine ()
 
@@ -77,22 +73,21 @@ class BankingTest (PXTest):
       "silver prize": 2,
     })
 
-    if self.args.bank_set:
-      self.testResourceSets ()
+    self.testResourceSets ()
     self.testReorg ()
 
   def testResourceSets (self):
     self.mainLogger.info ("Banking resources for sets...")
     self.dropLoot (self.bankPos, {
-      "raw a": 205,
-      "raw b": 200,
-      "raw c": 200,
-      "raw d": 200,
-      "raw e": 200,
-      "raw f": 200,
-      "raw g": 200,
-      "raw h": 200,
-      "raw i": 200,
+      "raw a": 25,
+      "raw b": 20,
+      "raw c": 20,
+      "raw d": 20,
+      "raw e": 20,
+      "raw f": 20,
+      "raw g": 20,
+      "raw h": 20,
+      "raw i": 20,
     })
     self.generate (1)
 

--- a/gametest/prospecting_resources.py
+++ b/gametest/prospecting_resources.py
@@ -49,7 +49,11 @@ class ProspectingResourcesTest (PXTest):
 
     r = self.getRegionAt (pos)
     self.assertEqual (r.data["prospection"]["name"], "domob")
-    return r.getResource ()
+
+    typ, amount = r.getResource ()
+    self.log.info ("Found %d of %s at (%d, %d)"
+                    % (amount, typ, pos["x"], pos["y"]))
+    return typ, amount
 
   def run (self):
     self.collectPremine ()
@@ -90,7 +94,6 @@ class ProspectingResourcesTest (PXTest):
       r = self.getRegionAt (I_AND_H)
       self.assertEqual (r.data["prospection"]["name"], "domob")
       typ, amount = r.getResource ()
-      assert amount > 0
 
 
 if __name__ == "__main__":

--- a/proto/roconfig/resourcedist.pb.text
+++ b/proto/roconfig/resourcedist.pb.text
@@ -20,47 +20,47 @@ resource_dist:
 base_amounts:
   {
     key: "raw a"
-    value: 700
+    value: 7
   }
 base_amounts:
   {
     key: "raw b"
-    value: 40
+    value: 7
   }
 base_amounts:
   {
     key: "raw c"
-    value: 14
+    value: 7
   }
 base_amounts:
   {
     key: "raw d"
-    value: 13
+    value: 7
   }
 base_amounts:
   {
     key: "raw e"
-    value: 12
+    value: 7
   }
 base_amounts:
   {
     key: "raw f"
-    value: 8
+    value: 7
   }
 base_amounts:
   {
     key: "raw g"
-    value: 5
+    value: 7
   }
 base_amounts:
   {
     key: "raw h"
-    value: 2
+    value: 7
   }
 base_amounts:
   {
     key: "raw i"
-    value: 1
+    value: 7
   }
 
 areas:

--- a/src/banking_tests.cpp
+++ b/src/banking_tests.cpp
@@ -113,17 +113,17 @@ TEST_F (BankingTests, BankingPoints)
   auto c = characters.CreateNew ("domob", Faction::RED);
   c->SetPosition (BANKING_POS);
   c->MutableProto ().set_cargo_space (5'000);
-  c->GetInventory ().SetFungibleCount ("raw a", 456);
-  c->GetInventory ().SetFungibleCount ("raw i", 987);
+  c->GetInventory ().SetFungibleCount ("raw a", 45);
+  c->GetInventory ().SetFungibleCount ("raw i", 98);
   c.reset ();
 
   ProcessBanking (db, ctx);
 
   a = accounts.GetByName ("domob");
   EXPECT_EQ (a->GetBankingPoints (), 12);
-  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw a"), 56);
-  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw b"), 600);
-  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw i"), 587);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw a"), 5);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw b"), 960);
+  EXPECT_EQ (a->GetBanked ().GetFungibleCount ("raw i"), 58);
 }
 
 } // anonymous namespace

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -160,15 +160,15 @@ Params::BankingSet () const
 {
   static const BankingSetData data =
     {
-      {"raw a", 200},
-      {"raw b", 200},
-      {"raw c", 200},
-      {"raw d", 200},
-      {"raw e", 200},
-      {"raw f", 200},
-      {"raw g", 200},
-      {"raw h", 200},
-      {"raw i", 200},
+      {"raw a", 20},
+      {"raw b", 20},
+      {"raw c", 20},
+      {"raw d", 20},
+      {"raw e", 20},
+      {"raw f", 20},
+      {"raw g", 20},
+      {"raw h", 20},
+      {"raw i", 20},
     };
 
   return data;


### PR DESCRIPTION
As discussed in #69, this adjusts the amount of resources to find for a "mining point" to 20 each (instead of 200).  Also the base amount for finding resources is set to 7 (i.e. 7-14 units are found per region), independently of the type of resource.