### PR TITLE
Add item inventories to buildings

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -258,6 +258,27 @@ CREATE TABLE IF NOT EXISTS `ground_loot` (
 
 -- =============================================================================
 
+-- Data for the inventories that accounts have in buildings.
+CREATE TABLE IF NOT EXISTS `building_inventories` (
+
+  -- The ID of the building this is for.
+  `building` INTEGER NOT NULL,
+
+  -- The account that owns the stuff.
+  `account` TEXT NOT NULL,
+
+  -- Serialised inventory proto.
+  `inventory` BLOB NOT NULL,
+
+  PRIMARY KEY (`building`, `account`)
+
+);
+
+CREATE INDEX IF NOT EXISTS `building_inventories_by_account`
+  ON `building_inventories` (`account`);
+
+-- =============================================================================
+
 -- Data about the still available prospecting prizes (so that we can
 -- ensure only a certain number can be found).
 CREATE TABLE IF NOT EXISTS `prizes` (

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -6,6 +6,7 @@ REGTESTS = \
   banking.py \
   buildings_basic.py \
   buildings_enterexit.py \
+  buildings_inventory.py \
   character_limit.py \
   characters.py \
   charon.py \

--- a/gametest/buildings_inventory.py
+++ b/gametest/buildings_inventory.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests account inventories in buildings.
+"""
+
+from pxtest import PXTest
+
+
+class BuildingsInventoriesTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("Placing a building and some loot...")
+    self.build ("checkmark", None, {"x": 0, "y": 0}, rot=0)
+    building = 1001
+    self.assertEqual (self.getBuildings ()[building].getType (), "checkmark")
+    self.pos = {"x": 3, "y": 0}
+    self.dropLoot (self.pos, {"foo": 1, "zerospace": 5})
+    self.generate (1)
+    reorgBlock = self.rpc.xaya.getbestblockhash ()
+
+    self.mainLogger.info ("Entering building with character...")
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob")
+    self.generate (1)
+    self.moveCharactersTo ({"domob": self.pos})
+    self.getCharacters ()["domob"].sendMove ({
+      "pu": {"f": {"foo": 10, "zerospace": 10}},
+      "eb": building,
+    })
+    self.generate (1)
+
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isInBuilding (), True)
+    self.assertEqual (c.getFungibleInventory (), {
+      "foo": 1,
+      "zerospace": 5,
+    })
+    self.assertEqual (self.getLoot (self.pos), {})
+
+    self.mainLogger.info ("Dropping loot in building...")
+    self.getCharacters ()["domob"].sendMove ({
+      "drop": {"f": {"foo": 10, "zerospace": 10}},
+    })
+    self.generate (1)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.getFungibleInventory (), {})
+    b = self.getBuildings ()[building]
+    self.assertEqual (b.getFungibleInventory ("domob"), {
+      "foo": 1,
+      "zerospace": 5,
+    })
+
+    self.mainLogger.info ("Picking up from building and leaving...")
+    self.getCharacters ()["domob"].sendMove ({
+      "pu": {"f": {"foo": 10, "zerospace": 10}},
+      "xb": {},
+    })
+    self.generate (1)
+
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isInBuilding (), False)
+    self.assertEqual (c.getFungibleInventory (), {
+      "foo": 1,
+      "zerospace": 5,
+    })
+    b = self.getBuildings ()[building]
+    self.assertEqual (b.getFungibleInventory ("domob"), {})
+
+    self.testReorg (reorgBlock)
+
+  def testReorg (self, blk):
+    self.mainLogger.info ("Testing reorg...")
+
+    originalState = self.getGameState ()
+    self.rpc.xaya.invalidateblock (blk)
+
+    self.assertEqual (self.getLoot (self.pos), {
+      "foo": 1,
+      "zerospace": 5,
+    })
+
+    self.rpc.xaya.reconsiderblock (blk)
+    self.expectGameState (originalState)
+    
+
+if __name__ == "__main__":
+  BuildingsInventoriesTest ().main ()

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -74,6 +74,7 @@ class GodModeTest (PXTest):
           {"x": 101, "y": 149},
           {"x": 102, "y": 148},
         ],
+      "inventories": {},
     })
     self.assertEqual (buildings[1003].data, {
       "id": 1003,
@@ -89,6 +90,7 @@ class GodModeTest (PXTest):
           {"x": -100, "y": -149},
           {"x": -100, "y": -148},
         ],
+      "inventories": {},
     })
 
     self.mainLogger.info ("Testing drop loot...")

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -134,6 +134,12 @@ class Building (object):
       return self.data["owner"]
     return None
 
+  def getFungibleInventory (self, account):
+    inv = self.data["inventories"]
+    if account not in inv:
+      return collections.Counter ()
+    return collections.Counter (inv[account]["fungible"])
+
 
 class Account (object):
   """
@@ -335,6 +341,18 @@ class PXTest (XayaGameTest):
       res[curId] = handle
 
     return res
+
+  def getLoot (self, pos):
+    """
+    Returns the ground-loot inventory at a given location.
+    """
+
+    loot = self.getRpc ("getgroundloot")
+    for l in loot:
+      if l["position"] == pos:
+        return collections.Counter (l["inventory"]["fungible"])
+
+    return collections.Counter ()
 
   def getRegion (self, regionId):
     """

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -26,7 +26,6 @@
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/faction.hpp"
-#include "database/inventory.hpp"
 #include "database/prizes.hpp"
 #include "database/region.hpp"
 #include "hexagonal/pathfinder.hpp"
@@ -333,6 +332,15 @@ template <>
   for (const auto& c : GetBuildingShape (b))
     tiles.append (CoordToJson (c));
   res["tiles"] = tiles;
+
+  auto invRes = buildingInventories.QueryForBuilding (b.GetId ());
+  Json::Value inv(Json::objectValue);
+  while (invRes.Step ())
+    {
+      auto h = buildingInventories.GetFromResult (invRes);
+      inv[h->GetAccount ()] = Convert (h->GetInventory ());
+    }
+  res["inventories"] = inv;
 
   return res;
 }

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -23,6 +23,7 @@
 
 #include "database/damagelists.hpp"
 #include "database/database.hpp"
+#include "database/inventory.hpp"
 #include "mapdata/basemap.hpp"
 
 #include <json/json.h>
@@ -40,6 +41,13 @@ private:
 
   /** Database to read from.  */
   Database& db;
+
+  /**
+   * Database table to access building inventories.  This needs to be a
+   * member field so that the "convert" function for buildings can access
+   * it without needing any more arguments.
+   */
+  mutable BuildingInventoriesTable buildingInventories;
 
   /** Damage lists accessor (for adding the attackers to a character JSON).  */
   const DamageLists dl;
@@ -60,7 +68,7 @@ private:
 public:
 
   explicit GameStateJson (Database& d, const Params& p, const BaseMap& m)
-    : db(d), dl(db), params(p), map(m)
+    : db(d), buildingInventories(db), dl(db), params(p), map(m)
   {}
 
   GameStateJson () = delete;

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -588,9 +588,10 @@ class BuildingJsonTests : public GameStateJsonTests
 protected:
 
   BuildingsTable tbl;
+  BuildingInventoriesTable inv;
 
   BuildingJsonTests ()
-    : tbl(db)
+    : tbl(db), inv(db)
   {}
 
 };
@@ -633,6 +634,44 @@ TEST_F (BuildingJsonTests, Ancient)
         {
           "owner": null,
           "faction": "a"
+        }
+      ]
+  })");
+}
+
+TEST_F (BuildingJsonTests, Inventories)
+{
+  ASSERT_EQ (tbl.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId (), 1);
+
+  inv.Get (1, "domob")->GetInventory ().SetFungibleCount ("foo", 2);
+  inv.Get (42, "domob")->GetInventory ().SetFungibleCount ("foo", 100);
+  inv.Get (1, "andy")->GetInventory ().SetFungibleCount ("bar", 1);
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "inventories":
+            {
+              "andy": {"fungible": {"bar": 1}},
+              "domob": {"fungible": {"foo": 2}}
+            }
+        }
+      ]
+  })");
+
+  inv.Get (1, "domob")->GetInventory ().SetFungibleCount ("foo", 0);
+  inv.Get (1, "andy")->GetInventory ().SetFungibleCount ("bar", 0);
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "inventories":
+            {
+              "andy": null,
+              "domob": null
+            }
         }
       ]
   })");

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -345,6 +345,28 @@ ValidateCharactersInBuildings (Database& db)
     }
 }
 
+/**
+ * Verifies that all "in building" inventories have an existing
+ * building and account association.
+ */
+void
+ValidateBuildingInventories (Database& db)
+{
+  BuildingInventoriesTable inv(db);
+  AccountsTable accounts(db);
+  BuildingsTable buildings(db);
+
+  auto res = inv.QueryAll ();
+  while (res.Step ())
+    {
+      auto h = inv.GetFromResult (res);
+      CHECK (buildings.GetById (h->GetBuildingId ()) != nullptr)
+          << "Inventory for non-existant building " << h->GetBuildingId ();
+      CHECK (accounts.GetByName (h->GetAccount ()) != nullptr)
+          << "Inventory for non-existant account " << h->GetAccount ();
+    }
+}
+
 } // anonymous namespace
 
 void
@@ -354,6 +376,7 @@ PXLogic::ValidateStateSlow (Database& db, const Context& ctx)
   ValidateCharacterBuildingFactions (db);
   ValidateCharacterLimit (db, ctx);
   ValidateCharactersInBuildings (db);
+  ValidateBuildingInventories (db);
 }
 
 } // namespace pxd

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -75,12 +75,13 @@ protected:
   AccountsTable accounts;
   BuildingsTable buildings;
   CharacterTable characters;
+  BuildingInventoriesTable inv;
   GroundLootTable groundLoot;
   RegionsTable regions;
 
   PXLogicTests ()
     : accounts(db), buildings(db), characters(db),
-      groundLoot(db), regions(db, HEIGHT)
+      inv(db), groundLoot(db), regions(db, HEIGHT)
   {
     InitialisePrizes (db, ctx.Params ());
   }
@@ -1035,6 +1036,23 @@ TEST_F (ValidateStateTests, CharactersInBuildings)
 
   characters.GetById (10)->SetBuildingId (12345);
   EXPECT_DEATH (ValidateState (), "is in non-existant building");
+}
+
+TEST_F (ValidateStateTests, BuildingInventories)
+{
+  db.SetNextId (10);
+  accounts.CreateNew ("domob", Faction::RED);
+  buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+
+  inv.Get (10, "andy")->GetInventory ().SetFungibleCount ("foo", 1);
+  EXPECT_DEATH (ValidateState (), "non-existant account");
+  accounts.CreateNew ("andy", Faction::GREEN);
+  ValidateState ();
+
+  inv.Get (11, "domob")->GetInventory ().SetFungibleCount ("foo", 1);
+  EXPECT_DEATH (ValidateState (), "non-existant building");
+  buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  ValidateState ();
 }
 
 /* ************************************************************************** */

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -83,6 +83,9 @@ protected:
   /** Access handle for ground loot.  */
   GroundLootTable groundLoot;
 
+  /** Access handle for building inventories.  */
+  BuildingInventoriesTable buildingInv;
+
   /** Access to the regions table.  */
   RegionsTable regions;
 


### PR DESCRIPTION
With this set of changes, we allow each account to own an inventory of items inside each building.  These inventories are unrestricted in cargo space, and the account owner can transport items into and out of a building with their characters as needed.

The game-state JSON for buildings now contains a JSON object keyed by account name holding the inventories of all people who own anything in the building.

Items can be dropped and picked up inside the building with a character in the same way (with the same moves) as outside, except that these moves will now interact with the account inventory in the building instead of with ground loot.