### PR TITLE
Allow retrieving only recently modified regions

### DIFF
--- a/database/region.cpp
+++ b/database/region.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,19 +21,29 @@
 namespace pxd
 {
 
-Region::Region (Database& d, const RegionMap::IdT i)
-  : db(d), id(i), resourceLeft(0), dirtyFields(false)
+Region::Region (Database& d, const unsigned h, const RegionMap::IdT i)
+  : db(d), currentHeight(h), id(i), resourceLeft(0), dirtyFields(false)
 {
   VLOG (1) << "Created instance for empty region with ID " << id;
   data.SetToDefault ();
 }
 
-Region::Region (Database& d, const Database::Result<RegionResult>& res)
-  : db(d), dirtyFields(false)
+Region::Region (Database& d, const unsigned h,
+                const Database::Result<RegionResult>& res)
+  : db(d), currentHeight(h), dirtyFields(false)
 {
   id = res.Get<RegionResult::id> ();
   resourceLeft = res.Get<RegionResult::resourceleft> ();
   data = res.GetProto<RegionResult::proto> ();
+
+  if (currentHeight != RegionsTable::HEIGHT_READONLY)
+    {
+      const auto modified = res.Get<RegionResult::modifiedheight> ();
+      LOG_IF (WARNING, currentHeight < modified)
+          << "Region " << id << " is has current block height " << currentHeight
+          << " set, but was last modified at height " << modified
+          << "!  This is probably fine in unit tests";
+    }
 
   VLOG (1) << "Created region data for ID " << id << " from database result";
 }
@@ -43,16 +53,19 @@ Region::~Region ()
   if (data.IsDirty ())
     {
       VLOG (1) << "Updating dirty region " << id << " including proto data";
+      CHECK_NE (currentHeight, RegionsTable::HEIGHT_READONLY)
+          << "Region table is readonly";
 
       auto stmt = db.Prepare (R"(
         INSERT OR REPLACE INTO `regions`
-          (`id`, `resourceleft`, `proto`)
-          VALUES (?1, ?2, ?3)
+          (`id`, `modifiedheight`, `resourceleft`, `proto`)
+          VALUES (?1, ?2, ?3, ?4)
       )");
 
       stmt.Bind (1, id);
-      stmt.Bind (2, resourceLeft);
-      stmt.BindProto (3, data);
+      stmt.Bind (2, currentHeight);
+      stmt.Bind (3, resourceLeft);
+      stmt.BindProto (4, data);
       stmt.Execute ();
 
       return;
@@ -61,15 +74,18 @@ Region::~Region ()
   if (dirtyFields)
     {
       VLOG (1) << "Updating dirty region " << id << " only in non-proto fields";
+      CHECK_NE (currentHeight, RegionsTable::HEIGHT_READONLY)
+          << "Region table is readonly";
 
       auto stmt = db.Prepare (R"(
         UPDATE `regions`
-          SET `resourceleft` = ?2
+          SET `modifiedheight` = ?2, `resourceleft` = ?3
           WHERE `id` = ?1
       )");
 
       stmt.Bind (1, id);
-      stmt.Bind (2, resourceLeft);
+      stmt.Bind (2, currentHeight);
+      stmt.Bind (3, resourceLeft);
       stmt.Execute ();
 
       return;
@@ -98,7 +114,7 @@ Region::SetResourceLeft (const Inventory::QuantityT value)
 RegionsTable::Handle
 RegionsTable::GetFromResult (const Database::Result<RegionResult>& res)
 {
-  return Handle (new Region (db, res));
+  return Handle (new Region (db, height, res));
 }
 
 RegionsTable::Handle
@@ -109,7 +125,7 @@ RegionsTable::GetById (const RegionMap::IdT id)
   auto res = stmt.Query<RegionResult> ();
 
   if (!res.Step ())
-    return Handle (new Region (db, id));
+    return Handle (new Region (db, height, id));
 
   auto r = GetFromResult (res);
   CHECK (!res.Step ());
@@ -120,6 +136,20 @@ Database::Result<RegionResult>
 RegionsTable::QueryNonTrivial ()
 {
   auto stmt = db.Prepare ("SELECT * FROM `regions` ORDER BY `id`");
+  return stmt.Query<RegionResult> ();
+}
+
+Database::Result<RegionResult>
+RegionsTable::QueryModifiedSince (const unsigned h)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `regions`
+      WHERE `modifiedheight` >= ?1
+      ORDER BY `id`
+  )");
+  stmt.Bind (1, h);
+
   return stmt.Query<RegionResult> ();
 }
 

--- a/database/region.hpp
+++ b/database/region.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -137,13 +137,30 @@ private:
   /** The Database reference for creating queries.  */
   Database& db;
 
+  /**
+   * Current block height.  This is used to set the "last changed height"
+   * for modified regions.
+   */
+  unsigned height;
+
 public:
+
+  /**
+   * Block height to pass if we just want a read-only view of regions and
+   * are not processing a block at the moment.
+   */
+  static constexpr unsigned HEIGHT_READONLY = 0;
 
   /** Movable handle to a region instance.  */
   using Handle = std::unique_ptr<Region>;
 
-  explicit RegionsTable (Database& d)
-    : db(d)
+  /**
+   * Constructs the table.  In order to make modifications, the current block
+   * height must be set.  If only data needs to be read, then it is possible
+   * to set the height to HEIGHT_READONLY.
+   */
+  explicit RegionsTable (Database& d, const unsigned h)
+    : db(d), height(h)
   {}
 
   RegionsTable () = delete;

--- a/database/region.hpp
+++ b/database/region.hpp
@@ -35,8 +35,9 @@ namespace pxd
 struct RegionResult : public Database::ResultType
 {
   RESULT_COLUMN (int64_t, id, 1);
-  RESULT_COLUMN (int64_t, resourceleft, 2);
-  RESULT_COLUMN (pxd::proto::RegionData, proto, 3);
+  RESULT_COLUMN (int64_t, modifiedheight, 2);
+  RESULT_COLUMN (int64_t, resourceleft, 3);
+  RESULT_COLUMN (pxd::proto::RegionData, proto, 4);
 };
 
 /**
@@ -53,6 +54,12 @@ private:
   /** Database reference this belongs to.  */
   Database& db;
 
+  /**
+   * Current block height.  When the region is actually modified, we use this
+   * to set the last modified block height in the database.
+   */
+  unsigned currentHeight;
+
   /** The ID of the region.  */
   RegionMap::IdT id;
 
@@ -68,13 +75,14 @@ private:
   /**
    * Constructs an instance with "default / empty" data for the given ID.
    */
-  explicit Region (Database& d, RegionMap::IdT);
+  explicit Region (Database& d, unsigned h, RegionMap::IdT);
 
   /**
    * Constructs an instance based on the given DB result set.  The result
    * set should be constructed by a RegionsTable.
    */
-  explicit Region (Database& d, const Database::Result<RegionResult>& res);
+  explicit Region (Database& d, unsigned h,
+                   const Database::Result<RegionResult>& res);
 
   friend class RegionsTable;
 
@@ -183,6 +191,12 @@ public:
    * GetFromResult.
    */
   Database::Result<RegionResult> QueryNonTrivial ();
+
+  /**
+   * Queries the database for all regions that were modified later (or equal)
+   * to the given block height.
+   */
+  Database::Result<RegionResult> QueryModifiedSince (unsigned h);
 
 };
 

