### PR TITLE
Restrict getregions, introduce bootstrap data

### DIFF
--- a/gametest/charon.py
+++ b/gametest/charon.py
@@ -161,6 +161,8 @@ class CharonTest (PXTest):
                         client.rpc.getregions, 42)
       self.expectError (-32602, ".*Invalid method parameters.*",
                         client.rpc.getregions, fromheight="not an int")
+      self.expectError (3, ".*too low for current block height.*",
+                        client.rpc.getregions, fromheight=-10000)
 
       self.mainLogger.info ("Testing waitforchange...")
       w = Waiter (client.rpc.waitforchange, "")

--- a/gametest/modifiedregions.py
+++ b/gametest/modifiedregions.py
@@ -70,6 +70,9 @@ class ModifiedRegionsTest (PXTest):
     self.assertEqual (self.queryRegions (h3), set ([r3]))
     self.assertEqual (self.queryRegions (1000), set ([]))
 
+    self.expectError (3, ".*too low for current block height.*",
+                      self.queryRegions, -10000)
+
 
 if __name__ == "__main__":
   ModifiedRegionsTest ().main ()

--- a/gametest/splitstaterpcs.py
+++ b/gametest/splitstaterpcs.py
@@ -66,6 +66,11 @@ class SplitStateRpcsTest (PXTest):
     self.assertEqual (regions, state["regions"])
     self.assertEqual (prizes, state["prizes"])
 
+    # Test the bootstrap data.
+    self.assertEqual (self.getRpc ("getbootstrapdata"), {
+      "regions": regions,
+    })
+
 
 if __name__ == "__main__":
   SplitStateRpcsTest ().main ()

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -429,4 +429,13 @@ GameStateJson::FullState ()
   return res;
 }
 
+Json::Value
+GameStateJson::BootstrapData ()
+{
+  Json::Value res(Json::objectValue);
+  res["regions"] = Regions (0);
+
+  return res;
+}
+
 } // namespace pxd

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -108,6 +108,13 @@ public:
    */
   Json::Value FullState ();
 
+  /**
+   * Returns the bootstrap data that the frontend needs on startup (e.g.
+   * including all regions, not just recently-modified ones).  This is
+   * potentially an expensive operation and has a large result.
+   */
+  Json::Value BootstrapData ();
+
 };
 
 } // namespace pxd

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -192,17 +192,29 @@ PXLogic::GetStateAsJson (sqlite3* db)
 }
 
 Json::Value
-PXLogic::GetCustomStateData (xaya::Game& game, const JsonStateFromDatabase& cb)
+PXLogic::GetCustomStateData (xaya::Game& game,
+                             const JsonStateFromDatabaseWithBlock& cb)
 {
   return SQLiteGame::GetCustomStateData (game, "data",
-      [this, &cb] (sqlite3* db)
+      [this, &cb] (sqlite3* db, const xaya::uint256& hash,
+                   const unsigned height)
         {
           SQLiteGameDatabase dbObj(*this);
           const Params params(GetChain ());
           GameStateJson gsj(dbObj, params, map);
 
-          return cb (gsj);
+          return cb (gsj, hash, height);
         });
+}
+
+Json::Value
+PXLogic::GetCustomStateData (xaya::Game& game, const JsonStateFromDatabase& cb)
+{
+  return GetCustomStateData (game,
+    [&cb] (GameStateJson& gsj, const xaya::uint256& hash, const unsigned height)
+    {
+      return cb (gsj);
+    });
 }
 
 namespace

--- a/src/logic.hpp
+++ b/src/logic.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -132,6 +132,11 @@ public:
   /** Type for a callback that retrieves JSON data from the database.  */
   using JsonStateFromDatabase = std::function<Json::Value (GameStateJson& gsj)>;
 
