### PR TITLE
Entering and leaving buildings

### DIFF
--- a/database/character.cpp
+++ b/database/character.cpp
@@ -379,6 +379,17 @@ CharacterTable::QueryBusyDone ()
   return stmt.Query<CharacterResult> ();
 }
 
+Database::Result<CharacterResult>
+CharacterTable::QueryForEnterBuilding ()
+{
+  auto stmt = db.Prepare (R"(
+    SELECT * FROM `characters`
+      WHERE `enterbuilding` IS NOT NULL
+      ORDER BY `id`
+  )");
+  return stmt.Query<CharacterResult> ();
+}
+
 namespace
 {
 

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -44,17 +44,18 @@ namespace pxd
 struct CharacterResult : public ResultWithFaction, public ResultWithCoord
 {
   RESULT_COLUMN (int64_t, id, 1);
-  RESULT_COLUMN (int64_t, inbuilding, 2);
-  RESULT_COLUMN (std::string, owner, 3);
-  RESULT_COLUMN (pxd::proto::VolatileMovement, volatilemv, 4);
-  RESULT_COLUMN (pxd::proto::HP, hp, 5);
-  RESULT_COLUMN (pxd::proto::RegenData, regendata, 6);
-  RESULT_COLUMN (int64_t, busy, 7);
-  RESULT_COLUMN (pxd::proto::Inventory, inventory, 8);
-  RESULT_COLUMN (pxd::proto::Character, proto, 9);
-  RESULT_COLUMN (int64_t, attackrange, 10);
-  RESULT_COLUMN (bool, canregen, 11);
-  RESULT_COLUMN (bool, hastarget, 12);
+  RESULT_COLUMN (std::string, owner, 2);
+  RESULT_COLUMN (int64_t, inbuilding, 3);
+  RESULT_COLUMN (int64_t, enterbuilding, 4);
+  RESULT_COLUMN (pxd::proto::VolatileMovement, volatilemv, 5);
+  RESULT_COLUMN (pxd::proto::HP, hp, 6);
+  RESULT_COLUMN (pxd::proto::RegenData, regendata, 7);
+  RESULT_COLUMN (int64_t, busy, 8);
+  RESULT_COLUMN (pxd::proto::Inventory, inventory, 9);
+  RESULT_COLUMN (pxd::proto::Character, proto, 10);
+  RESULT_COLUMN (int64_t, attackrange, 11);
+  RESULT_COLUMN (bool, canregen, 12);
+  RESULT_COLUMN (bool, hastarget, 13);
 };
 
 /**
@@ -89,6 +90,9 @@ private:
 
   /** The building the character is in, or EMPTY_ID if outside.  */
   Database::IdT inBuilding;
+
+  /** The building the character wants to enter or EMPTY_ID.  */
+  Database::IdT enterBuilding;
 
   /** Volatile movement proto.  */
   LazyProto<proto::VolatileMovement> volatileMv;
@@ -247,6 +251,19 @@ public:
   {
     dirtyFields = true;
     inBuilding = id;
+  }
+
+  Database::IdT
+  GetEnterBuilding () const
+  {
+    return enterBuilding;
+  }
+
+  void
+  SetEnterBuilding (const Database::IdT id)
+  {
+    dirtyFields = true;
+    enterBuilding = id;
   }
 
   const proto::VolatileMovement&

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -456,6 +456,11 @@ public:
   Database::Result<CharacterResult> QueryBusyDone ();
 
   /**
+   * Queries all characters that want to enter a building.
+   */
+  Database::Result<CharacterResult> QueryForEnterBuilding ();
+
+  /**
    * Processes all positions of characters on the map.  This is used to
    * construct the dynamic obstacle map, avoiding the need to query all data
    * for each character and construct a full Character handle.

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -77,6 +77,7 @@ TEST_F (CharacterTests, Creation)
 
   c = tbl.CreateNew ("domob", Faction::GREEN);
   const auto id2 = c->GetId ();
+  c->SetBuildingId (100);
   c->MutableProto ().mutable_movement ();
   c.reset ();
 
@@ -87,6 +88,7 @@ TEST_F (CharacterTests, Creation)
   ASSERT_EQ (c->GetId (), id1);
   EXPECT_EQ (c->GetOwner (), "domob");
   EXPECT_EQ (c->GetFaction (), Faction::RED);
+  ASSERT_FALSE (c->IsInBuilding ());
   EXPECT_EQ (c->GetPosition (), pos);
   EXPECT_EQ (c->GetHP ().armour (), 10);
   EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 1234);
@@ -98,6 +100,8 @@ TEST_F (CharacterTests, Creation)
   ASSERT_EQ (c->GetId (), id2);
   EXPECT_EQ (c->GetOwner (), "domob");
   EXPECT_EQ (c->GetFaction (), Faction::GREEN);
+  ASSERT_TRUE (c->IsInBuilding ());
+  EXPECT_EQ (c->GetBuildingId (), 100);
   EXPECT_FALSE (c->GetRegenData ().has_shield_regeneration_mhp ());
   EXPECT_EQ (c->GetBusy (), 0);
   EXPECT_TRUE (c->GetProto ().has_movement ());
@@ -155,6 +159,7 @@ TEST_F (CharacterTests, ModificationFieldsOnly)
      and later modify just the value.  */
   auto c = tbl.CreateNew ("domob", Faction::RED);
   const auto id = c->GetId ();
+  c->SetBuildingId (100);
   SetBusy (*c, 100);
   c.reset ();
 
@@ -171,10 +176,19 @@ TEST_F (CharacterTests, ModificationFieldsOnly)
   ASSERT_TRUE (c != nullptr);
   EXPECT_EQ (c->GetOwner (), "andy");
   EXPECT_EQ (c->GetFaction (), Faction::RED);
+  ASSERT_FALSE (c->IsInBuilding ());
   EXPECT_EQ (c->GetPosition (), pos);
   EXPECT_EQ (c->GetVolatileMv ().partial_step (), 24);
   EXPECT_EQ (c->GetHP ().shield (), 5);
   EXPECT_EQ (c->GetBusy (), 42);
+
+  c->SetBuildingId (101);
+  c.reset ();
+
+  c = tbl.GetById (id);
+  ASSERT_TRUE (c != nullptr);
+  ASSERT_TRUE (c->IsInBuilding ());
+  EXPECT_EQ (c->GetBuildingId (), 101);
 }
 
 TEST_F (CharacterTests, Inventory)