--- a/database/region_tests.cpp
+++ b/database/region_tests.cpp
@@ -94,6 +94,23 @@ TEST_F (RegionTests, DefaultNotWritten)
   EXPECT_FALSE (res.Step ());
 }
 
+TEST_F (RegionTests, ReadOnlyTable)
+{
+  RegionsTable ro(db, RegionsTable::HEIGHT_READONLY);
+
+  auto r = tbl.GetById (42);
+  r->MutableProto ().mutable_prospection ()->set_resource ("foo");
+  r->SetResourceLeft (10);
+  r.reset ();
+  EXPECT_EQ (ro.GetById (42)->GetResourceLeft (), 10);
+
+  tbl.GetById (42)->SetResourceLeft (1);
+  EXPECT_EQ (ro.GetById (42)->GetResourceLeft (), 1);
+
+  EXPECT_DEATH (ro.GetById (42)->SetResourceLeft (5), "readonly");
+  EXPECT_DEATH (ro.GetById (42)->MutableProto (), "readonly");
+}
+
 using RegionsTableTests = RegionTests;
 
 TEST_F (RegionsTableTests, QueryNonTrivial)
@@ -111,6 +128,41 @@ TEST_F (RegionsTableTests, QueryNonTrivial)
   ASSERT_TRUE (res.Step ());
   EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 3);
 
