### PR TITLE
Integrate with Charon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ AS_IF([test "x$enable_slow_asserts" = "xyes"], [
 PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES([XAYAGAME], [libxayautil libxayagame])
+PKG_CHECK_MODULES([CHARON], [charon])
 PKG_CHECK_MODULES([SQLITE3], [sqlite3])
 PKG_CHECK_MODULES([JSON], [jsoncpp])
 PKG_CHECK_MODULES([GLOG], [libglog])

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -6,6 +6,7 @@ REGTESTS = \
   banking.py \
   character_limit.py \
   characters.py \
+  charon.py \
   combat_damage.py \
   combat_targets.py \
   damage_lists.py \

--- a/gametest/charon.py
+++ b/gametest/charon.py
@@ -156,6 +156,12 @@ class CharonTest (PXTest):
       self.mainLogger.info ("Testing RPC through Charon...")
       self.assertEqual (client.rpc.getaccounts (), self.rpc.game.getaccounts ())
 
+      self.mainLogger.info ("Testing invalid Charon method call...")
+      self.expectError (-32602, ".*Invalid method parameters.*",
+                        client.rpc.getregions, 42)
+      self.expectError (-32602, ".*Invalid method parameters.*",
+                        client.rpc.getregions, fromheight="not an int")
+
       self.mainLogger.info ("Testing waitforchange...")
       w = Waiter (client.rpc.waitforchange, "")
       w.assertRunning ()

--- a/gametest/charon.py
+++ b/gametest/charon.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests the Charon integration of tauriond.
+"""
+
+from pxtest import PXTest
+
+import jsonrpclib
+
+import logging
+import os
+import os.path
+import shutil
+import socket
+import subprocess
+import threading
+import time
+
+
+# Accounts on chat.xaya.io (XID mainnet) for use with testing.
+# See src/testutils.cpp for more details.
+TEST_ACCOUNTS = [
+  ("xmpptest1", "CkEfa5+WT2Rc5/TiMDhMynAbSJ+DY9FmE5lcWgWMRQWUBV5UQsgjiBWL302N4k"
+                "dLZYygJVBVx3vYsDNUx8xBbw27WA=="),
+  ("xmpptest2", "CkEgOEFNwRdLQ6uD543MJLSzip7mTahM1we9GDl3S5NlR49nrJ0JxcFfQmDbbF"
+                "4C4OpqSlTpx8OG6xtFjCUMLh/AGA=="),
+]
+XMPP_SERVER = "chat.xaya.io"
+PUBSUB = "pubsub.chat.xaya.io"
+
+
+def testAccountJid (acc):
+  return "%s@%s" % (acc[0], XMPP_SERVER)
+
+
+class CharonClient ():
+  """
+  Wrapper around a running tauriond process that is started as Charon client
+  (without Xaya Core RPC URL).  It is a context manager that handles starting
+  and stopping of the client.
+  """
+
+  def __init__ (self, binary, basedir, rpcport):
+    self.log = logging.getLogger ("charonclient")
+
+    self.binary = binary
+    self.rpcport = rpcport
+
+    self.datadir = os.path.join (basedir, "charonclient")
+    self.log.info ("Creating data directory for charon client in %s"
+                    % self.datadir)
+    shutil.rmtree (self.datadir, ignore_errors=True)
+    os.mkdir (self.datadir)
+
+    self.rpc = jsonrpclib.Server ("http://localhost:%d" % self.rpcport)
+    self.proc = None
+
+  def __enter__ (self):
+    self.log.info ("Starting charon client process...")
+    assert self.proc is None
+
+    args = [self.binary]
+    args.extend (["--datadir", self.datadir])
+    args.append ("--game_rpc_port=%d" % self.rpcport)
+    args.extend (["--charon", "client"])
+    args.extend (["--charon_server_jid", testAccountJid (TEST_ACCOUNTS[0])])
+    args.extend (["--charon_client_jid", testAccountJid (TEST_ACCOUNTS[1])])
+    args.extend (["--charon_password", TEST_ACCOUNTS[1][1]])
+
+    envVars = dict (os.environ)
+    envVars["GLOG_log_dir"] = self.datadir
+    self.proc = subprocess.Popen (args, env=envVars)
+
+    # Wait until the client's RPC interface is up.
+    while True:
+      try:
+        self.rpc.getregionat (coord={"x": 1, "y": 1})
+        return self
+      except socket.error as exc:
+        self.log.info ("RPC connection error, waiting: %s" % exc)
+        time.sleep (0.1)
+
+  def __exit__ (self, exc, value, traceback):
+    self.log.info ("Stopping charon client process...")
+    assert self.proc is not None
+    self.proc.terminate ()
+    self.proc.wait ()
+    self.proc = None
+
+
+class Waiter:
+  """
+  Async call to a waitforchange method, which allows waiting for its result
+  and checking that the result is as expected.
+  """
+
+  def __init__ (self, fcn, *args):
+    def task ():
+      self.result = fcn (*args)
+
+    self.thread = threading.Thread (target=task)
+    self.thread.start ()
+
+  def assertRunning (self):
+    time.sleep (0.1)
+    assert self.thread.isAlive ()
+
+  def await (self):
+    self.thread.join ()
+    return self.result
+
+
+class CharonTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.initAccount ("domob", "r")
+    self.generate (1)
+
+    self.mainLogger.info ("Starting tauriond with Charon server...")
+    self.stopGameDaemon ()
+    args = []
+    args.extend (["--charon", "server"])
+    args.extend (["--charon_pubsub_service", PUBSUB])
+    args.extend (["--charon_server_jid", testAccountJid (TEST_ACCOUNTS[0])])
+    args.extend (["--charon_password", TEST_ACCOUNTS[0][1]])
+    self.startGameDaemon (extraArgs=args)
+
+    self.mainLogger.info ("Starting tauriond as Charon client...")
+    with CharonClient (self.args.game_daemon,
+                       self.basedir, self.basePort + 10) as client:
+
+      self.mainLogger.info ("Testing local RPC...")
+      pos = {"x": 10, "y": 50}
+      self.assertEqual (client.rpc.getregionat (coord=pos),
+                        self.rpc.game.getregionat (coord=pos))
+
+      self.mainLogger.info ("Testing RPC through Charon...")
+      self.assertEqual (client.rpc.getaccounts (), self.rpc.game.getaccounts ())
+
+      self.mainLogger.info ("Testing waitforchange...")
+      w = Waiter (client.rpc.waitforchange, "")
+      w.assertRunning ()
+      self.generate (1)
+      self.assertEqual (w.await (), self.rpc.xaya.getbestblockhash ())
+
+      self.mainLogger.info ("Testing waitforpendingchange...")
+      w = Waiter (client.rpc.waitforpendingchange, 0)
+      w.assertRunning ()
+      self.createCharacters ("domob", 1)
+      self.assertEqual (w.await ()["pending"], {
+        "characters": [],
+        "newcharacters":
+          [
+            {"name": "domob", "creations": [{"faction": "r"}]},
+          ],
+      })
+
+
+if __name__ == "__main__":
+  CharonTest ().main ()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,12 @@
 noinst_LTLIBRARIES = libtaurion.la
 bin_PROGRAMS = tauriond
 
-EXTRA_DIST = rpc-stubs/pxd.json
+EXTRA_DIST = \
+  rpc-stubs/nonstate.json \
+  rpc-stubs/pxd.json
 
 RPC_STUBS = \
+  rpc-stubs/nonstaterpcserverstub.h \
   rpc-stubs/pxrpcserverstub.h
 BUILT_SOURCES = $(RPC_STUBS)
 CLEANFILES = $(RPC_STUBS)
@@ -71,6 +74,7 @@ tauriond_SOURCES = main.cpp \
 tauriondheaders = \
   pxrpcserver.hpp \
   \
+  rpc-stubs/nonstaterpcserverstub.h \
   rpc-stubs/pxrpcserverstub.h
 
 noinst_HEADERS = $(libtaurionheaders) $(tauriondheaders)
@@ -145,5 +149,8 @@ benchmarks_SOURCES = \
   combat_target_bench.cpp \
   movement_bench.cpp
 
+rpc-stubs/nonstaterpcserverstub.h: $(srcdir)/rpc-stubs/nonstate.json
+	jsonrpcstub "$<" \
+          --cpp-server=NonStateRpcServerStub --cpp-server-file="$@"
 rpc-stubs/pxrpcserverstub.h: $(srcdir)/rpc-stubs/pxd.json
 	jsonrpcstub "$<" --cpp-server=PXRpcServerStub --cpp-server-file="$@"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,19 +59,21 @@ libtaurionheaders = \
 
 tauriond_CXXFLAGS = \
   -I$(top_srcdir) \
-  $(XAYAGAME_CFLAGS) \
+  $(XAYAGAME_CFLAGS) $(CHARON_CFLAGS) \
   $(JSON_CFLAGS) \
   $(GLOG_CFLAGS) $(GFLAGS_CFLAGS) $(PROTOBUF_CFLAGS)
 tauriond_LDADD = \
   $(builddir)/libtaurion.la \
   $(top_builddir)/mapdata/libmapdata.la \
   $(top_builddir)/database/libdatabase.la \
-  $(XAYAGAME_LIBS) \
+  $(XAYAGAME_LIBS) $(CHARON_LIBS) \
   $(JSON_LIBS) \
   $(GLOG_LIBS) $(GFLAGS_LIBS) $(PROTOBUF_LIBS)
 tauriond_SOURCES = main.cpp \
+  charon.cpp \
   pxrpcserver.cpp
 tauriondheaders = \
+  charon.hpp \
   pxrpcserver.hpp \
   \
   rpc-stubs/nonstaterpcserverstub.h \

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -1,0 +1,211 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "charon.hpp"
+
+#include "pxrpcserver.hpp"
+
+#include <charon/notifications.hpp>
+#include <charon/rpcserver.hpp>
+#include <charon/server.hpp>
+#include <charon/waiterthread.hpp>
+
+#include <json/json.h>
+#include <jsonrpccpp/common/errors.h>
+#include <jsonrpccpp/common/exception.h>
+#include <jsonrpccpp/server/abstractserverconnector.h>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <map>
+#include <string>
+
+namespace pxd
+{
+
+namespace
+{
+
+DEFINE_string (charon, "",
+               "Whether to run a Charon server (\"server\"),"
+               " client (\"client\") or nothing (default)");
+
+DEFINE_string (charon_server_jid, "", "Bare or full JID for the Charon server");
+DEFINE_string (charon_password, "", "XMPP password for the Charon JID");
+DEFINE_int32 (charon_priority, 0, "Priority for the XMPP connection");
+
+DEFINE_string (charon_pubsub_service, "",
+               "The pubsub service to use on the Charon server");
+
+/** Method pointer to a PXRpcServer method.  */
+using PXRpcMethod = void (PXRpcServer::*) (const Json::Value&, Json::Value&);
+
+/** Methods that are forwarded through Charon.  */
+const std::map<std::string, PXRpcMethod> CHARON_METHODS = {
+  {"getnullstate", &PXRpcServer::getnullstateI},
+  {"getpendingstate", &PXRpcServer::getpendingstateI},
+  {"getaccounts", &PXRpcServer::getaccountsI},
+  {"getcharacters", &PXRpcServer::getcharactersI},
+  {"getgroundloot", &PXRpcServer::getgroundlootI},
+  {"getregions", &PXRpcServer::getregionsI},
+  {"getprizestats", &PXRpcServer::getprizestatsI},
+};
+
+/**
+ * UpdateWaiter implementation that forwards wait calls to a given call
+ * on a PXRpcServer instance.
+ */
+class UpdateWaiter : public charon::UpdateWaiter
+{
+
+private:
+
+  /** PXRpcServer instance to call wait methods on.  */
+  PXRpcServer& rpc;
+
+  /** The method to actually call.  */
+  const PXRpcMethod method;
+
+  /** The argument list to pass.  */
+  Json::Value params;
+
+public:
+
+  explicit UpdateWaiter (PXRpcServer& r, const PXRpcMethod m,
+                         const Json::Value& alwaysBlock)
+    : rpc(r), method(m), params(Json::arrayValue)
+  {
+    params.append (alwaysBlock);
+  }
+
+  bool
+  WaitForUpdate (Json::Value& newState) override
+  {
+    (rpc.*method) (params, newState);
+    return true;
+  }
+
+};
+
+/**
+ * Charon backend implementation that answers method calls directly through
+ * a Game instance (without going through some JSON-RPC loop).
+ */
+class CharonBackend : public xaya::GameComponent, private charon::RpcServer
+{
+
+private:
+
+  /** Fake server connector we use.  */
+  NullServerConnector conn;
+
+  /** Underlying PXRpcServer that we call through on.  */
+  PXRpcServer rpc;
+
+  /** The Charon server that we use.  */
+  charon::Server srv;
+
+  /**
+   * Enables a notification waiter on the server.  The waiter will just
+   * use the given notification type and call through to a method on
+   * our PXRpcServer instance.
+   */
+  void
+  AddNotification (std::unique_ptr<charon::NotificationType> n,
+                   const PXRpcMethod m)
+  {
+    auto w = std::make_unique<UpdateWaiter> (rpc, m, n->AlwaysBlockId ());
+    auto t = std::make_unique<charon::WaiterThread> (std::move (n),
+                                                     std::move (w));
+    srv.AddNotification (std::move (t));
+  }
+
+  Json::Value HandleMethod (const std::string& method,
+                            const Json::Value& params) override;
+
+public:
+
+  explicit CharonBackend (xaya::Game& game, PXLogic& rules)
+    : rpc(game, rules, conn), srv(*this)
+  {}
+
+  void
+  Start () override
+  {
+    LOG (INFO) << "Starting Charon server as " << FLAGS_charon_server_jid;
+    srv.Connect (FLAGS_charon_server_jid, FLAGS_charon_password,
+                 FLAGS_charon_priority);
+
+    LOG (INFO) << "Using " << FLAGS_charon_pubsub_service << " for pubsub";
+    srv.AddPubSub (FLAGS_charon_pubsub_service);
+
+    AddNotification (std::make_unique<charon::StateChangeNotification> (),
+                     &PXRpcServer::waitforchangeI);
+    AddNotification (std::make_unique<charon::PendingChangeNotification> (),
+                     &PXRpcServer::waitforpendingchangeI);
+  }
+
+  void
+  Stop () override
+  {
+    LOG (INFO) << "Stopping Charon server...";
+    srv.Disconnect ();
+  }
+
+};
+
+Json::Value
+CharonBackend::HandleMethod (const std::string& method,
+                             const Json::Value& params)
+{
+  const auto mit = CHARON_METHODS.find (method);
+  if (mit == CHARON_METHODS.end ())
+    throw jsonrpc::JsonRpcException (
+        jsonrpc::Errors::ERROR_RPC_METHOD_NOT_FOUND);
+
+  Json::Value result;
+  (rpc.*(mit->second)) (params, result);
+  return result;
+}
+
+} // anonymous namespace
+
+std::unique_ptr<xaya::GameComponent>
+MaybeBuildCharonServer (xaya::Game& g, PXLogic& r)
+{
+  if (FLAGS_charon != "server")
+    {
+      LOG (INFO) << "Charon server is not enabled";
+      return nullptr;
+    }
+
+  if (FLAGS_charon_server_jid.empty () || FLAGS_charon_password.empty ()
+        || FLAGS_charon_pubsub_service.empty ())
+    {
+      LOG (ERROR)
+          << "--charon_server_jid, --charon_password and"
+             " --charon_pubsub_service must be given,"
+             " Charon server will be disabled";
+      return nullptr;
+    }
+
+  return std::make_unique<CharonBackend> (g, r);
+}
+
+} // namespace pxd

--- a/src/charon.hpp
+++ b/src/charon.hpp
@@ -1,0 +1,41 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_CHARON_HPP
+#define PXD_CHARON_HPP
+
+#include "logic.hpp"
+
+#include <xayagame/defaultmain.hpp>
+#include <xayagame/game.hpp>
+
+#include <memory>
+
+namespace pxd
+{
+
+/**
+ * Checks if a Charon server should be run (according to the command-line flags)
+ * and constructs one wrapped as a GameComponent.
+ */
+std::unique_ptr<xaya::GameComponent> MaybeBuildCharonServer (
+    xaya::Game& g, PXLogic& r);
+
+} // namespace pxd
+
+#endif // PXD_CHARON_HPP

--- a/src/charon.hpp
+++ b/src/charon.hpp
@@ -21,8 +21,11 @@
 
 #include "logic.hpp"
 
+#include <charon/client.hpp>
 #include <xayagame/defaultmain.hpp>
 #include <xayagame/game.hpp>
+
+#include <jsonrpccpp/server/abstractserverconnector.h>
 
 #include <memory>
 
@@ -30,11 +33,45 @@ namespace pxd
 {
 
 /**
+ * Abstract interface for a Charon client.  The actual implementation (which
+ * holds a real Charon client and a local RPC server) is an implementation
+ * detail.
+ */
+class CharonClient
+{
+
+protected:
+
+  CharonClient () = default;
+
+public:
+
+  virtual ~CharonClient () = default;
+
+  /**
+   * Sets up the JSON-RPC connector for the local server.
+   */
+  virtual void SetupLocalRpc (jsonrpc::AbstractServerConnector& conn) = 0;
+
+  /**
+   * Starts the client and local server, returning only when the server
+   * should be stopped.
+   */
+  virtual void Run () = 0;
+
+};
+
+/**
  * Checks if a Charon server should be run (according to the command-line flags)
  * and constructs one wrapped as a GameComponent.
  */
 std::unique_ptr<xaya::GameComponent> MaybeBuildCharonServer (
     xaya::Game& g, PXLogic& r);
+
+/**
+ * Checks if this should run as Charon client.  If so, returns a new instance.
+ */
+std::unique_ptr<CharonClient> MaybeBuildCharonClient ();
 
 } // namespace pxd
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 #include "config.h"
 
+#include "charon.hpp"
 #include "logic.hpp"
 #include "pending.hpp"
 #include "pxrpcserver.hpp"
@@ -82,6 +83,18 @@ public:
     std::unique_ptr<xaya::RpcServerInterface> res;
     res.reset (new xaya::WrappedRpcServer<pxd::PXRpcServer> (game, rules,
                                                              conn));
+    return res;
+  }
+
+  std::vector<std::unique_ptr<xaya::GameComponent>>
+  BuildGameComponents (xaya::Game& game) override
+  {
+    std::vector<std::unique_ptr<xaya::GameComponent>> res;
+
+    auto charonSrv = MaybeBuildCharonServer (game, rules);
+    if (charonSrv != nullptr)
+      res.push_back (std::move (charonSrv));
+
     return res;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,35 @@ main (int argc, char** argv)
   gflags::SetVersionString (PACKAGE_VERSION);
   gflags::ParseCommandLineFlags (&argc, &argv, true);
 
+#ifdef ENABLE_SLOW_ASSERTS
+  LOG (WARNING)
+      << "Slow assertions are enabled.  This is fine for testing, but will"
+         " slow down syncing";
+#endif // ENABLE_SLOW_ASSERTS
+
+  auto charonClient = pxd::MaybeBuildCharonClient ();
+  if (charonClient != nullptr)
+    {
+      std::unique_ptr<jsonrpc::HttpServer> srv;
+      if (FLAGS_game_rpc_port != 0)
+        {
+          srv = std::make_unique<jsonrpc::HttpServer> (FLAGS_game_rpc_port);
+          if (FLAGS_game_rpc_listen_locally)
+            srv->BindLocalhost ();
+          charonClient->SetupLocalRpc (*srv);
+          LOG (INFO)
+              << "Starting local RPC interface at port " << FLAGS_game_rpc_port;
+        }
+
+      charonClient->Run ();
+
+      /* We have to explicitly free the CharonClient instance here already
+         before its associated HttpServer goes out of scope.  */
+      charonClient.reset ();
+
+      return EXIT_SUCCESS;;
+    }
+
   if (FLAGS_xaya_rpc_url.empty ())
     {
       std::cerr << "Error: --xaya_rpc_url must be set" << std::endl;
@@ -122,12 +151,6 @@ main (int argc, char** argv)
       std::cerr << "Error: --datadir must be specified" << std::endl;
       return EXIT_FAILURE;
     }
-
-#ifdef ENABLE_SLOW_ASSERTS
-  LOG (WARNING)
-      << "Slow assertions are enabled.  This is fine for testing, but will"
-         " slow down syncing";
-#endif // ENABLE_SLOW_ASSERTS
 
   xaya::GameDaemonConfiguration config;
   config.XayaRpcUrl = FLAGS_xaya_rpc_url;

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -19,9 +19,12 @@
 #ifndef PXD_PXRPCSERVER_HPP
 #define PXD_PXRPCSERVER_HPP
 
+#include "rpc-stubs/nonstaterpcserverstub.h"
 #include "rpc-stubs/pxrpcserverstub.h"
 
 #include "logic.hpp"
+
+#include "mapdata/basemap.hpp"
 
 #include <xayagame/game.hpp>
 
@@ -30,6 +33,59 @@
 
 namespace pxd
 {
+
+/**
+ * Fake JSON-RPC server connector that just does nothing.  By using this class,
+ * we can construct instances of the libjson-rpc-cpp servers without needing to
+ * really process requests with them (we'll just use it to call the actual
+ * methods on it directly).
+ */
+class NullServerConnector : public jsonrpc::AbstractServerConnector
+{
+
+public:
+
+  NullServerConnector () = default;
+
+  bool
+  StartListening () override
+  {
+    return false;
+  }
+
+  bool
+  StopListening () override
+  {
+    return false;
+  }
+
+};
+
+/**
+ * Implementation of RPC methods that do not require a full GSP but instead
+ * just operate on e.g. map data.  These methods are exposed locally also
+ * for Charon clients (rather than through the server link).
+ */
+class NonStateRpcServer : public NonStateRpcServerStub
+{
+
+private:
+
+  /** The basemap we use.  */
+  const BaseMap& map;
+
+public:
+
+  explicit NonStateRpcServer (jsonrpc::AbstractServerConnector& conn,
+                              const BaseMap& m)
+    : NonStateRpcServerStub(conn), map(m)
+  {}
+
+  Json::Value findpath (int l1range, const Json::Value& source,
+                        const Json::Value& target, int wpdist) override;
+  Json::Value getregionat (const Json::Value& coord) override;
+
+};
 
 /**
  * Implementation of the JSON-RPC interface to the game daemon.  This mostly
@@ -47,11 +103,18 @@ private:
   /** The PX game logic implementation.  */
   PXLogic& logic;
 
+  /** Null connector for the nonstate instance.  */
+  NullServerConnector nullConnector;
+
+  /** NonStateRpcServer for answering the calls it supports.  */
+  NonStateRpcServer nonstate;
+
 public:
 
   explicit PXRpcServer (xaya::Game& g, PXLogic& l,
                         jsonrpc::AbstractServerConnector& conn)
-    : PXRpcServerStub(conn), game(g), logic(l)
+    : PXRpcServerStub(conn), game(g), logic(l),
+      nonstate(nullConnector, logic.map)
   {}
 
   void stop () override;
@@ -67,9 +130,18 @@ public:
   Json::Value getregions (int fromHeight) override;
   Json::Value getprizestats () override;
 
-  Json::Value findpath (int l1range, const Json::Value& source,
-                        const Json::Value& target, int wpdist) override;
-  Json::Value getregionat (const Json::Value& coord) override;
+  Json::Value
+  findpath (int l1range, const Json::Value& source,
+            const Json::Value& target, int wpdist) override
+  {
+    return nonstate.findpath (l1range, source, target, wpdist);
+  }
+
+  Json::Value
+  getregionat (const Json::Value& coord) override
+  {
+    return nonstate.getregionat (coord);
+  }
 
 };
 

--- a/src/rpc-stubs/nonstate.json
+++ b/src/rpc-stubs/nonstate.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "findpath",
+    "params":
+      {
+        "source": {},
+        "target": {},
+        "l1range": 100,
+        "wpdist": 10
+      },
+    "returns": {}
+  },
+  {
+    "name": "getregionat",
+    "params":
+      {
+        "coord": {}
+      },
+    "returns": {}
+  }
+]


### PR DESCRIPTION
This integrates Taurion directly with [Charon](https://github.com/xaya/charon).  `tauriond` can now (optionally) also run a Charon server in addition to its local RPC for GSP data.  It can also be run in "Charon client mode", which does not need a Xaya Core connection nor game-state data.