@@ -303,6 +317,10 @@ TEST_F (CharacterTableTests, QueryWithAttacks)
   tbl.CreateNew ("domob", Faction::RED);
   tbl.CreateNew ("andy", Faction::RED)
     ->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (1);
+  auto h = tbl.CreateNew ("inbuilding", Faction::RED);
+  h->SetBuildingId (100);
+  h->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (1);
+  h.reset ();
 
   auto res = tbl.QueryWithAttacks ();
   ASSERT_TRUE (res.Step ());
@@ -417,6 +435,7 @@ TEST_F (CharacterTableTests, ProcessAllPositions)
   tbl.CreateNew ("red", Faction::RED)->SetPosition (HexCoord (1, 5));
   tbl.CreateNew ("red", Faction::RED)->SetPosition (HexCoord (-1, -5));
   tbl.CreateNew ("blue", Faction::BLUE)->SetPosition (HexCoord (0, 0));
+  tbl.CreateNew ("green", Faction::GREEN)->SetBuildingId (100);
 
   struct Entry
   {

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -435,6 +435,20 @@ TEST_F (CharacterTableTests, QueryBusyDone)
   ASSERT_FALSE (res.Step ());
 }
 
+TEST_F (CharacterTableTests, QueryForEnterBuilding)
+{
+  tbl.CreateNew ("not entering", Faction::RED);
+  tbl.CreateNew ("entering 1", Faction::GREEN)->SetEnterBuilding (10);
+  tbl.CreateNew ("entering 2", Faction::GREEN)->SetEnterBuilding (1);
+
+  auto res = tbl.QueryForEnterBuilding ();
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "entering 1");
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "entering 2");
+  ASSERT_FALSE (res.Step ());
+}
+
 TEST_F (CharacterTableTests, ProcessAllPositions)
 {
   tbl.CreateNew ("red", Faction::RED)->SetPosition (HexCoord (1, 5));

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -68,8 +68,9 @@ TEST_F (CharacterTests, Creation)
   const HexCoord pos(5, -2);
 
   auto c = tbl.CreateNew  ("domob", Faction::RED);
-  c->SetPosition (pos);
   const auto id1 = c->GetId ();
+  c->SetPosition (pos);
+  c->SetEnterBuilding (10);
   c->MutableHP ().set_armour (10);
   c->MutableRegenData ().set_shield_regeneration_mhp (1234);
   SetBusy (*c, 42);
@@ -90,6 +91,7 @@ TEST_F (CharacterTests, Creation)
   EXPECT_EQ (c->GetFaction (), Faction::RED);
   ASSERT_FALSE (c->IsInBuilding ());
   EXPECT_EQ (c->GetPosition (), pos);
+  EXPECT_EQ (c->GetEnterBuilding (), 10);
   EXPECT_EQ (c->GetHP ().armour (), 10);
   EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 1234);
   EXPECT_EQ (c->GetBusy (), 42);
@@ -102,6 +104,7 @@ TEST_F (CharacterTests, Creation)
   EXPECT_EQ (c->GetFaction (), Faction::GREEN);
   ASSERT_TRUE (c->IsInBuilding ());
   EXPECT_EQ (c->GetBuildingId (), 100);
+  EXPECT_EQ (c->GetEnterBuilding (), Database::EMPTY_ID);
   EXPECT_FALSE (c->GetRegenData ().has_shield_regeneration_mhp ());
   EXPECT_EQ (c->GetBusy (), 0);
   EXPECT_TRUE (c->GetProto ().has_movement ());
@@ -167,6 +170,7 @@ TEST_F (CharacterTests, ModificationFieldsOnly)
   ASSERT_TRUE (c != nullptr);
   c->SetOwner ("andy");
   c->SetPosition (pos);
+  c->SetEnterBuilding (42);
   c->MutableVolatileMv ().set_partial_step (24);
   c->MutableHP ().set_shield (5);
   c->SetBusy (42);
@@ -178,6 +182,7 @@ TEST_F (CharacterTests, ModificationFieldsOnly)
   EXPECT_EQ (c->GetFaction (), Faction::RED);
   ASSERT_FALSE (c->IsInBuilding ());
   EXPECT_EQ (c->GetPosition (), pos);
+  EXPECT_EQ (c->GetEnterBuilding (), 42);
   EXPECT_EQ (c->GetVolatileMv ().partial_step (), 24);
   EXPECT_EQ (c->GetHP ().shield (), 5);
   EXPECT_EQ (c->GetBusy (), 42);