+  ASSERT_FALSE (res.Step ());
+}
+
+TEST_F (RegionsTableTests, QueryModifiedSince)
+{
+  auto t = std::make_unique<RegionsTable> (db, 10);
+  t->GetById (1)->MutableProto ();
+
+  t = std::make_unique<RegionsTable> (db, 15);
+  t->GetById (2)->MutableProto ().mutable_prospection ()->set_resource ("foo");
+
+  auto res = tbl.QueryModifiedSince (15);
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 2);
+  ASSERT_FALSE (res.Step ());
+
+  t = std::make_unique<RegionsTable> (db, 20);
+  t->GetById (1)->MutableProto ();
+
+  res = tbl.QueryModifiedSince (20);
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 1);
+  ASSERT_FALSE (res.Step ());
+
+  t = std::make_unique<RegionsTable> (db, 30);
+  t->GetById (2)->SetResourceLeft (10);
+
+  res = tbl.QueryModifiedSince (20);
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 1);
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 2);
+  ASSERT_FALSE (res.Step ());
+
+  res = tbl.QueryModifiedSince (31);
   ASSERT_FALSE (res.Step ());
 }
 

--- a/database/region_tests.cpp
+++ b/database/region_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -36,7 +36,7 @@ protected:
   RegionsTable tbl;
 
   RegionTests ()
-    : tbl(db)
+    : tbl(db, 1'042)
   {}
 
 };

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,5 +1,5 @@
 --  GSP for the Taurion blockchain game
---  Copyright (C) 2019  Autonomous Worlds Ltd
+--  Copyright (C) 2019-2020  Autonomous Worlds Ltd
 --
 --  This program is free software: you can redistribute it and/or modify
 --  it under the terms of the GNU General Public License as published by