+  /** Extended callback that expects also block hash and height.  */
+  using JsonStateFromDatabaseWithBlock
+    = std::function<Json::Value (GameStateJson& gsj,
+                                 const xaya::uint256& hash, unsigned height)>;
+
   PXLogic () = default;
 
   PXLogic (const PXLogic&) = delete;
@@ -151,6 +156,13 @@ public:
    * Returns custom game-state data as JSON.  The provided callback is invoked
    * with a GameStateJson instance to retrieve the "main" state data that is
    * returned in the JSON "data" field.
+   */
+  Json::Value GetCustomStateData (xaya::Game& game,
+                                  const JsonStateFromDatabaseWithBlock& cb);
+
+  /**
+   * Variant of the other overload that extracts data with a callback that does
+   * not need block hash or height.
    */
   Json::Value GetCustomStateData (xaya::Game& game,
                                   const JsonStateFromDatabase& cb);

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -292,4 +292,15 @@ PXRpcServer::getprizestats ()
       });
 }
 
+Json::Value
+PXRpcServer::getbootstrapdata ()
+{
+  LOG (INFO) << "RPC method called: getbootstrapdata";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.BootstrapData ();
+      });
+}
+
 } // namespace pxd

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -34,6 +34,9 @@ namespace pxd
 namespace
 {
 
+/** Maximum number of past blocks for which getregions can be called.  */
+constexpr int MAX_REGIONS_HEIGHT_DIFFERENCE = 2 * 60 * 24 * 3;
+
 /**
  * Error codes returned from the PX RPC server.  All values should have an
  * explicit integer number, because this also defines the RPC protocol
@@ -52,6 +55,9 @@ enum class ErrorCode
 
   /* Specific errors with getregionat.  */
   REGIONAT_OUT_OF_MAP = 2,
+
+  /* Specific errors with getregions.  */
+  GETREGIONS_FROM_TOO_LOW = 3,
 
 };
 
@@ -256,9 +262,21 @@ Json::Value
 PXRpcServer::getregions (const int fromHeight)
 {
   LOG (INFO) << "RPC method called: getregions " << fromHeight;
+
   return logic.GetCustomStateData (game,
-    [fromHeight] (GameStateJson& gsj)
+    [fromHeight] (GameStateJson& gsj, const xaya::uint256 hash,
+                  const int height)
       {
+        if (fromHeight + MAX_REGIONS_HEIGHT_DIFFERENCE < height)
+          {
+            std::ostringstream msg;
+            msg << "fromHeight " << fromHeight
+                << " is too low for current block height " << height
+                << ", needs to be at least "
+                << height - MAX_REGIONS_HEIGHT_DIFFERENCE;
+            ReturnError (ErrorCode::GETREGIONS_FROM_TOO_LOW, msg.str ());
+          }
+
         return gsj.Regions (fromHeight);
       });
 }

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -130,6 +130,8 @@ public:
   Json::Value getregions (int fromHeight) override;
   Json::Value getprizestats () override;
 
+  Json::Value getbootstrapdata () override;
+
   Json::Value
   findpath (int l1range, const Json::Value& source,
             const Json::Value& target, int wpdist) override

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -58,6 +58,12 @@
   },
 
   {
+    "name": "getbootstrapdata",
+    "params": {},
+    "returns": {}
+  },
+
+  {
     "name": "findpath",
     "params":
       {


### PR DESCRIPTION
`getregions` can be quite costly (and result in a huge state) if called with a low `fromheight` argument.  This set of changes restricts `getregions` so that it will only accept a `fromheight` at most three days behind the current chain tip.  This makes the call suitable also for e.g. GSP servers or Charon, and serves all needs of frontends while they are in ordinary operation.

For getting the initial data, the new RPC `getbootstrapdata` is added instead, which (for now) just returns all region data.  This method is not allowed through Charon, but light clients will be able to retrieve bootstrap data in the future through e.g. some static web server that is just updated from time to time.  (And we might even want to add such functionality to `tauriond` itself.)