--- a/database/database.cpp
+++ b/database/database.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,6 +26,8 @@ namespace pxd
 {
 
 /* ************************************************************************** */
+
+constexpr Database::IdT Database::EMPTY_ID;
 
 Database::Statement
 Database::Prepare (const std::string& sql)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -42,6 +42,10 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- outside, in which case their position is given by x/y.
   `inbuilding` INTEGER NULL,
 
+  -- If the character has indicated they want to enter a building (if it
+  -- is or becomes possible), then this holds the desired building's ID.
+  `enterbuilding` INTEGER NULL,
+
   -- Movement data for the character that changes frequently and is thus
   -- not part of the big main proto.
   `volatilemv` BLOB NOT NULL,
@@ -101,6 +105,8 @@ CREATE TABLE IF NOT EXISTS `characters` (
 CREATE INDEX IF NOT EXISTS `characters_owner` ON `characters` (`owner`);
 CREATE INDEX IF NOT EXISTS `characters_pos` ON `characters` (`x`, `y`);
 CREATE INDEX IF NOT EXISTS `characters_building` ON `characters` (`inbuilding`);
+CREATE INDEX IF NOT EXISTS `characters_enterbuilding`
+  ON `characters` (`enterbuilding`);
 CREATE INDEX IF NOT EXISTS `characters_busy` ON `characters` (`busy`);
 CREATE INDEX IF NOT EXISTS `characters_ismoving` ON `characters` (`ismoving`);
 CREATE INDEX IF NOT EXISTS `characters_ismining` ON `characters` (`ismining`);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -34,9 +34,13 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- Current position of the character on the map.  We need this in the table
   -- so that we can look characters up based on "being near" a given other
   -- coordinate.  Coordinates are in the axial system (as everywhere else
-  -- in the backend).
-  `x` INTEGER NOT NULL,
-  `y` INTEGER NOT NULL,
+  -- in the backend).  May be NULL if the character is inside a building.
+  `x` INTEGER NULL,
+  `y` INTEGER NULL,
+
+  -- ID of the building the character is in, if any.  NULL indicates they are
+  -- outside, in which case their position is given by x/y.
+  `inbuilding` INTEGER NULL,
 
   -- Movement data for the character that changes frequently and is thus
   -- not part of the big main proto.
@@ -96,6 +100,7 @@ CREATE TABLE IF NOT EXISTS `characters` (
 -- Non-unique indices for the characters table.
 CREATE INDEX IF NOT EXISTS `characters_owner` ON `characters` (`owner`);
 CREATE INDEX IF NOT EXISTS `characters_pos` ON `characters` (`x`, `y`);
+CREATE INDEX IF NOT EXISTS `characters_building` ON `characters` (`inbuilding`);
 CREATE INDEX IF NOT EXISTS `characters_busy` ON `characters` (`busy`);
 CREATE INDEX IF NOT EXISTS `characters_ismoving` ON `characters` (`ismoving`);
 CREATE INDEX IF NOT EXISTS `characters_ismining` ON `characters` (`ismining`);

--- a/database/target.cpp
+++ b/database/target.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -39,7 +39,8 @@ TargetFinder::ProcessL1Targets (const HexCoord& centre,
                                 const Faction faction,
                                 const ProcessingFcn& cb)
 {
-
+  /* Note that the "between" statement is automatically false for NULL values,
+     hence characters in buildings are ignored (as they should).  */
   auto stmt = db.Prepare (R"(
     SELECT `x`, `y`, `id` FROM `characters`
       WHERE (`x` BETWEEN ?1 AND ?2) AND (`y` BETWEEN ?3 AND ?4)

--- a/database/target_tests.cpp
+++ b/database/target_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -36,15 +36,10 @@ namespace
 class TargetFinderTests : public DBTestWithSchema
 {
 
-private:
+protected:
 
   /** Character table instance for inserting test characters.  */
   CharacterTable characters;
-
-  /** Counter to generate unique names for test characters.  */
-  unsigned characterCnt = 0;
-
-protected:
 
   /** TargetFinder instance for use in the tests.  */
   TargetFinder finder;
@@ -99,6 +94,13 @@ TEST_F (TargetFinderTests, CharacterFactions)
   EXPECT_EQ (found[1].first, HexCoord (0, 0));
   EXPECT_EQ (found[1].second.type (), proto::TargetId::TYPE_CHARACTER);
   EXPECT_EQ (found[1].second.id (), idEnemy2);
+}
+
+TEST_F (TargetFinderTests, InBuilding)
+{
+  characters.CreateNew ("domob", Faction::GREEN)->SetBuildingId (100);
+  finder.ProcessL1Targets (HexCoord (0, 0), 1, Faction::RED, cb);
+  EXPECT_TRUE (found.empty ());
 }
 
 TEST_F (TargetFinderTests, CharacterRange)

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -5,6 +5,7 @@ REGTESTS = \
   accounts.py \
   banking.py \
   buildings_basic.py \
+  buildings_enterexit.py \
   character_limit.py \
   characters.py \
   charon.py \

--- a/gametest/buildings_enterexit.py
+++ b/gametest/buildings_enterexit.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests entering and exiting buildings with characters.
+"""
+
+from pxtest import PXTest
+
+
+class BuildingsEnterExitTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    # Somehow we need to split the premine coin like this, or else the
+    # wallet will show empty balance in the reorg test.
+    for i in range (10):
+      self.rpc.xaya.sendtoaddress (self.rpc.xaya.getnewaddress (), 100)
+    self.generate (1)
+
+    self.mainLogger.info ("Placing a building...")
+    self.build ("checkmark", None, {"x": 0, "y": 0}, rot=0)
+    building = 1001
+    self.assertEqual (self.getBuildings ()[building].getType (), "checkmark")
+
+    self.mainLogger.info ("Entering building with character...")
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob")
+    self.generate (1)
+    self.moveCharactersTo ({"domob": {"x": 20, "y": 0}})
+    self.getCharacters ()["domob"].sendMove ({
+      "wp": [{"x": 3, "y": 0}],
+      "eb": building
+    })
+    self.generate (2)
+    reorgBlock = self.rpc.xaya.getbestblockhash ()
+
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isInBuilding (), False)
+    self.assertEqual (c.data["enterbuilding"], building)
+
+    self.generate (10)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isInBuilding (), True)
+    self.assertEqual (c.getBuildingId (), building)
+
+    self.mainLogger.info ("Exiting building...")
+    self.getCharacters ()["domob"].sendMove ({"xb": {}})
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["domob"].isInBuilding (), False)
+
+    self.mainLogger.info ("Attacking and being inside buildings...")
+    self.initAccount ("andy", "g")
+    self.createCharacters ("andy")
+    self.generate (1)
+    self.moveCharactersTo ({
+      "domob": {"x": 5, "y": 0},
+      "andy": {"x": 5, "y": 0},
+    })
+
+    chars = self.getCharacters ()
+    self.assertEqual (chars["andy"].data["combat"]["target"]["id"],
+                      chars["domob"].getId ())
+    self.assertEqual (chars["domob"].data["combat"]["target"]["id"],
+                      chars["andy"].getId ())
+
+    chars["andy"].sendMove ({"eb": building})
+    self.generate (1)
+    chars = self.getCharacters ()
+    self.assertEqual (chars["andy"].isInBuilding (), True)
+    assert "target" not in chars["andy"].data["combat"]
+    assert "target" not in chars["domob"].data["combat"]
+
+    # Before doing the reorg, make sure this is the longest chain.
+    self.generate (100)
+    self.testReorg (reorgBlock)
+
+  def testReorg (self, blk):
+    self.mainLogger.info ("Testing reorg...")
+
+    originalState = self.getGameState ()
+    self.rpc.xaya.invalidateblock (blk)
+
+    self.getCharacters ()["domob"].sendMove ({"eb": None})
+    self.generate (20)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isInBuilding (), False)
+    self.assertEqual (c.getPosition (), {"x": 3, "y": 0})
+    assert "enterbuilding" not in c.data
+
+    self.rpc.xaya.reconsiderblock (blk)
+    self.expectGameState (originalState)
+    
+
+if __name__ == "__main__":
+  BuildingsEnterExitTest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -70,6 +70,12 @@ class Character (object):
   def getOwner (self):
     return self.data["owner"]
 
+  def isInBuilding (self):
+    return "inbuilding" in self.data
+
+  def getBuildingId (self):
+    return self.data["inbuilding"]
+
   def getPosition (self):
     return self.data["position"]
 

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -120,6 +120,8 @@ message Character
      - string owner
      - int faction
      - position on the map
+     - building the character is in
+     - building the character wants to enter
      - volatile movement proto (partial step, blocked for counter)
      - current HP proto
      - HP regeneration data proto

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -39,6 +39,12 @@ std::vector<HexCoord> GetBuildingShape (const Building& b);
  */
 void InitialiseBuildings (Database& db);
 
+/**
+ * Processes all characters that want to enter a building, and lets them in
+ * if it is possible for them.
+ */
+void ProcessEnterBuildings (Database& db);
+
 } // namespace pxd
 
 #endif // PXD_BUILDINGS_HPP

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -19,9 +19,15 @@
 #ifndef PXD_BUILDINGS_HPP
 #define PXD_BUILDINGS_HPP
 
+#include "context.hpp"
+#include "dynobstacles.hpp"
+
 #include "database/building.hpp"
+#include "database/character.hpp"
 #include "database/database.hpp"
 #include "hexagonal/coord.hpp"
+
+#include <xayautil/random.hpp>
 
 #include <vector>
 
@@ -44,6 +50,12 @@ void InitialiseBuildings (Database& db);
  * if it is possible for them.
  */
 void ProcessEnterBuildings (Database& db);
+
+/**
+ * Makes the given character leave the building it is currently in.
+ */
+void LeaveBuilding (BuildingsTable& buildings, Character& c,
+                    xaya::Random& rnd, DynObstacles& dyn, const Context& ctx);
 
 } // namespace pxd
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -270,7 +270,10 @@ template <>
   res["id"] = IntToJson (c.GetId ());
   res["owner"] = c.GetOwner ();
   res["faction"] = FactionToString (c.GetFaction ());
-  res["position"] = CoordToJson (c.GetPosition ());
+  if (c.IsInBuilding ())
+    res["inbuilding"] = IntToJson (c.GetBuildingId ());
+  else
+    res["position"] = CoordToJson (c.GetPosition ());
   res["combat"] = GetCombatJsonObject (c, dl);
   res["speed"] = c.GetProto ().speed ();
   res["inventory"] = Convert (c.GetInventory ());

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -270,10 +270,15 @@ template <>
   res["id"] = IntToJson (c.GetId ());
   res["owner"] = c.GetOwner ();
   res["faction"] = FactionToString (c.GetFaction ());
+
   if (c.IsInBuilding ())
     res["inbuilding"] = IntToJson (c.GetBuildingId ());
   else
     res["position"] = CoordToJson (c.GetPosition ());
+
+  if (c.GetEnterBuilding () != Database::EMPTY_ID)
+    res["enterbuilding"] = IntToJson (c.GetEnterBuilding ());
+
   res["combat"] = GetCombatJsonObject (c, dl);
   res["speed"] = c.GetProto ().speed ();
   res["inventory"] = Convert (c.GetInventory ());

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -112,7 +112,7 @@ TEST_F (CharacterJsonTests, Basic)
   c->MutableProto ().set_speed (750);
   c.reset ();
 
-  tbl.CreateNew ("andy", Faction::GREEN);
+  tbl.CreateNew ("andy", Faction::GREEN)->SetBuildingId (100);
 
   ExpectStateJson (R"({
     "characters":
@@ -120,11 +120,13 @@ TEST_F (CharacterJsonTests, Basic)
         {
           "id": 1, "owner": "domob", "faction": "r",
           "speed": 750,
+          "inbuilding": null,
           "position": {"x": -5, "y": 2}
         },
         {
           "id": 2, "owner": "andy", "faction": "g",
-          "position": {"x": -0, "y": 0}
+          "inbuilding": 100,
+          "position": null
         }
       ]
   })");

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -132,6 +132,26 @@ TEST_F (CharacterJsonTests, Basic)
   })");
 }
 
+TEST_F (CharacterJsonTests, EnterBuilding)
+{
+  tbl.CreateNew ("domob", Faction::RED);
+  tbl.CreateNew ("andy", Faction::BLUE)->SetEnterBuilding (5);
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "id": 1, "owner": "domob", "faction": "r",
+          "enterbuilding": null
+        },
+        {
+          "id": 2, "owner": "andy", "faction": "b",
+          "enterbuilding": 5
+        }
+      ]
+  })");
+}
+
 TEST_F (CharacterJsonTests, ChosenSpeed)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -124,6 +124,12 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
 
   ProcessBanking (db, ctx);
 
+  /* Entering buildings should be after moves and movement, so that players
+     enter as soon as possible (perhaps in the same instant the move for it
+     gets confirmed).  It should be before combat targets, so that players
+     entering a building won't be attacked any more.  */
+  ProcessEnterBuildings (db);
+
   FindCombatTargets (db, rnd);
 
 #ifdef ENABLE_SLOW_ASSERTS
@@ -315,6 +321,8 @@ PXLogic::ValidateStateSlow (Database& db, const Context& ctx)
   LOG (INFO) << "Performing slow validation of the game-state database...";
   ValidateCharacterBuildingFactions (db);
   ValidateCharacterLimit (db, ctx);
+  /* FIXME: Validate that characters are only in buildings that match
+     their faction.  */
 }
 
 } // namespace pxd

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -982,6 +982,34 @@ TEST_F (ValidateStateTests, CharacterLimit)
   EXPECT_DEATH (ValidateState (), "Account domob has too many");
 }
 
+TEST_F (ValidateStateTests, CharactersInBuildings)
+{
+  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("andy", Faction::BLUE);
+
+  const auto idAncient
+      = buildings.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId ();
+  const auto idOk
+      = buildings.CreateNew ("checkmark", "domob", Faction::RED)->GetId ();
+  const auto idWrong
+      = buildings.CreateNew ("checkmark", "andy", Faction::BLUE)->GetId ();
+
+  db.SetNextId (10);
+  ASSERT_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 10);
+
+  characters.GetById (10)->SetBuildingId (idAncient);
+  ValidateState ();
+
+  characters.GetById (10)->SetBuildingId (idOk);
+  ValidateState ();
+
+  characters.GetById (10)->SetBuildingId (idWrong);
+  EXPECT_DEATH (ValidateState (), "of opposing faction");
+
+  characters.GetById (10)->SetBuildingId (12345);
+  EXPECT_DEATH (ValidateState (), "is in non-existant building");
+}
+
 /* ************************************************************************** */
 
 } // anonymous namespace

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -924,6 +924,33 @@ TEST_F (PXLogicTests, EnterBuildingAndTargetFinding)
   EXPECT_FALSE (characters.GetById (3)->GetProto ().has_target ());
 }
 
+TEST_F (PXLogicTests, EnterAndExitBuildingWhenOutside)
+{
+  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  ASSERT_EQ (b->GetId (), 1);
+  b->SetCentre (HexCoord (0, 0));
+  b.reset ();
+
+  auto c = CreateCharacter ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 2);
+  c->SetPosition (HexCoord (5, 0));
+  c.reset ();
+
+  /* Entering and exiting a building in the same move will only enter,
+     as the exit is invalid until the enter intents are actually processed
+     (which is after processing moves).  */
+  UpdateState (R"([
+    {
+      "name": "domob",
+      "move": {"c": {"2": {"eb": 1, "xb": {}}}}
+    }
+  ])");
+
+  c = characters.GetById (2);
+  ASSERT_TRUE (c->IsInBuilding ());
+  EXPECT_EQ (c->GetBuildingId (), 1);
+}
+
 /* ************************************************************************** */
 
 using ValidateStateTests = PXLogicTests;

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -827,6 +827,103 @@ TEST_F (PXLogicTests, BankingAndMovement)
   EXPECT_EQ (a->GetBanked ().GetFungibleCount ("foo"), 1);
 }
 
+TEST_F (PXLogicTests, EnterBuildingAfterMovesAndMovement)
+{
+  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  ASSERT_EQ (b->GetId (), 1);
+  b->SetCentre (HexCoord (0, 0));
+  b.reset ();
+
+  auto c = CreateCharacter ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 2);
+  c->SetPosition (HexCoord (6, 0));
+  c->MutableProto ().set_speed (1'000);
+  auto* mv = c->MutableProto ().mutable_movement ();
+  *mv->add_waypoints () = CoordToProto (HexCoord (5, 0));
+  c.reset ();
+
+  /* Setting the "enter building" intent and moving into range both
+     happen in this very update.  */
+  UpdateState (R"([
+    {
+      "name": "domob",
+      "move": {"c": {"2": {"eb": 1}}}
+    }
+  ])");
+
+  c = characters.GetById (2);
+  ASSERT_TRUE (c->IsInBuilding ());
+  EXPECT_EQ (c->GetBuildingId (), 1);
+}
+
+TEST_F (PXLogicTests, EnterBuildingDelayed)
+{
+  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  ASSERT_EQ (b->GetId (), 1);
+  b->SetCentre (HexCoord (0, 0));
+  b.reset ();
+
+  auto c = CreateCharacter ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 2);
+  c->SetPosition (HexCoord (10, 0));
+  c->SetEnterBuilding (1);
+  c->MutableProto ().set_speed (1'000);
+  auto* mv = c->MutableProto ().mutable_movement ();
+  *mv->add_waypoints () = CoordToProto (HexCoord (5, 0));
+  c.reset ();
+
+  /* We will be in range exactly after 5 updates.  */
+  for (unsigned i = 0; i < 5; ++i)
+    {
+      EXPECT_FALSE (characters.GetById (2)->IsInBuilding ());
+      UpdateState ("[]");
+    }
+
+  c = characters.GetById (2);
+  ASSERT_TRUE (c->IsInBuilding ());
+  EXPECT_EQ (c->GetBuildingId (), 1);
+}
+
+TEST_F (PXLogicTests, EnterBuildingAndTargetFinding)
+{
+  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  ASSERT_EQ (b->GetId (), 1);
+  b->SetCentre (HexCoord (0, 0));
+  b.reset ();
+
+  auto c = CreateCharacter ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 2);
+  c->MutableHP ().set_armour (100);
+  c->SetPosition (HexCoord (3, 0));
+  AddUnityAttack (*c, 10);
+  c.reset ();
+
+  c = CreateCharacter ("andy", Faction::BLUE);
+  ASSERT_EQ (c->GetId (), 3);
+  c->MutableHP ().set_armour (100);
+  c->SetPosition (HexCoord (0, 3));
+  AddUnityAttack (*c, 10);
+  c.reset ();
+
+  /* Both characters will target and attack each other.  */
+  UpdateState ("[]");
+
+  EXPECT_EQ (characters.GetById (2)->GetProto ().target ().id (), 3);
+  EXPECT_EQ (characters.GetById (3)->GetProto ().target ().id (), 2);
+
+  /* Now the "domob" character will enter the building, and neither will
+     target the other any more.  */
+  UpdateState (R"([
+    {
+      "name": "domob",
+      "move": {"c": {"2": {"eb": 1}}}
+    }
+  ])");
+
+  EXPECT_FALSE (characters.GetById (2)->GetProto ().has_target ());
+  EXPECT_FALSE (characters.GetById (3)->GetProto ().has_target ());
+}
+
 /* ************************************************************************** */
 
 using ValidateStateTests = PXLogicTests;

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -18,13 +18,24 @@
 
 #include "mining.hpp"
 
-#include "database/character.hpp"
 #include "database/inventory.hpp"
 #include "database/region.hpp"
 #include "proto/roconfig.hpp"
 
 namespace pxd
 {
+
+void
+StopMining (Character& c)
+{
+  if (!c.GetProto ().has_mining ())
+    return;
+
+  VLOG_IF (1, c.GetProto ().mining ().active ())
+      << "Stopping mining with character " << c.GetId ();
+
+  c.MutableProto ().mutable_mining ()->clear_active ();
+}
 
 void
 ProcessAllMining (Database& db, xaya::Random& rnd, const Context& ctx)

--- a/src/mining.hpp
+++ b/src/mining.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,12 +21,19 @@
 
 #include "context.hpp"
 
+#include "database/character.hpp"
 #include "database/database.hpp"
 
 #include <xayautil/random.hpp>
 
 namespace pxd
 {
+
+/**
+ * Stops mining with the given character, if it can mine (and is doing it
+ * at the moment).
+ */
+void StopMining (Character& c);
 
 /**
  * Processes all mining of characters in the current turn.

--- a/src/mining_tests.cpp
+++ b/src/mining_tests.cpp
@@ -94,6 +94,21 @@ protected:
 
 };
 
+TEST_F (MiningTests, StopMining)
+{
+  GetTest ()->MutableProto ().mutable_mining ()->set_active (true);
+  StopMining (*GetTest ());
+  EXPECT_TRUE (GetTest ()->GetProto ().has_mining ());
+  EXPECT_FALSE (GetTest ()->GetProto ().mining ().has_active ());
+  EXPECT_FALSE (GetTest ()->GetProto ().mining ().active ());
+
+  /* If there is no mining field in the proto at all, it will not be
+     added by StopMining.  */
+  GetTest ()->MutableProto ().clear_mining ();
+  StopMining (*GetTest ());
+  EXPECT_FALSE (GetTest ()->GetProto ().has_mining ());
+}
+
 TEST_F (MiningTests, Basic)
 {
   ProcessAllMining (db, rnd, ctx);

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -19,6 +19,7 @@
 #include "moveprocessor.hpp"
 
 #include "jsonutils.hpp"
+#include "mining.hpp"
 #include "movement.hpp"
 #include "prospecting.hpp"
 #include "protoutils.hpp"
@@ -669,13 +670,7 @@ MoveProcessor::MaybeSetCharacterWaypoints (Character& c, const Json::Value& upd)
       << " from waypoints: " << upd["wp"];
 
   StopCharacter (c);
-  if (c.GetProto ().has_mining ())
-    {
-      VLOG_IF (1, c.GetProto ().mining ().active ())
-          << "Stopping mining with character " << c.GetId ()
-          << " because of waypoints command";
-      c.MutableProto ().mutable_mining ()->clear_active ();
-    }
+  StopMining (c);
 
   if (wp.empty ())
     return;

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -224,6 +224,14 @@ BaseMoveProcessor::ParseCharacterWaypoints (const Character& c,
       return false;
     }
 
+  if (c.IsInBuilding ())
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId ()
+          << " is inside a building, can't set waypoints";
+      return false;
+    }
+
   for (const auto& entry : wpArr)
     {
       HexCoord coord;
@@ -339,6 +347,14 @@ BaseMoveProcessor::ParseCharacterProspecting (const Character& c,
       return false;
     }
 
+  if (c.IsInBuilding ())
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId ()
+          << " is inside a building, can't prospect";
+      return false;
+    }
+
   const auto& pos = c.GetPosition ();
   regionId = ctx.Map ().Regions ().GetRegionId (pos);
   VLOG (1)
@@ -366,12 +382,6 @@ BaseMoveProcessor::ParseCharacterMining (const Character& c,
       return false;
     }
 
-  const auto& pos = c.GetPosition ();
-  regionId = ctx.Map ().Regions ().GetRegionId (pos);
-  VLOG (1)
-      << "Character " << c.GetId ()
-      << " wants to start mining region " << regionId;
-
   if (!c.GetProto ().has_mining ())
     {
       LOG (WARNING) << "Character " << c.GetId () << " can't mine";
@@ -384,6 +394,19 @@ BaseMoveProcessor::ParseCharacterMining (const Character& c,
           << "Character " << c.GetId () << " is busy, can't mine";
       return false;
     }
+
+  if (c.IsInBuilding ())
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId () << " is inside a building, can't mine";
+      return false;
+    }
+
+  const auto& pos = c.GetPosition ();
+  regionId = ctx.Map ().Regions ().GetRegionId (pos);
+  VLOG (1)
+      << "Character " << c.GetId ()
+      << " wants to start mining region " << regionId;
 
   if (c.GetProto ().has_movement ())
     {
@@ -722,6 +745,12 @@ MoveProcessor::MaybeDropLoot (Character& c, const Json::Value& cmd)
   if (fungible.empty ())
     return;
 
+  if (c.IsInBuilding ())
+    {
+      LOG (WARNING) << "Drop/pickup inside building is ignored";
+      return;
+    }
+
   std::ostringstream fromName;
   fromName << "character " << c.GetId ();
   std::ostringstream toName;
@@ -740,6 +769,12 @@ MoveProcessor::MaybePickupLoot (Character& c, const Json::Value& cmd)
   const auto fungible = ParseDropPickupFungible (cmd);
   if (fungible.empty ())
     return;
+
+  if (c.IsInBuilding ())
+    {
+      LOG (WARNING) << "Drop/pickup inside building is ignored";
+      return;
+    }
 
   std::ostringstream fromName;
   fromName << "ground loot at " << c.GetPosition ();

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -108,6 +108,15 @@ protected:
                                        std::vector<HexCoord>& wp);
 
   /**
+   * Parses and verifies a potential update to the character's
+   * "enter building" value.  On success, buildingId will be set
+   * to the ID of the building to enter, or EMPTY_ID if the move
+   * is to cancel any current enter command.
+   */
+  bool ParseEnterBuilding (const Character& c, const Json::Value& upd,
+                           Database::IdT& buildingId);
+
+  /**
    * Parses and validates the content of a drop or pick-up character command.
    * Returns the fungible items and their quantities to drop or pick up.
    */
@@ -212,6 +221,11 @@ private:
    * is there.
    */
   static void MaybeSetCharacterWaypoints (Character& c, const Json::Value& upd);
+
+  /**
+   * Processes a command to set (or clear) a character's "enter building".
+   */
+  void MaybeEnterBuilding (Character& c, const Json::Value& upd);
 
   /**
    * Processes a command to start prospecting at the character's current

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -117,6 +117,11 @@ protected:
                            Database::IdT& buildingId);
 
   /**
+   * Parses and verifies a potential update to exit the current building.
+   */
+  static bool ParseExitBuilding (const Character& c, const Json::Value& upd);
+
+  /**
    * Parses and validates the content of a drop or pick-up character command.
    * Returns the fungible items and their quantities to drop or pick up.
    */
@@ -226,6 +231,11 @@ private:
    * Processes a command to set (or clear) a character's "enter building".
    */
   void MaybeEnterBuilding (Character& c, const Json::Value& upd);
+
+  /**
+   * Processes a command to exit a building the character is in.
+   */
+  void MaybeExitBuilding (Character& c, const Json::Value& upd);
 
   /**
    * Processes a command to start prospecting at the character's current

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -648,6 +648,35 @@ TEST_F (CharacterUpdateTests, WhenBusy)
   EXPECT_FALSE (h->GetProto ().mining ().active ());
 }
 
+TEST_F (CharacterUpdateTests, InvalidWhenInsideBuilding)
+{
+  auto h = GetTest ();
+  h->SetBuildingId (10);
+  h->MutableProto ().mutable_prospection ();
+  h->MutableProto ().mutable_mining ();
+  h.reset ();
+
+  Process (R"([
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"wp": [{"x": -3, "y": 4}]}}}
+    },
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"prospect": {}}}}
+    },
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"mine": {}}}}
+    }
+  ])");
+
+  h = GetTest ();
+  EXPECT_EQ (h->GetBusy (), 0);
+  EXPECT_FALSE (h->GetProto ().has_movement ());
+  EXPECT_FALSE (h->GetProto ().mining ().active ());
+}
+
 TEST_F (CharacterUpdateTests, BasicWaypoints)
 {
   /* Set up some stuff that will be cleared.  */

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -93,6 +93,13 @@ PendingState::AddEnterBuilding (const Character& ch,
 }
 
 void
+PendingState::AddExitBuilding (const Character& ch)
+{
+  VLOG (1) << "Adding exit-building command for character " << ch.GetId ();
+  GetCharacterState (ch).exitBuilding = ch.GetBuildingId ();
+}
+
+void
 PendingState::AddCharacterDrop (const Character& ch)
 {
   VLOG (1) << "Adding pending item drop for character " << ch.GetId ();
@@ -215,6 +222,12 @@ PendingState::CharacterState::ToJson () const
       else
         res["enterbuilding"] = IntToJson (enterBuilding);
     }
+  if (exitBuilding != Database::EMPTY_ID)
+    {
+      Json::Value exit(Json::objectValue);
+      exit["building"] = IntToJson (exitBuilding);
+      res["exitbuilding"] = exit;
+    }
 
   res["drop"] = drop;
   res["pickup"] = pickup;
@@ -308,6 +321,8 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
   Database::IdT buildingId;
   if (ParseEnterBuilding (c, upd, buildingId))
     state.AddEnterBuilding (c, buildingId);
+  if (ParseExitBuilding (c, upd))
+    state.AddExitBuilding (c);
 }
 
 void

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -82,6 +82,17 @@ PendingState::AddCharacterWaypoints (const Character& ch,
 }
 
 void
+PendingState::AddEnterBuilding (const Character& ch,
+                                const Database::IdT buildingId)
+{
+  VLOG (1) << "Adding enter-building command for character " << ch.GetId ();
+  auto& chState = GetCharacterState (ch);
+
+  chState.hasEnterBuilding = true;
+  chState.enterBuilding = buildingId;
+}
+
+void
 PendingState::AddCharacterDrop (const Character& ch)
 {
   VLOG (1) << "Adding pending item drop for character " << ch.GetId ();
@@ -197,6 +208,14 @@ PendingState::CharacterState::ToJson () const
       res["waypoints"] = wpJson;
     }
 
+  if (hasEnterBuilding)
+    {
+      if (enterBuilding == Database::EMPTY_ID)
+        res["enterbuilding"] = Json::Value ();
+      else
+        res["enterbuilding"] = IntToJson (enterBuilding);
+    }
+
   res["drop"] = drop;
   res["pickup"] = pickup;
 
@@ -285,6 +304,10 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
           << ": " << upd["wp"];
       state.AddCharacterWaypoints (c, wp);
     }
+
+  Database::IdT buildingId;
+  if (ParseEnterBuilding (c, upd, buildingId))
+    state.AddEnterBuilding (c, buildingId);
 }
 
 void

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -62,6 +62,14 @@ private:
      * that we are removing any movement.
      */
     std::unique_ptr<std::vector<HexCoord>> wp;
+
+    /** Whether or not an "enter building" command is pending.  */
+    bool hasEnterBuilding = false;
+    /**
+     * If there is an enter building command, then this is the ID of the
+     * building (or EMPTY_ID) that will be set on the character.
+     */
+    Database::IdT enterBuilding;
 
     /** Set to true if there is a pending pickup command.  */
     bool pickup = false;
@@ -143,6 +151,11 @@ public:
    */
   void AddCharacterWaypoints (const Character& ch,
                               const std::vector<HexCoord>& wp);
+
+  /**
+   * Updates the state, adding an "enter building" command.
+   */
+  void AddEnterBuilding (const Character& ch, Database::IdT buildingId);
 
   /**
    * Marks the character state as having a pending drop command.

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -71,6 +71,12 @@ private:
      */
     Database::IdT enterBuilding;
 
+    /**
+     * Set to the building the character is in when it has a pending
+     * move to exit.  EMPTY_ID otherwise.
+     */
+    Database::IdT exitBuilding = Database::EMPTY_ID;
+
     /** Set to true if there is a pending pickup command.  */
     bool pickup = false;
 
@@ -156,6 +162,11 @@ public:
    * Updates the state, adding an "enter building" command.
    */
   void AddEnterBuilding (const Character& ch, Database::IdT buildingId);
+
+  /**
+   * Updates the state, turning on the "exit building" flag.
+   */
+  void AddExitBuilding (const Character& ch);
 
   /**
    * Marks the character state as having a pending drop command.

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -22,6 +22,7 @@
 #include "testutils.hpp"
 
 #include "database/account.hpp"
+#include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
 #include "database/region.hpp"
@@ -87,6 +88,7 @@ TEST_F (PendingStateTests, Clear)
 
   auto h = characters.CreateNew ("domob", Faction::RED);
   state.AddCharacterWaypoints (*h, {});
+  state.AddEnterBuilding (*h, 42);
   state.AddCharacterDrop (*h);
   state.AddCharacterPickup (*h);
   h.reset ();
@@ -141,6 +143,38 @@ TEST_F (PendingStateTests, Waypoints)
           {
             "id": 3,
             "waypoints": []
+          }
+        ]
+    }
+  )");
+}
+
+TEST_F (PendingStateTests, EnterBuilding)
+{
+  auto c1 = characters.CreateNew ("domob", Faction::RED);
+  auto c2 = characters.CreateNew ("domob", Faction::RED);
+
+  ASSERT_EQ (c1->GetId (), 1);
+  ASSERT_EQ (c2->GetId (), 2);
+
+  state.AddEnterBuilding (*c1, 42);
+  state.AddEnterBuilding (*c1, 45);
+  state.AddEnterBuilding (*c2, Database::EMPTY_ID);
+
+  c1.reset ();
+  c2.reset ();
+
+  ExpectStateJson (R"(
+    {
+      "characters":
+        [
+          {
+            "id": 1,
+            "enterbuilding": 45
+          },
+          {
+            "id": 2,
+            "enterbuilding": "null"
           }
         ]
     }
@@ -395,8 +429,10 @@ private:
 
 protected:
 
+  BuildingsTable buildings;
+
   PendingStateUpdaterTests ()
-    : updater(db, state, ctx)
+    : updater(db, state, ctx), buildings(db)
   {}
 
   /**
@@ -576,6 +612,53 @@ TEST_F (PendingStateUpdaterTests, Waypoints)
         [
           {"id": 2, "waypoints": []},
           {"id": 3, "waypoints": [{"x": 1, "y": -2}]}
+        ]
+    }
+  )");
+}
+
+TEST_F (PendingStateUpdaterTests, EnterBuilding)
+{
+  accounts.CreateNew ("domob", Faction::RED);
+
+  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
+  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 2);
+  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 3);
+
+  db.SetNextId (100);
+  buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  buildings.CreateNew ("checkmark", "domob", Faction::RED);
+
+  /* Some invalid updates that will just not show up (i.e. ID 1 will have no
+     pending updates later on).  */
+  Process ("domob", R"({
+    "c": {"1": {"eb": "foo"}}
+  })");
+  Process ("domob", R"({
+    "c": {"1": {"eb": 20}}
+  })");
+
+  /* Perform valid updates.  */
+  Process ("domob", R"({
+    "c":
+      {
+        "2": {"eb": 100},
+        "3": {"eb": null}
+      }
+  })");
+  Process ("domob", R"({
+    "c":
+      {
+        "2": {"eb": 101}
+      }
+  })");
+
+  ExpectStateJson (R"(
+    {
+      "characters":
+        [
+          {"id": 2, "enterbuilding": 101},
+          {"id": 3, "enterbuilding": "null"}
         ]
     }
   )");

--- a/src/spawn.hpp
+++ b/src/spawn.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -32,6 +32,16 @@
 
 namespace pxd
 {
+
+/**
+ * Chooses the actual spawn location for a new character of the given faction.
+ * This places them randomly within the given radius around the centre,
+ * displacing them as needed to find an accessible spot.  This function is
+ * also used for leaving buildings.
+ */
+HexCoord ChooseSpawnLocation (const HexCoord& centre, HexCoord::IntT radius,
+                              const Faction f, xaya::Random& rnd,
+                              const DynObstacles& dyn, const BaseMap& map);
 
 /**
  * Spawns a new character on the map.  This takes care of initialising the


### PR DESCRIPTION
This implements #80:  Characters can now enter and leave buildings (and thus can be inside a building in addition to on the map).  If a character is inside a building, the `inbuilding` field in its JSON will specify the building ID, rather than there being a hex coordinate.  Characters in buildings won't be affected by combat.

Any character may enter an ancient building, and characters can also enter buildings of their own faction (but not other factions).

To enter a building, a character can send a move like this:

    {"c": {"42": {"eb": 123}}}

This will then store in the game state an intent that character 42 wants to enter building 123.  (Which is also visible with `enterbuilding` in the character JSON.)  This move can be sent any time except when inside a building, even while e.g. prospecting or far away from the building.  It can also be sent e.g. together with a waypoints command that moves the character towards the building.

The "enter building" intent can also be "unset" if needed:

    {"c": {"42": {"eb": null}}}

If a character has the enter-building intent set, is not prospecting at the moment and is close enough to a building, then they will automatically enter the building.  This stops any existing movement or mining.

When inside, a character can again leave a building with a move like this:

    {"c": {"42": {"xb": {}}}}

This will place them on the map at a random free location around the building (similar to spawning).

Both "enter" and "exit" moves are also tracked in the pending state.