@@ -170,6 +170,10 @@ CREATE TABLE IF NOT EXISTS `regions` (
   -- all values are real regions.
   `id` INTEGER PRIMARY KEY,
 
+  -- Block height when it was last modified.  We have an index on this, so that
+  -- we can query only for regions modified recently from the frontend.
+  `modifiedheight` INTEGER NOT NULL,
+
   -- The amount of resources left to be mined.  The type of resource is
   -- defined in the region proto.  The value is undefined for regions that
   -- have not been prospected yet.
@@ -183,6 +187,9 @@ CREATE TABLE IF NOT EXISTS `regions` (
   `proto` BLOB NOT NULL
 
 );
+
+CREATE INDEX IF NOT EXISTS `regions_by_modifiedheight`
+  ON `regions` (`modifiedheight`);
 
 -- =============================================================================
 

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -15,6 +15,7 @@ REGTESTS = \
   godmode.py \
   loot.py \
   mining.py \
+  modifiedregions.py \
   movement.py \
   multiupdate.py \
   nullstate.py \

--- a/gametest/modifiedregions.py
+++ b/gametest/modifiedregions.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests the getregions RPC filtering for only recently modified regions.
+"""
+
+from pxtest import PXTest
+
+
+class ModifiedRegionsTest (PXTest):
+
+  def prospectAt (self, pos):
+    """
+    Prospects the region at the given position, and returns the ID of the
+    region there as well as an "approximate" modified height for the region.
+    """
+
+    data = self.rpc.game.getregionat (coord=pos)
+
+    self.moveCharactersTo ({"prospector": pos})
+    h = self.rpc.xaya.getblockcount ()
+
+    self.getCharacters ()["prospector"].sendMove ({"prospect": {}})
+    self.generate (15)
+
+    return data["id"], h
+
+  def queryRegions (self, h):
+    """
+    Queries the regions since the given height, and returns the set of
+    region IDs in the result set.
+    """
+
+    data = self.getRpc ("getregions", fromheight=h)
+    return set ({r["id"] for r in data})
+
+  def run (self):
+    self.collectPremine ()
+
+    self.initAccount ("prospector", "r")
+    self.createCharacters ("prospector")
+    self.generate (1)
+
+    r1, h1 = self.prospectAt ({"x": 10, "y": 10})
+    r2, h2 = self.prospectAt ({"x": 100, "y": -42})
+    r3, h3 = self.prospectAt ({"x": -10, "y": 50})
+
+    assert r1 != r2
+    assert r1 != r3
+
+    self.assertEqual (self.queryRegions (0), set ([r1, r2, r3]))
+    self.assertEqual (self.queryRegions (h1), set ([r1, r2, r3]))
+    self.assertEqual (self.queryRegions (h2), set ([r2, r3]))
+    self.assertEqual (self.queryRegions (h3), set ([r3]))
+    self.assertEqual (self.queryRegions (1000), set ([]))
+
+
+if __name__ == "__main__":
+  ModifiedRegionsTest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -1,5 +1,5 @@
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -286,7 +286,7 @@ class PXTest (XayaGameTest):
     explicitly present.
     """
 
-    for r in self.getRpc ("getregions"):
+    for r in self.getRpc ("getregions", fromheight=0):
       if r["id"] == regionId:
         return Region (r)
 

--- a/gametest/splitstaterpcs.py
+++ b/gametest/splitstaterpcs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -53,7 +53,7 @@ class SplitStateRpcsTest (PXTest):
     accounts = self.getRpc ("getaccounts")
     characters = self.getRpc ("getcharacters")
     loot = self.getRpc ("getgroundloot")
-    regions = self.getRpc ("getregions")
+    regions = self.getRpc ("getregions", fromheight=0)
     prizes = self.getRpc ("getprizestats")
     assert len (accounts) > 0
     assert len (characters) > 0

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -228,7 +228,7 @@ ProcessKills (Database& db, DamageLists& dl, GroundLootTable& loot,
               const Context& ctx)
 {
   CharacterTable characters(db);
-  RegionsTable regions(db);
+  RegionsTable regions(db, ctx.Height ());
 
   for (const auto& id : dead)
     switch (id.type ())

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -618,7 +618,8 @@ TEST_F (ProcessKillsTests, CancelsProspection)
   c->MutableProto ().mutable_prospection ();
   c.reset ();
 
-  RegionsTable regions(db);
+  ctx.SetHeight (1'042);
+  RegionsTable regions(db, ctx.Height ());
   auto r = regions.GetById (regionId);
   r->MutableProto ().set_prospecting_character (id);
   r.reset ();

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -411,7 +411,7 @@ GameStateJson::GroundLoot ()
 Json::Value
 GameStateJson::Regions ()
 {
-  RegionsTable tbl(db);
+  RegionsTable tbl(db, RegionsTable::HEIGHT_READONLY);
   return ResultsAsArray (tbl, tbl.QueryNonTrivial ());
 }
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -409,10 +409,10 @@ GameStateJson::GroundLoot ()
 }
 
 Json::Value
-GameStateJson::Regions ()
+GameStateJson::Regions (const unsigned h)
 {
   RegionsTable tbl(db, RegionsTable::HEIGHT_READONLY);
-  return ResultsAsArray (tbl, tbl.QueryNonTrivial ());
+  return ResultsAsArray (tbl, tbl.QueryModifiedSince (h));
 }
 
 Json::Value
@@ -423,7 +423,7 @@ GameStateJson::FullState ()
   res["accounts"] = Accounts ();
   res["characters"] = Characters ();
   res["groundloot"] = GroundLoot ();
-  res["regions"] = Regions ();
+  res["regions"] = Regions (0);
   res["prizes"] = PrizeStats ();
 
   return res;

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -90,9 +90,10 @@ public:
   Json::Value GroundLoot ();
 
   /**
-   * Returns the JSON data representing all regions in the game state.
+   * Returns the JSON data representing all regions in the game state which
+   * where modified after the given block height.
    */
-  Json::Value Regions ();
+  Json::Value Regions (unsigned h);
 
   /**
    * Returns the JSON data representing the available and found prizes

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -630,7 +630,7 @@ protected:
   RegionsTable tbl;
 
   RegionJsonTests ()
-    : tbl(db)
+    : tbl(db, 1'042)
   {}
 
 };

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -57,7 +57,7 @@ void
 ProcessBusy (Database& db, xaya::Random& rnd, const Context& ctx)
 {
   CharacterTable characters(db);
-  RegionsTable regions(db);
+  RegionsTable regions(db, ctx.Height ());
 
   auto res = characters.QueryBusyDone ();
   while (res.Step ())

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -61,6 +61,12 @@ private:
 
   TestRandom rnd;
 
+  /**
+   * Block height we use in tests.  This must be consistent between some things
+   * to not trigger assertion failures.
+   */
+  static constexpr unsigned HEIGHT = 42;
+
 protected:
 
   ContextForTesting ctx;
@@ -71,7 +77,7 @@ protected:
   RegionsTable regions;
 
   PXLogicTests ()
-    : accounts(db), characters(db), groundLoot(db), regions(db)
+    : accounts(db), characters(db), groundLoot(db), regions(db, HEIGHT)
   {
     InitialisePrizes (db, ctx.Params ());
   }
@@ -87,7 +93,7 @@ protected:
     blockData["admin"] = Json::Value (Json::arrayValue);
 
     Json::Value meta(Json::objectValue);
-    meta["height"] = 42;
+    meta["height"] = HEIGHT;
     meta["timestamp"] = 1500000000;
     blockData["block"] = meta;
 

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ void
 ProcessAllMining (Database& db, xaya::Random& rnd, const Context& ctx)
 {
   CharacterTable characters(db);
-  RegionsTable regions(db);
+  RegionsTable regions(db, ctx.Height ());
 
   const auto& itemData = RoConfigData ().fungible_items ();
 

--- a/src/mining_tests.cpp
+++ b/src/mining_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -48,9 +48,11 @@ protected:
   const RegionMap::IdT region;
 
   MiningTests ()
-    : characters(db), regions(db),
+    : characters(db), regions(db, 1'042),
       pos(-10, 42), region(ctx.Map ().Regions ().GetRegionId (pos))
   {
+    ctx.SetHeight (1'042);
+
     auto c = GetTest ();
     c->SetPosition (pos);
     auto& pb = c->MutableProto ();

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -34,6 +34,11 @@ namespace pxd
 {
 
 /* ************************************************************************** */
+
+BaseMoveProcessor::BaseMoveProcessor (Database& d, const Context& c)
+  : ctx(c), db(d),
+    accounts(db), characters(db), groundLoot(db), regions(db, ctx.Height ())
+{}
 
 bool
 BaseMoveProcessor::ExtractMoveBasics (const Json::Value& moveObj,

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -82,10 +82,7 @@ protected:
   /** Access to the regions table.  */
   RegionsTable regions;
 
-  explicit BaseMoveProcessor (Database& d, const Context& c)
-    : ctx(c), db(d),
-      accounts(db), characters(db), groundLoot(db), regions(db)
-  {}
+  explicit BaseMoveProcessor (Database& d, const Context& c);
 
   /**
    * Parses some basic stuff from a move JSON object.  This extracts the

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -47,14 +47,13 @@ protected:
 private:
 
   TestRandom rnd;
-  MoveProcessor mvProc;
 
 protected:
 
   AccountsTable accounts;
 
   explicit MoveProcessorTests ()
-    : dyn(db), mvProc(db, dyn, rnd, ctx), accounts(db)
+    : dyn(db), accounts(db)
   {}
 
   /**
@@ -67,6 +66,7 @@ protected:
     std::istringstream in(str);
     in >> cmd;
 
+    MoveProcessor mvProc(db, dyn, rnd, ctx);
     mvProc.ProcessAdmin (cmd);
   }
 
@@ -81,6 +81,7 @@ protected:
     std::istringstream in(str);
     in >> val;
 
+    MoveProcessor mvProc(db, dyn, rnd, ctx);
     mvProc.ProcessAll (val);
   }
 
@@ -99,6 +100,7 @@ protected:
     for (auto& entry : val)
       entry["out"][ctx.Params ().DeveloperAddress ()] = AmountToJson (amount);
 
+    MoveProcessor mvProc(db, dyn, rnd, ctx);
     mvProc.ProcessAll (val);
   }
 
@@ -1094,8 +1096,10 @@ protected:
   const RegionMap::IdT region;
 
   MoveTestsWithRegion ()
-    : regions(db), pos(-10, 42), region(ctx.Map ().Regions ().GetRegionId (pos))
+    : regions(db, 1'042),
+      pos(-10, 42), region(ctx.Map ().Regions ().GetRegionId (pos))
   {
+    ctx.SetHeight (1'042);
     GetTest ()->SetPosition (pos);
   }
 

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -49,7 +49,7 @@ protected:
   RegionsTable regions;
 
   PendingStateTests ()
-    : accounts(db), characters(db), regions(db)
+    : accounts(db), characters(db), regions(db, 1'042)
   {}
 
   /**

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -56,7 +56,7 @@ protected:
   const RegionMap::IdT region;
 
   CanProspectRegionTests ()
-    : characters(db), regions(db),
+    : characters(db), regions(db, 1'042),
       pos(-10, 42), region(ctx.Map ().Regions ().GetRegionId (pos))
   {
     ctx.SetChain (xaya::Chain::REGTEST);
@@ -125,7 +125,7 @@ protected:
   ContextForTesting ctx;
 
   FinishProspectingTests ()
-    : characters(db), regions(db)
+    : characters(db), regions(db, 1'042)
   {
     ctx.SetChain (xaya::Chain::REGTEST);
     InitialisePrizes (db, ctx.Params ());

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -164,13 +164,13 @@ PXRpcServer::getgroundloot ()
 }
 
 Json::Value
-PXRpcServer::getregions ()
+PXRpcServer::getregions (const int fromHeight)
 {
-  LOG (INFO) << "RPC method called: getregions";
+  LOG (INFO) << "RPC method called: getregions " << fromHeight;
   return logic.GetCustomStateData (game,
-    [] (GameStateJson& gsj)
+    [fromHeight] (GameStateJson& gsj)
       {
-        return gsj.Regions ();
+        return gsj.Regions (fromHeight);
       });
 }
 

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -64,7 +64,7 @@ public:
   Json::Value getaccounts () override;
   Json::Value getcharacters () override;
   Json::Value getgroundloot () override;
-  Json::Value getregions () override;
+  Json::Value getregions (int fromHeight) override;
   Json::Value getprizestats () override;
 
   Json::Value findpath (int l1range, const Json::Value& source,

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -46,7 +46,9 @@
   },
   {
     "name": "getregions",
-    "params": {},
+    "params": {
+      "fromheight": 42
+    },
     "returns": {}
   },
   {


### PR DESCRIPTION
With this set of changes, we track the block height at which some region in the database was last modified (through `RegionsTable`).  With this, we can allow `getregions` to return only regions that were "recently modified", which greatly improves performance for frontends that can otherwise not process all regions on every block.