### PR TITLE
Implement combat with buildings

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -16,6 +16,7 @@ libdatabase_la_SOURCES = \
   account.cpp \
   building.cpp \
   character.cpp \
+  combat.cpp \
   coord.cpp \
   damagelists.cpp \
   database.cpp \
@@ -30,6 +31,7 @@ noinst_HEADERS = \
   account.hpp \
   building.hpp \
   character.hpp \
+  combat.hpp \
   coord.hpp coord.tpp \
   damagelists.hpp \
   database.hpp database.tpp \
@@ -74,6 +76,7 @@ tests_SOURCES = \
   account_tests.cpp \
   building_tests.cpp \
   character_tests.cpp \
+  combat_tests.cpp \
   coord_tests.cpp \
   damagelists_tests.cpp \
   database_tests.cpp \

--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -31,7 +31,7 @@ noinst_HEADERS = \
   account.hpp \
   building.hpp \
   character.hpp \
-  combat.hpp \
+  combat.hpp combat.tpp \
   coord.hpp coord.tpp \
   damagelists.hpp \
   database.hpp database.tpp \

--- a/database/building.cpp
+++ b/database/building.cpp
@@ -146,4 +146,17 @@ BuildingsTable::QueryAll ()
   return stmt.Query<BuildingResult> ();
 }
 
+void
+BuildingsTable::DeleteById (const Database::IdT id)
+{
+  VLOG (1) << "Deleting building with ID " << id;
+
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `buildings`
+      WHERE `id` = ?1
+  )");
+  stmt.Bind (1, id);
+  stmt.Execute ();
+}
+
 } // namespace pxd

--- a/database/building.hpp
+++ b/database/building.hpp
@@ -19,6 +19,7 @@
 #ifndef DATABASE_BUILDING_HPP
 #define DATABASE_BUILDING_HPP
 
+#include "combat.hpp"
 #include "coord.hpp"
 #include "database.hpp"
 #include "faction.hpp"
@@ -32,7 +33,8 @@ namespace pxd
 /**
  * Database result for a row from the buildings table.
  */
-struct BuildingResult : public ResultWithFaction, public ResultWithCoord
+struct BuildingResult : public ResultWithFaction, public ResultWithCoord,
+                        public ResultWithCombat
 {
   RESULT_COLUMN (int64_t, id, 1);
   RESULT_COLUMN (std::string, type, 2);
@@ -46,13 +48,10 @@ struct BuildingResult : public ResultWithFaction, public ResultWithCoord
  *
  * Instantiations of this class should be made through the BuildingsTable.
  */
-class Building
+class Building : public CombatEntity
 {
 
 private:
-
-  /** Database reference this belongs to.  */
-  Database& db;
 
   /** The ID of the building.  */
   Database::IdT id;
@@ -72,12 +71,6 @@ private:
   /** Generic data stored in the proto BLOB.  */
   LazyProto<proto::Building> data;
 
-  /**
-   * Whether or not this is a new building that needs to be inserted into
-   * the database in the destructor.
-   */
-  bool isNew;
-
   /** Whether or not non-proto fields have been modified.  */
   bool dirtyFields;
 
@@ -95,6 +88,20 @@ private:
   explicit Building (Database& d, const Database::Result<BuildingResult>& res);
 
   friend class BuildingsTable;
+
+protected:
+
+  bool
+  IsDirtyCombatData () const override
+  {
+    return data.IsDirty ();
+  }
+
+  const proto::CombatData&
+  GetCombatData () const override
+  {
+    return data.Get ().combat_data ();
+  }
 
 public:
 
@@ -213,6 +220,22 @@ public:
    * Queries the database for all buildings.
    */
   Database::Result<BuildingResult> QueryAll ();
+
+  /**
+   * Queries for all buildings with attacks.
+   */
+  Database::Result<BuildingResult> QueryWithAttacks ();
+
+  /**
+   * Queries for all buildings that may need to have HP regenerated.
+   */
+  Database::Result<BuildingResult> QueryForRegen ();
+
+  /**
+   * Queries for all buildings that have a combat target and thus need
+   * to be processed for damage.
+   */
+  Database::Result<BuildingResult> QueryWithTarget ();
 
   /**
    * Deletes the row for a given building ID.

--- a/database/building.hpp
+++ b/database/building.hpp
@@ -214,6 +214,11 @@ public:
    */
   Database::Result<BuildingResult> QueryAll ();
 
+  /**
+   * Deletes the row for a given building ID.
+   */
+  void DeleteById (Database::IdT id);
+
 };
 
 } // namespace pxd

--- a/database/building.hpp
+++ b/database/building.hpp
@@ -97,12 +97,6 @@ protected:
     return data.IsDirty ();
   }
 
-  const proto::CombatData&
-  GetCombatData () const override
-  {
-    return data.Get ().combat_data ();
-  }
-
 public:
 
   /**
@@ -167,6 +161,12 @@ public:
   MutableProto ()
   {
     return data.Mutable ();
+  }
+
+  const proto::CombatData&
+  GetCombatData () const override
+  {
+    return data.Get ().combat_data ();
   }
 
 };

--- a/database/building_tests.cpp
+++ b/database/building_tests.cpp
@@ -141,6 +141,20 @@ TEST_F (BuildingsTableTests, QueryAll)
   ASSERT_FALSE (res.Step ());
 }
 
+TEST_F (BuildingsTableTests, DeleteById)
+{
+  auto id1 = tbl.CreateNew ("turret", "domob", Faction::RED)->GetId ();
+  auto id2 = tbl.CreateNew ("turret", "andy", Faction::GREEN)->GetId ();
+
+  ASSERT_NE (tbl.GetById (id2), nullptr);
+  tbl.DeleteById (id2);
+  ASSERT_EQ (tbl.GetById (id2), nullptr);
+
+  auto h = tbl.GetById (id1);
+  ASSERT_NE (h, nullptr);
+  EXPECT_EQ (h->GetOwner (), "domob");
+}
+
 /* ************************************************************************** */
 
 } // anonymous namespace

--- a/database/building_tests.cpp
+++ b/database/building_tests.cpp
@@ -114,6 +114,37 @@ TEST_F (BuildingTests, ModificationOfFields)
   EXPECT_EQ (h->GetFaction (), Faction::RED);
 }
 
+TEST_F (BuildingTests, CombatFields)
+{
+  const auto id = tbl.CreateNew ("turret", "andy", Faction::RED)->GetId ();
+
+  auto h = tbl.GetById (id);
+  EXPECT_EQ (h->GetAttackRange (), 0);
+  auto* att = h->MutableProto ().mutable_combat_data ()->add_attacks ();
+  att->set_range (5);
+  h.reset ();
+
+  h = tbl.GetById (id);
+  EXPECT_EQ (h->GetProto ().combat_data ().attacks_size (), 1);
+  EXPECT_EQ (h->GetAttackRange (), 5);
+  h->MutableHP ().set_armour (10);
+  h.reset ();
+
+  h = tbl.GetById (id);
+  EXPECT_EQ (h->GetHP ().armour (), 10);
+  h->MutableRegenData ().set_shield_regeneration_mhp (42);
+  h.reset ();
+
+  h = tbl.GetById (id);
+  EXPECT_EQ (h->GetRegenData ().shield_regeneration_mhp (), 42);
+  h->MutableTarget ().set_id (50);
+  h.reset ();
+
+  h = tbl.GetById (id);
+  EXPECT_EQ (h->GetTarget ().id (), 50);
+  h.reset ();
+}
+
 /* ************************************************************************** */
 
 using BuildingsTableTests = BuildingTests;
@@ -136,6 +167,62 @@ TEST_F (BuildingsTableTests, QueryAll)
   auto res = tbl.QueryAll ();
   ASSERT_TRUE (res.Step ());
   EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "domob");
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "andy");
+  ASSERT_FALSE (res.Step ());
+}
+
+TEST_F (BuildingsTableTests, QueryWithAttacks)
+{
+  tbl.CreateNew ("checkmark", "domob", Faction::RED);
+  tbl.CreateNew ("checkmark", "andy", Faction::RED)
+    ->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (1);
+
+  auto res = tbl.QueryWithAttacks ();
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "andy");
+  ASSERT_FALSE (res.Step ());
+}
+
+TEST_F (BuildingsTableTests, QueryForRegen)
+{
+  /* This test is much more basic than the one for CharacterTable,
+     because the underlying code is shared anyway.  We do not cover all
+     the different cases here, just check that the function works
+     in general (i.e. queries correctly in SQL).  */
+
+  tbl.CreateNew ("checkmark", "no regen", Faction::RED);
+
+  auto h = tbl.CreateNew ("checkmark", "can regen", Faction::RED);
+  h->MutableHP ().set_shield (10);
+  h->MutableRegenData ().mutable_max_hp ()->set_shield (100);
+  h->MutableRegenData ().set_shield_regeneration_mhp (1);
+  h.reset ();
+
+  auto res = tbl.QueryForRegen ();
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "can regen");
+  ASSERT_FALSE (res.Step ());
+}
+
+TEST_F (BuildingsTableTests, QueryWithTarget)
+{
+  auto h = tbl.CreateNew ("turret", "domob", Faction::RED);
+  const auto id1 = h->GetId ();
+  h->MutableTarget ().set_id (5);
+  h.reset ();
+
+  const auto id2 = tbl.CreateNew ("turret", "andy", Faction::GREEN)->GetId ();
+
+  auto res = tbl.QueryWithTarget ();
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "domob");
+  ASSERT_FALSE (res.Step ());
+
+  tbl.GetById (id1)->MutableTarget ().clear_id ();
+  tbl.GetById (id2)->MutableTarget ().set_id (42);
+
+  res = tbl.QueryWithTarget ();
   ASSERT_TRUE (res.Step ());
   EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "andy");
   ASSERT_FALSE (res.Step ());

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -323,6 +323,19 @@ CharacterTable::QueryForOwner (const std::string& owner)
 }
 
 Database::Result<CharacterResult>
+CharacterTable::QueryForBuilding (const Database::IdT building)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `characters`
+      WHERE `inbuilding` = ?1
+      ORDER BY `id`
+  )");
+  stmt.Bind (1, building);
+  return stmt.Query<CharacterResult> ();
+}
+
+Database::Result<CharacterResult>
 CharacterTable::QueryMoving ()
 {
   auto stmt = db.Prepare (R"(

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -18,8 +18,6 @@
 
 #include "character.hpp"
 
-#include "fighter.hpp"
-
 #include "proto/roconfig.hpp"
 
 #include <glog/logging.h>
@@ -84,7 +82,7 @@ Character::~Character ()
 
   bool canRegen = oldCanRegen;
   if (hp.IsDirty () || regenData.IsDirty ())
-    canRegen = ComputeCanRegen ();
+    canRegen = ComputeCanRegen (hp.Get (), regenData.Get ());
 
   if (isNew || regenData.IsDirty () || inv.IsDirty () || data.IsDirty ())
     {
@@ -233,17 +231,6 @@ Character::GetBuildingId () const
 {
   CHECK (IsInBuilding ());
   return inBuilding;
-}
-
-bool
-Character::ComputeCanRegen () const
-{
-  const auto& regenPb = regenData.Get ();
-
-  if (regenPb.shield_regeneration_mhp () == 0)
-    return false;
-
-  return hp.Get ().shield () < regenPb.max_hp ().shield ();
 }
 
 HexCoord::IntT

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -422,6 +422,11 @@ public:
   Database::Result<CharacterResult> QueryForOwner (const std::string& owner);
 
   /**
+   * Queries all characters that are in a given building.
+   */
+  Database::Result<CharacterResult> QueryForBuilding (Database::IdT building);
+
+  /**
    * Queries for all characters that are currently moving (and thus may need
    * to be updated for move stepping).
    */

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -143,12 +143,6 @@ protected:
     return data.IsDirty ();
   }
 
-  const proto::CombatData&
-  GetCombatData () const override
-  {
-    return data.Get ().combat_data ();
-  }
-
 public:
 
   /**
@@ -286,6 +280,12 @@ public:
    * Returns the used cargo space for the character's inventory.
    */
   uint64_t UsedCargoSpace () const;
+
+  const proto::CombatData&
+  GetCombatData () const override
+  {
+    return data.Get ().combat_data ();
+  }
 
 };
 

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -50,10 +50,9 @@ struct CharacterResult : public ResultWithFaction, public ResultWithCoord,
   RESULT_COLUMN (int64_t, inbuilding, 3);
   RESULT_COLUMN (int64_t, enterbuilding, 4);
   RESULT_COLUMN (pxd::proto::VolatileMovement, volatilemv, 5);
-  RESULT_COLUMN (pxd::proto::RegenData, regendata, 6);
-  RESULT_COLUMN (int64_t, busy, 7);
-  RESULT_COLUMN (pxd::proto::Inventory, inventory, 8);
-  RESULT_COLUMN (pxd::proto::Character, proto, 9);
+  RESULT_COLUMN (int64_t, busy, 6);
+  RESULT_COLUMN (pxd::proto::Inventory, inventory, 7);
+  RESULT_COLUMN (pxd::proto::Character, proto, 8);
 };
 
 /**
@@ -105,6 +104,13 @@ private:
    */
   LazyProto<proto::RegenData> regenData;
 
+  /**
+   * The selected target as TargetId proto, if any.  If there is no target,
+   * then the underlying database column is NULL, and this proto will have
+   * no fields set.
+   */
+  LazyProto<proto::TargetId> target;
+
   /** The number of blocks (or zero) the character is still busy.  */
   int busy;
 
@@ -122,12 +128,6 @@ private:
    * the RegenData or HP have been modified.
    */
   bool oldCanRegen;
-
-  /**
-   * Stores the flag of whether or not the character had a combat target
-   * originally in the database.
-   */
-  bool hasTarget;
 
   /**
    * Set to true if this is a new character, so we know that we have to
@@ -294,6 +294,18 @@ public:
     return regenData.Mutable ();
   }
 
+  const proto::TargetId&
+  GetTarget () const
+  {
+    return target.Get ();
+  }
+
+  proto::TargetId&
+  MutableTarget ()
+  {
+    return target.Mutable ();
+  }
+
   unsigned
   GetBusy () const
   {
@@ -339,14 +351,6 @@ public:
    * column in the database directly.
    */
   HexCoord::IntT GetAttackRange () const;
-
-  /**
-   * Returns whether or not the character has a combat target.  This works
-   * without parsing the main proto, and can thus be used for efficient checks
-   * during target finding.  Note that the method must not be called if the
-   * character is new or if the main proto has been modified.
-   */
-  bool HasTarget () const;
 
   /**
    * Returns the used cargo space for the character's inventory.

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -19,6 +19,7 @@
 #ifndef DATABASE_CHARACTER_HPP
 #define DATABASE_CHARACTER_HPP
 
+#include "combat.hpp"
 #include "coord.hpp"
 #include "database.hpp"
 #include "faction.hpp"
@@ -41,21 +42,18 @@ namespace pxd
 /**
  * Database result type for rows from the characters table.
  */
-struct CharacterResult : public ResultWithFaction, public ResultWithCoord
+struct CharacterResult : public ResultWithFaction, public ResultWithCoord,
+                         public ResultWithCombat
 {
   RESULT_COLUMN (int64_t, id, 1);
   RESULT_COLUMN (std::string, owner, 2);
   RESULT_COLUMN (int64_t, inbuilding, 3);
   RESULT_COLUMN (int64_t, enterbuilding, 4);
   RESULT_COLUMN (pxd::proto::VolatileMovement, volatilemv, 5);
-  RESULT_COLUMN (pxd::proto::HP, hp, 6);
-  RESULT_COLUMN (pxd::proto::RegenData, regendata, 7);
-  RESULT_COLUMN (int64_t, busy, 8);
-  RESULT_COLUMN (pxd::proto::Inventory, inventory, 9);
-  RESULT_COLUMN (pxd::proto::Character, proto, 10);
-  RESULT_COLUMN (int64_t, attackrange, 11);
-  RESULT_COLUMN (bool, canregen, 12);
-  RESULT_COLUMN (bool, hastarget, 13);
+  RESULT_COLUMN (pxd::proto::RegenData, regendata, 6);
+  RESULT_COLUMN (int64_t, busy, 7);
+  RESULT_COLUMN (pxd::proto::Inventory, inventory, 8);
+  RESULT_COLUMN (pxd::proto::Character, proto, 9);
 };
 
 /**
@@ -173,12 +171,6 @@ private:
    * is any mismatch in the fields.
    */
   void Validate () const;
-
-  /**
-   * Computes the "canregen" field based on our protos.  This forces parsing
-   * of the main data proto, so it should only be called when needed.
-   */
-  bool ComputeCanRegen () const;
 
   friend class CharacterTable;
 

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -292,6 +292,28 @@ TEST_F (CharacterTableTests, QueryForOwner)
   ASSERT_FALSE (res.Step ());
 }
 
+TEST_F (CharacterTableTests, QueryForBuilding)
+{
+  tbl.CreateNew ("domob", Faction::RED)->GetId ();
+  const auto id2 = tbl.CreateNew ("domob", Faction::RED)->GetId ();
+  const auto id3 = tbl.CreateNew ("domob", Faction::RED)->GetId ();
+  const auto id4 = tbl.CreateNew ("domob", Faction::RED)->GetId ();
+
+  tbl.GetById (id4)->SetBuildingId (10);
+  tbl.GetById (id2)->SetBuildingId (10);
+  tbl.GetById (id3)->SetBuildingId (42);
+
+  auto res = tbl.QueryForBuilding (10);
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), id2);
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), id4);
+  ASSERT_FALSE (res.Step ());
+
+  res = tbl.QueryForBuilding (12345);
+  ASSERT_FALSE (res.Step ());
+}
+
 TEST_F (CharacterTableTests, QueryMoving)
 {
   tbl.CreateNew ("domob", Faction::RED);

--- a/database/combat.cpp
+++ b/database/combat.cpp
@@ -1,0 +1,46 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "combat.hpp"
+
+namespace pxd
+{
+
+bool
+ComputeCanRegen (const proto::HP& hp, const proto::RegenData& regen)
+{
+  if (regen.shield_regeneration_mhp () == 0)
+    return false;
+
+  return hp.shield () < regen.max_hp ().shield ();
+}
+
+HexCoord::IntT
+FindAttackRange (const proto::CombatData& cd)
+{
+  HexCoord::IntT res = 0;
+  for (const auto& attack : cd.attacks ())
+    {
+      CHECK_GT (attack.range (), 0);
+      res = std::max<HexCoord::IntT> (res, attack.range ());
+    }
+
+  return res;
+}
+
+} // namespace pxd

--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -1,0 +1,57 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_COMBAT_HPP
+#define DATABASE_COMBAT_HPP
+
+#include "database.hpp"
+#include "lazyproto.hpp"
+
+#include "hexagonal/coord.hpp"
+#include "proto/combat.pb.h"
+
+namespace pxd
+{
+
+/**
+ * Database result type for rows that have basic combat fields (i.e.
+ * characters and buildings).
+ */
+struct ResultWithCombat : public Database::ResultType
+{
+  RESULT_COLUMN (pxd::proto::HP, hp, 53);
+  RESULT_COLUMN (int64_t, attackrange, 54);
+  RESULT_COLUMN (bool, canregen, 55);
+  RESULT_COLUMN (bool, hastarget, 56);
+};
+
+/**
+ * Computes (from HP and RegenData protos) whether or not an entity
+ * needs to regenerate HP.
+ */
+bool ComputeCanRegen (const proto::HP& hp, const proto::RegenData& regen);
+
+/**
+ * Computes the attack range of a fighter with the given combat data.
+ * Returns zero if there are no attacks at all.
+ */
+HexCoord::IntT FindAttackRange (const proto::CombatData& cd);
+
+} // namespace pxd
+
+#endif // DATABASE_COMBAT_HPP

--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -167,11 +167,6 @@ protected:
    */
   virtual bool IsDirtyCombatData () const = 0;
 
-  /**
-   * Subclasses must implement this to return the combat data proto.
-   */
-  virtual const proto::CombatData& GetCombatData () const = 0;
-
 public:
 
   /**
@@ -224,6 +219,11 @@ public:
    * column in the database directly.
    */
   HexCoord::IntT GetAttackRange () const;
+
+  /**
+   * Subclasses must implement this to return the combat data proto.
+   */
+  virtual const proto::CombatData& GetCombatData () const = 0;
 
 };
 

--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -42,17 +42,193 @@ struct ResultWithCombat : public Database::ResultType
 };
 
 /**
- * Computes (from HP and RegenData protos) whether or not an entity
- * needs to regenerate HP.
+ * Basic database wrapper type with combat data.  This is a shared superclass
+ * between Character and Building.
  */
-bool ComputeCanRegen (const proto::HP& hp, const proto::RegenData& regen);
+class CombatEntity
+{
 
-/**
- * Computes the attack range of a fighter with the given combat data.
- * Returns zero if there are no attacks at all.
- */
-HexCoord::IntT FindAttackRange (const proto::CombatData& cd);
+protected:
+
+  /** Database reference this belongs to.  */
+  Database& db;
+
+  /**
+   * Set to true if this is a new entity, so we know that we have to
+   * insert it into the database.
+   */
+  bool isNew;
+
+private:
+
+  /** Current HP proto.  */
+  LazyProto<proto::HP> hp;
+
+  /**
+   * Data about HP regeneration.  This is accessed often but not updated
+   * frequently.  If modified, then we do a full update as per the proto
+   * update.  But parsing it should be cheap.
+   */
+  LazyProto<proto::RegenData> regenData;
+
+  /**
+   * The selected target as TargetId proto, if any.  If there is no target,
+   * then the underlying database column is NULL, and this proto will have
+   * no fields set.
+   */
+  LazyProto<proto::TargetId> target;
+
+  /**
+   * The longest attack or zero if there are none.  This field is loaded
+   * from the database but never updated.
+   */
+  HexCoord::IntT oldAttackRange;
+
+  /**
+   * Stores the canregen flag from the database.  We only update it if
+   * the RegenData or HP have been modified.
+   */
+  bool oldCanRegen;
+
+  /**
+   * Computes (from HP and RegenData protos) whether or not an entity
+   * needs to regenerate HP.
+   */
+  static bool ComputeCanRegen (const proto::HP& hp,
+                               const proto::RegenData& regen);
+
+  /**
+   * Computes the attack range of a fighter with the given combat data.
+   * Returns zero if there are no attacks at all.
+   */
+  static HexCoord::IntT FindAttackRange (const proto::CombatData& cd);
+
+  friend class ComputeCanRegenTests;
+  friend class FindAttackRangeTests;
+
+protected:
+
+  /**
+   * Constructs a new instance meant to be inserted into the DB.
+   */
+  explicit CombatEntity (Database& d);
+
+  /**
+   * Constructs a new instance based on a database result.
+   */
+  template <typename T>
+    explicit CombatEntity (Database& d, const Database::Result<T>& res);
+
+  /**
+   * Returns whether a full update of the database (including all the
+   * fields) is necessary.
+   */
+  bool
+  IsDirtyFull () const
+  {
+    return regenData.IsDirty () || target.IsDirty ();
+  }
+
+  /**
+   * Returns whether a partial update (of the small / fast changing fields
+   * like HP) is required.
+   */
+  bool
+  IsDirtyFields () const
+  {
+    return hp.IsDirty ();
+  }
+
+  /**
+   * Binds statement parameters for the large / expensive proto fields.
+   * Does not include the ones from BindField!
+   */
+  void
+  BindFullFields (Database::Statement& stmt, unsigned indRegenData,
+                  unsigned indTarget, unsigned indAttackRange) const;
+
+  /**
+   * Binds statement parameters for updating the small / fast changing
+   * fields (HP, canRegen).
+   */
+  void
+  BindFields (Database::Statement& stmt, unsigned indHp,
+              unsigned indCanRegen) const;
+
+  /**
+   * Validates the character state for consistency.  CHECK-fails if there
+   * is any mismatch in the fields.
+   */
+  virtual void Validate () const;
+
+  /**
+   * Subclasses must implement this to return whether or not the main proto
+   * (with combat data) is dirty.
+   */
+  virtual bool IsDirtyCombatData () const = 0;
+
+  /**
+   * Subclasses must implement this to return the combat data proto.
+   */
+  virtual const proto::CombatData& GetCombatData () const = 0;
+
+public:
+
+  /**
+   * The destructor here does nothing.  It is the subclasses' job to
+   * update the database row, using the IsDirty and BindField functions.
+   */
+  virtual ~CombatEntity () = default;
+
+  const proto::HP&
+  GetHP () const
+  {
+    return hp.Get ();
+  }
+
+  proto::HP&
+  MutableHP ()
+  {
+    return hp.Mutable ();
+  }
+
+  const proto::RegenData&
+  GetRegenData () const
+  {
+    return regenData.Get ();
+  }
+
+  proto::RegenData&
+  MutableRegenData ()
+  {
+    return regenData.Mutable ();
+  }
+
+  const proto::TargetId&
+  GetTarget () const
+  {
+    return target.Get ();
+  }
+
+  proto::TargetId&
+  MutableTarget ()
+  {
+    return target.Mutable ();
+  }
+
+  /**
+   * Returns the entity's attack range or zero if there are no attacks.
+   * Note that this method must only be called if the instance has been
+   * read from the database (not newly constructed) and if its main proto
+   * has not been modified.  That allows us to use the cached attack-range
+   * column in the database directly.
+   */
+  HexCoord::IntT GetAttackRange () const;
+
+};
 
 } // namespace pxd
+
+#include "combat.tpp"
 
 #endif // DATABASE_COMBAT_HPP

--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -35,9 +35,10 @@ namespace pxd
 struct ResultWithCombat : public Database::ResultType
 {
   RESULT_COLUMN (pxd::proto::HP, hp, 53);
-  RESULT_COLUMN (int64_t, attackrange, 54);
-  RESULT_COLUMN (bool, canregen, 55);
-  RESULT_COLUMN (bool, hastarget, 56);
+  RESULT_COLUMN (pxd::proto::RegenData, regendata, 54);
+  RESULT_COLUMN (pxd::proto::TargetId, target, 55);
+  RESULT_COLUMN (int64_t, attackrange, 56);
+  RESULT_COLUMN (bool, canregen, 57);
 };
 
 /**

--- a/database/combat.tpp
+++ b/database/combat.tpp
@@ -1,0 +1,45 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Template implementation code for combat.hpp.  */
+
+#include <type_traits>
+
+namespace pxd
+{
+
+template <typename T>
+  CombatEntity::CombatEntity (Database& d, const Database::Result<T>& res)
+    : db(d), isNew(false)
+{
+  static_assert (std::is_base_of<ResultWithCombat, T>::value,
+                 "CombatEntity needs a ResultWithCombat");
+  
+  hp = res.template GetProto<typename T::hp> ();
+  regenData = res.template GetProto<typename T::regendata> ();
+
+  if (res.template IsNull<typename T::target> ())
+    target.SetToDefault ();
+  else
+    target = res.template GetProto<typename T::target> ();
+
+  oldAttackRange = res.template Get<typename T::attackrange> ();
+  oldCanRegen = res.template Get<typename T::canregen> ();
+}
+
+} // namespace pxd

--- a/database/combat_tests.cpp
+++ b/database/combat_tests.cpp
@@ -1,0 +1,129 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "combat.hpp"
+
+#include "proto/combat.pb.h"
+
+#include <gtest/gtest.h>
+
+#include <google/protobuf/text_format.h>
+
+namespace pxd
+{
+namespace
+{
+
+using google::protobuf::TextFormat;
+
+class ComputeCanRegenTests : public testing::Test
+{
+
+protected:
+
+  /**
+   * Calls ComputeCanRegen based on given text protos.
+   */
+  static bool
+  CanRegen (const std::string& hpStr, const std::string& regenStr)
+  {
+    proto::HP hp;
+    CHECK (TextFormat::ParseFromString (hpStr, &hp));
+    proto::RegenData regen;
+    CHECK (TextFormat::ParseFromString (regenStr, &regen));
+
+    return ComputeCanRegen (hp, regen);
+  }
+
+};
+
+TEST_F (ComputeCanRegenTests, CanRegenerate)
+{
+  EXPECT_TRUE (CanRegen (R"(
+    armour: 10
+    shield: 0
+  )", R"(
+    max_hp: { armour: 10 shield: 10 }
+    shield_regeneration_mhp: 100
+  )"));
+}
+
+TEST_F (ComputeCanRegenTests, NoRegeneration)
+{
+  EXPECT_FALSE (CanRegen (R"(
+    armour: 10
+    shield: 0
+  )", R"(
+    max_hp: { armour: 10 shield: 10 }
+    shield_regeneration_mhp: 0
+  )"));
+}
+
+TEST_F (ComputeCanRegenTests, FullShield)
+{
+  EXPECT_FALSE (CanRegen (R"(
+    armour: 1
+    shield: 10
+  )", R"(
+    max_hp: { armour: 10 shield: 10 }
+    shield_regeneration_mhp: 100
+  )"));
+  EXPECT_FALSE (CanRegen (R"(
+    armour: 1
+    shield: 0
+  )", R"(
+    max_hp: { armour: 10 shield: 0 }
+    shield_regeneration_mhp: 100
+  )"));
+}
+
+class FindAttackRangeTests : public testing::Test
+{
+
+protected:
+
+  /**
+   * Calls FindAttackRange based on the combat data given as text proto.
+   */
+  static HexCoord::IntT
+  FindRange (const std::string str)
+  {
+    proto::CombatData pb;
+    CHECK (TextFormat::ParseFromString (str, &pb));
+
+    return FindAttackRange (pb);
+  }
+
+};
+
+TEST_F (FindAttackRangeTests, NoAttacks)
+{
+  EXPECT_EQ (FindRange (""), 0);
+}
+
+TEST_F (FindAttackRangeTests, MaximumRange)
+{
+  EXPECT_EQ (FindRange (R"(
+    attacks: { range: 5 }
+    attacks: { range: 42 }
+    attacks: { range: 1 }
+  )"), 42);
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/database/combat_tests.cpp
+++ b/database/combat_tests.cpp
@@ -24,12 +24,10 @@
 
 #include <google/protobuf/text_format.h>
 
+using google::protobuf::TextFormat;
+
 namespace pxd
 {
-namespace
-{
-
-using google::protobuf::TextFormat;
 
 class ComputeCanRegenTests : public testing::Test
 {
@@ -47,10 +45,13 @@ protected:
     proto::RegenData regen;
     CHECK (TextFormat::ParseFromString (regenStr, &regen));
 
-    return ComputeCanRegen (hp, regen);
+    return CombatEntity::ComputeCanRegen (hp, regen);
   }
 
 };
+
+namespace
+{
 
 TEST_F (ComputeCanRegenTests, CanRegenerate)
 {
@@ -92,6 +93,8 @@ TEST_F (ComputeCanRegenTests, FullShield)
   )"));
 }
 
+} // anonymous namespace
+
 class FindAttackRangeTests : public testing::Test
 {
 
@@ -106,10 +109,13 @@ protected:
     proto::CombatData pb;
     CHECK (TextFormat::ParseFromString (str, &pb));
 
-    return FindAttackRange (pb);
+    return CombatEntity::FindAttackRange (pb);
   }
 
 };
+
+namespace
+{
 
 TEST_F (FindAttackRangeTests, NoAttacks)
 {

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -168,19 +168,6 @@ FighterTable::ProcessWithTarget (const Callback& cb)
   auto res = characters.QueryWithTarget ();
   while (res.Step ())
     cb (Fighter (characters.GetFromResult (res)));
-}
-
-HexCoord::IntT
-FindAttackRange (const proto::CombatData& cd)
-{
-  HexCoord::IntT res = 0;
-  for (const auto& attack : cd.attacks ())
-    {
-      CHECK_GT (attack.range (), 0);
-      res = std::max<HexCoord::IntT> (res, attack.range ());
-    }
-
-  return res;
 }
 
 } // namespace pxd

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -26,11 +26,19 @@ namespace pxd
 proto::TargetId
 Fighter::GetId () const
 {
-  CHECK (character != nullptr);
-
   proto::TargetId res;
-  res.set_type (proto::TargetId::TYPE_CHARACTER);
-  res.set_id (character->GetId ());
+
+  if (building != nullptr)
+    {
+      res.set_type (proto::TargetId::TYPE_BUILDING);
+      res.set_id (building->GetId ());
+    }
+  else
+    {
+      CHECK (character != nullptr);
+      res.set_type (proto::TargetId::TYPE_CHARACTER);
+      res.set_id (character->GetId ());
+    }
 
   return res;
 }
@@ -38,6 +46,9 @@ Fighter::GetId () const
 Faction
 Fighter::GetFaction () const
 {
+  if (building != nullptr)
+    return building->GetFaction ();
+
   CHECK (character != nullptr);
   return character->GetFaction ();
 }
@@ -45,6 +56,9 @@ Fighter::GetFaction () const
 const HexCoord&
 Fighter::GetPosition () const
 {
+  if (building != nullptr)
+    return building->GetCentre ();
+
   CHECK (character != nullptr);
   return character->GetPosition ();
 }
@@ -52,6 +66,9 @@ Fighter::GetPosition () const
 const proto::RegenData&
 Fighter::GetRegenData () const
 {
+  if (building != nullptr)
+    return building->GetRegenData ();
+
   CHECK (character != nullptr);
   return character->GetRegenData ();
 }
@@ -59,21 +76,31 @@ Fighter::GetRegenData () const
 const proto::CombatData&
 Fighter::GetCombatData () const
 {
+  if (building != nullptr)
+    {
+      const auto& pb = building->GetProto ();
+
+      /* Every fighter must have combat data to be valid.  This is set when
+         first created and then only updated.  Enforce this requirement here,
+         so that we do not accidentally work with an empty proto just because it
+         has not been initialised due to a bug.  */
+      CHECK (pb.has_combat_data ());
+
+      return pb.combat_data ();
+    }
+
   CHECK (character != nullptr);
   const auto& pb = character->GetProto ();
-
-  /* Every character must have combat data to be valid.  This is set when
-     first created and then only updated.  Enforce this requirement here,
-     so that we do not accidentally work with an empty proto just because it
-     has not been initialised due to a bug.  */
   CHECK (pb.has_combat_data ());
-
   return pb.combat_data ();
 }
 
 HexCoord::IntT
 Fighter::GetAttackRange () const
 {
+  if (building != nullptr)
+    return building->GetAttackRange ();
+
   CHECK (character != nullptr);
   return character->GetAttackRange ();
 }
@@ -81,30 +108,51 @@ Fighter::GetAttackRange () const
 const proto::TargetId&
 Fighter::GetTarget () const
 {
-  CHECK (character != nullptr);
-  const auto& res = character->GetTarget ();
-  CHECK (res.has_id ());
-  return res;
+  const proto::TargetId* pb;
+  if (building != nullptr)
+    pb = &building->GetTarget ();
+  else
+    {
+      CHECK (character != nullptr);
+      pb = &character->GetTarget ();
+    }
+
+  CHECK (pb->has_id ());
+  return *pb;
 }
 
 void
 Fighter::SetTarget (const proto::TargetId& target)
 {
-  CHECK (character != nullptr);
   CHECK (target.has_id ());
-  character->MutableTarget () = target;
+
+  if (building != nullptr)
+    building->MutableTarget () = target;
+  else
+    {
+      CHECK (character != nullptr);
+      character->MutableTarget () = target;
+    }
 }
 
 void
 Fighter::ClearTarget ()
 {
-  CHECK (character != nullptr);
-  character->MutableTarget ().clear_id ();
+  if (building != nullptr)
+    building->MutableTarget ().clear_id ();
+  else
+    {
+      CHECK (character != nullptr);
+      character->MutableTarget ().clear_id ();
+    }
 }
 
 const proto::HP&
 Fighter::GetHP () const
 {
+  if (building != nullptr)
+    return building->GetHP ();
+
   CHECK (character != nullptr);
   return character->GetHP ();
 }
@@ -112,6 +160,9 @@ Fighter::GetHP () const
 proto::HP&
 Fighter::MutableHP ()
 {
+  if (building != nullptr)
+    return building->MutableHP ();
+
   CHECK (character != nullptr);
   return character->MutableHP ();
 }
@@ -119,13 +170,14 @@ Fighter::MutableHP ()
 void
 Fighter::reset ()
 {
+  building.reset ();
   character.reset ();
 }
 
 bool
 Fighter::empty () const
 {
-  return character == nullptr;
+  return building == nullptr && character == nullptr;
 }
 
 Fighter
@@ -133,6 +185,9 @@ FighterTable::GetForTarget (const proto::TargetId& id)
 {
   switch (id.type ())
     {
+    case proto::TargetId::TYPE_BUILDING:
+      return Fighter (buildings.GetById (id.id ()));
+
     case proto::TargetId::TYPE_CHARACTER:
       return Fighter (characters.GetById (id.id ()));
 
@@ -144,25 +199,49 @@ FighterTable::GetForTarget (const proto::TargetId& id)
 void
 FighterTable::ProcessWithAttacks (const Callback& cb)
 {
-  auto res = characters.QueryWithAttacks ();
-  while (res.Step ())
-    cb (Fighter (characters.GetFromResult (res)));
+  {
+    auto res = buildings.QueryWithAttacks ();
+    while (res.Step ())
+      cb (Fighter (buildings.GetFromResult (res)));
+  }
+
+  {
+    auto res = characters.QueryWithAttacks ();
+    while (res.Step ())
+      cb (Fighter (characters.GetFromResult (res)));
+  }
 }
 
 void
 FighterTable::ProcessForRegen (const Callback& cb)
 {
-  auto res = characters.QueryForRegen ();
-  while (res.Step ())
-    cb (Fighter (characters.GetFromResult (res)));
+  {
+    auto res = buildings.QueryForRegen ();
+    while (res.Step ())
+      cb (Fighter (buildings.GetFromResult (res)));
+  }
+
+  {
+    auto res = characters.QueryForRegen ();
+    while (res.Step ())
+      cb (Fighter (characters.GetFromResult (res)));
+  }
 }
 
 void
 FighterTable::ProcessWithTarget (const Callback& cb)
 {
-  auto res = characters.QueryWithTarget ();
-  while (res.Step ())
-    cb (Fighter (characters.GetFromResult (res)));
+  {
+    auto res = buildings.QueryWithTarget ();
+    while (res.Step ())
+      cb (Fighter (buildings.GetFromResult (res)));
+  }
+
+  {
+    auto res = characters.QueryWithTarget ();
+    while (res.Step ())
+      cb (Fighter (characters.GetFromResult (res)));
+  }
 }
 
 } // namespace pxd

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -82,29 +82,24 @@ const proto::TargetId&
 Fighter::GetTarget () const
 {
   CHECK (character != nullptr);
-  const auto& pb = character->GetProto ();
-  CHECK (pb.has_target ());
-  return pb.target ();
+  const auto& res = character->GetTarget ();
+  CHECK (res.has_id ());
+  return res;
 }
 
 void
 Fighter::SetTarget (const proto::TargetId& target)
 {
   CHECK (character != nullptr);
-  *character->MutableProto ().mutable_target () = target;
+  CHECK (target.has_id ());
+  character->MutableTarget () = target;
 }
 
 void
 Fighter::ClearTarget ()
 {
   CHECK (character != nullptr);
-
-  /* Make sure to mark the proto as dirty only if there was actually a target
-     before.  This avoids updating the proto in the database unnecessarily
-     for the common case where there was no target and there also is none
-     in the future.  */
-  if (character->HasTarget ())
-    character->MutableProto ().clear_target ();
+  character->MutableTarget ().clear_id ();
 }
 
 const proto::HP&

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -180,12 +180,6 @@ public:
   void ProcessWithTarget (const Callback& cb);
 
 };
-
-/**
- * Computes the attack range of a fighter with the given combat data.
- * Returns zero if there are no attacks at all.
- */
-HexCoord::IntT FindAttackRange (const proto::CombatData& cd);
 
 } // namespace pxd
 

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -19,6 +19,7 @@
 #ifndef DATABASE_FIGHTER_HPP
 #define DATABASE_FIGHTER_HPP
 
+#include "building.hpp"
 #include "character.hpp"
 
 #include "hexagonal/coord.hpp"
@@ -39,8 +40,18 @@ class Fighter
 
 private:
 
+  /** The character handle if this is a building.  */
+  BuildingsTable::Handle building;
+
   /** The character handle if this is a character.  */
   CharacterTable::Handle character;
+
+  /**
+   * Construct a fighter based on a building handle.
+   */
+  explicit Fighter (BuildingsTable::Handle b)
+    : building(std::move (b))
+  {}
 
   /**
    * Construct a fighter based on a character handle.
@@ -138,6 +149,9 @@ class FighterTable
 
 private:
 
+  /** The BuildingsTable from which we retrieve building-based fighters.  */
+  BuildingsTable& buildings;
+
   /** The CharacterTable from which we retrieve character-based fighters.  */
   CharacterTable& characters;
 
@@ -147,10 +161,11 @@ public:
   using Callback = std::function<void (Fighter f)>;
 
   /**
-   * Constructs a fighter table drawing characters from the given table.
+   * Constructs a fighter table drawing buildings and characters from the given
+   * database table wrappers.
    */
-  explicit FighterTable (CharacterTable& c)
-    : characters(c)
+  explicit FighterTable (BuildingsTable& b, CharacterTable& c)
+    : buildings(b), characters(c)
   {}
 
   FighterTable () = delete;

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -27,14 +27,10 @@
 
 #include <gtest/gtest.h>
 
-#include <google/protobuf/text_format.h>
-
 namespace pxd
 {
 namespace
 {
-
-using google::protobuf::TextFormat;
 
 class FighterTests : public DBTestWithSchema
 {
@@ -159,39 +155,6 @@ TEST_F (FighterTests, ProcessWithTarget)
       EXPECT_EQ (f.GetFaction (), Faction::RED);
     });
   EXPECT_EQ (cnt, 1);
-}
-
-class FindAttackRangeTests : public testing::Test
-{
-
-protected:
-
-  /**
-   * Calls FindAttackRange based on the combat data given as text proto.
-   */
-  static HexCoord::IntT
-  FindRange (const std::string str)
-  {
-    proto::CombatData pb;
-    CHECK (TextFormat::ParseFromString (str, &pb));
-
-    return FindAttackRange (pb);
-  }
-
-};
-
-TEST_F (FindAttackRangeTests, NoAttacks)
-{
-  EXPECT_EQ (FindRange (""), 0);
-}
-
-TEST_F (FindAttackRangeTests, MaximumRange)
-{
-  EXPECT_EQ (FindRange (R"(
-    attacks: { range: 5 }
-    attacks: { range: 42 }
-    attacks: { range: 1 }
-  )"), 42);
 }
 
 } // anonymous namespace

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -60,7 +60,7 @@ TEST_F (FighterTests, Characters)
 
   c = characters.CreateNew ("domob", Faction::GREEN);
   const auto id2 = c->GetId ();
-  c->MutableProto ().mutable_target ()->set_id (42);
+  c->MutableTarget ().set_id (42);
   c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (10);
   c.reset ();
 
@@ -109,11 +109,11 @@ TEST_F (FighterTests, Characters)
   EXPECT_EQ (cnt, 2);
 
   c = characters.GetById (id1);
-  EXPECT_EQ (c->GetProto ().target ().id (), 5);
+  EXPECT_EQ (c->GetTarget ().id (), 5);
   EXPECT_EQ (c->GetHP ().armour (), 5);
   c.reset ();
 
-  EXPECT_FALSE (characters.GetById (id2)->GetProto ().has_target ());
+  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
 }
 
 TEST_F (FighterTests, GetForTarget)
@@ -143,7 +143,7 @@ TEST_F (FighterTests, GetForTarget)
 TEST_F (FighterTests, ProcessWithTarget)
 {
   auto c = characters.CreateNew ("domob", Faction::RED);
-  c->MutableProto ().mutable_target ()->set_id (5);
+  c->MutableTarget ().set_id (5);
   c.reset ();
 
   characters.CreateNew ("domob", Faction::GREEN);

--- a/database/inventory.cpp
+++ b/database/inventory.cpp
@@ -307,6 +307,17 @@ BuildingInventoriesTable::QueryForBuilding (const Database::IdT building)
   return stmt.Query<BuildingInventoryResult> ();
 }
 
+void
+BuildingInventoriesTable::RemoveBuilding (const Database::IdT building)
+{
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `building_inventories`
+      WHERE `building` = ?1
+  )");
+  stmt.Bind (1, building);
+  stmt.Execute ();
+}
+
 /* ************************************************************************** */
 
 } // namespace pxd

--- a/database/inventory.cpp
+++ b/database/inventory.cpp
@@ -93,6 +93,15 @@ Inventory::AddFungibleCount (const std::string& type, const QuantityT count)
   SetFungibleCount (type, previous + count);
 }
 
+Inventory&
+Inventory::operator+= (const Inventory& other)
+{
+  for (const auto& entry : other.GetFungible ())
+    AddFungibleCount (entry.first, entry.second);
+
+  return *this;
+}
+
 int64_t
 Inventory::Product (const QuantityT amount, const int64_t dual)
 {

--- a/database/inventory.hpp
+++ b/database/inventory.hpp
@@ -406,6 +406,12 @@ public:
    */
   Database::Result<BuildingInventoryResult> QueryForBuilding (Database::IdT b);
 
+  /**
+   * Removes all entries for inventories in the given building.  This is used
+   * to clean up data when a building is destroyed.
+   */
+  void RemoveBuilding (Database::IdT building);
+
 };
 
 /* ************************************************************************** */

--- a/database/inventory.hpp
+++ b/database/inventory.hpp
@@ -123,6 +123,11 @@ public:
   void AddFungibleCount (const std::string& type, QuantityT count);
 
   /**
+   * Adds in all items from a given second inventory.
+   */
+  Inventory& operator+= (const Inventory& other);
+
+  /**
    * Returns true if the inventory data has been modified (and thus needs to
    * be saved back to the database).
    */

--- a/database/inventory_tests.cpp
+++ b/database/inventory_tests.cpp
@@ -109,6 +109,20 @@ TEST_F (InventoryTests, Modification)
   EXPECT_TRUE (inv.IsDirty ());
 }
 
+TEST_F (InventoryTests, AdditionOfOtherInventory)
+{
+  inv.SetFungibleCount ("foo", 10);
+
+  Inventory other;
+  other.SetFungibleCount ("foo", 2);
+  other.SetFungibleCount ("bar", 3);
+
+  inv += other;
+
+  EXPECT_EQ (inv.GetFungibleCount ("foo"), 12);
+  EXPECT_EQ (inv.GetFungibleCount ("bar"), 3);
+}
+
 TEST_F (InventoryTests, DualProduct)
 {
   const auto val = Inventory::Product (MAX_ITEM_QUANTITY, -MAX_ITEM_DUAL);

--- a/database/inventory_tests.cpp
+++ b/database/inventory_tests.cpp
@@ -366,6 +366,23 @@ TEST_F (BuildingInventoriesTableTests, QueryForBuilding)
   ASSERT_FALSE (res.Step ());
 }
 
+TEST_F (BuildingInventoriesTableTests, RemoveBuilding)
+{
+  tbl.Get (123, "domob")->GetInventory ().SetFungibleCount ("foo", 1);
+  tbl.Get (124, "domob")->GetInventory ().SetFungibleCount ("foo", 2);
+  tbl.Get (123, "andy")->GetInventory ().SetFungibleCount ("foo", 3);
+
+  tbl.RemoveBuilding (123);
+
+  auto res = tbl.QueryAll ();
+  ASSERT_TRUE (res.Step ());
+  auto h = tbl.GetFromResult (res);
+  EXPECT_EQ (h->GetBuildingId (), 124);
+  EXPECT_EQ (h->GetAccount (), "domob");
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 2);
+  EXPECT_FALSE (res.Step ());
+}
+
 /* ************************************************************************** */
 
 } // anonymous namespace

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -149,10 +149,34 @@ CREATE TABLE IF NOT EXISTS `buildings` (
   `x` INTEGER NOT NULL,
   `y` INTEGER NOT NULL,
 
+  -- Current HP data as an encoded HP proto.  This is stored directly in
+  -- the database rather than the "proto" BLOB since it is a field that
+  -- is changed frequently.
+  `hp` BLOB NULL NOT NULL,
+
+  -- Data about HP regeneration encoded as RegenData proto.
+  `regendata` BLOB NOT NULL,
+
+  -- The attacked target (if any), as a serialised TargetId proto.
+  `target` BLOB NULL,
+
+  -- The range of the longest attack this building has or NULL if there
+  -- is no attack at all.
+  `attackrange` INTEGER NULL,
+
+  -- Flag indicating whether a building may need HP regeneration.
+  `canregen` INTEGER NULL NOT NULL,
+
   -- Additional data encoded as a Building protocol buffer.
   `proto` BLOB NOT NULL
 
 );
+
+CREATE INDEX IF NOT EXISTS `buildings_pos` ON `buildings` (`x`, `y`);
+CREATE INDEX IF NOT EXISTS `buildings_attackrange`
+  ON `buildings` (`attackrange`);
+CREATE INDEX IF NOT EXISTS `buildings_canregen` ON `buildings` (`canregen`);
+CREATE INDEX IF NOT EXISTS `buildings_target` ON `buildings` (`target`);
 
 -- =============================================================================
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -62,6 +62,13 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- performance reasons.  It is not updated often, mostly read.
   `regendata` BLOB NOT NULL,
 
+  -- The attacked target (if any), as a serialised TargetId proto.
+  -- The presence of this column also tells us that there are enemies in
+  -- range, which is important for area attacks.   So even if e.g. a character
+  -- has just area attacks, we need to select one target for them nevertheless,
+  -- as we later on only process attacks of characters with a selected target.
+  `target` BLOB NULL,
+
   -- If non-zero, then the number represents for how many more blocks the
   -- character is "locked" at being busy (e.g. prospecting).
   `busy` INTEGER NOT NULL,
@@ -88,11 +95,6 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- retrieve and process characters that need regeneration.
   `canregen` INTEGER NOT NULL,
 
-  -- Flag indicating whether or not the character has a combat target.
-  -- This is used so we can later efficiently retrieve only those characters
-  -- that need to be processed for combat damage.
-  `hastarget` INTEGER NOT NULL,
-
   -- The character's inventory encoded as Inventory proto.
   `inventory` BLOB NOT NULL,
 
@@ -113,7 +115,7 @@ CREATE INDEX IF NOT EXISTS `characters_ismining` ON `characters` (`ismining`);
 CREATE INDEX IF NOT EXISTS `characters_attackrange`
   ON `characters` (`attackrange`);
 CREATE INDEX IF NOT EXISTS `characters_canregen` ON `characters` (`canregen`);
-CREATE INDEX IF NOT EXISTS `characters_hastarget` ON `characters` (`hastarget`);
+CREATE INDEX IF NOT EXISTS `characters_target` ON `characters` (`target`);
 
 -- =============================================================================
 

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -4,6 +4,7 @@ TEST_LIBRARY = \
 REGTESTS = \
   accounts.py \
   buildings_basic.py \
+  buildings_combat.py \
   buildings_enterexit.py \
   buildings_inventory.py \
   character_limit.py \

--- a/gametest/buildings_combat.py
+++ b/gametest/buildings_combat.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests basic combat with buildings (turrets and destroying a building).
+"""
+
+from pxtest import PXTest
+
+
+class BuildingsCombatTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("Ancient buildings are neutral...")
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob")
+    self.generate (1)
+    ancientBuilding = 1
+    b = self.getBuildings ()[ancientBuilding]
+    self.assertEqual (b.getFaction (), "a")
+    self.moveCharactersTo ({"domob": b.getCentre ()})
+    self.generate (3)
+    assert "target" not in self.getCharacters ()["domob"].data["combat"]
+    assert "target" not in self.getBuildings ()[ancientBuilding].data["combat"]
+
+    self.mainLogger.info ("Placing a turret...")
+    self.generate (1)
+    self.build ("r_rt", "domob", {"x": 0, "y": 0}, rot=0)
+    self.building = 1002
+    self.assertEqual (self.getBuildings ()[self.building].getType (), "r_rt")
+
+    # Enter turret with a character, to test that it will get killed
+    # correctly when the turret is destroyed.
+    self.moveCharactersTo ({"domob": {"x": 1, "y": 0}})
+    self.getCharacters ()["domob"].sendMove ({"eb": self.building})
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["domob"].getBuildingId (),
+                      self.building)
+
+    self.mainLogger.info ("Placing an attacking character...")
+    self.initAccount ("attacker", "g")
+    self.generate (1)
+    self.createCharacters ("attacker")
+    self.generate (2)
+    reorgBlk = self.rpc.xaya.getbestblockhash ()
+    self.moveCharactersTo ({"attacker": {"x": 1, "y": 0}})
+
+    self.mainLogger.info ("Killing both entities...")
+    self.adminCommand ({"god": {"sethp": {"b": {
+      "%s" % self.building: {"a": 1, "s": 0},
+    }}}})
+    self.setCharactersHP ({"attacker": {"a": 1, "s": 0}})
+    self.generate (1)
+    assert self.building not in self.getBuildings ()
+    self.assertEqual (self.getCharacters (), {})
+
+    self.generate (20)
+    self.testReorg (reorgBlk)
+
+  def testReorg (self, blk):
+    self.mainLogger.info ("Testing reorg...")
+
+    originalState = self.getGameState ()
+    self.rpc.xaya.invalidateblock (blk)
+
+    self.generate (5)
+    self.assertEqual (self.getCharacters ().keys (), ["attacker", "domob"])
+    assert self.building in self.getBuildings ()
+
+    self.rpc.xaya.reconsiderblock (blk)
+    self.expectGameState (originalState)
+    
+
+if __name__ == "__main__":
+  BuildingsCombatTest ().main ()

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -74,6 +74,15 @@ class GodModeTest (PXTest):
           {"x": 101, "y": 149},
           {"x": 102, "y": 148},
         ],
+      "combat":
+        {
+          "hp":
+            {
+              "current": {"armour": 0, "shield": 0},
+              "max": {"armour": 0, "shield": 0},
+              "regeneration": 0.0,
+            },
+        },
       "inventories": {},
     })
     self.assertEqual (buildings[1003].data, {
@@ -90,6 +99,15 @@ class GodModeTest (PXTest):
           {"x": -100, "y": -149},
           {"x": -100, "y": -148},
         ],
+      "combat":
+        {
+          "hp":
+            {
+              "current": {"armour": 0, "shield": 0},
+              "max": {"armour": 0, "shield": 0},
+              "regeneration": 0.0,
+            },
+        },
       "inventories": {},
     })
 

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -33,34 +33,13 @@ class GodModeTest (PXTest):
     self.generate (1)
     c = self.getCharacters ()["domob"]
     pos = c.getPosition ()
-    idStr = c.getIdStr ()
-
-    self.mainLogger.info ("Testing teleport...")
-    target = {"x": 28, "y": 9}
-    assert pos != target
-    self.adminCommand ({"god": {"teleport": {idStr: target}}})
-    self.generate (1)
-    self.assertEqual (self.getCharacters ()["domob"].getPosition (), target)
-
-    self.mainLogger.info ("Testing sethp...")
-    self.adminCommand ({
-      "god":
-        {
-          "sethp":
-            {
-              idStr: {"a": 32, "s": 15, "ma": 100, "ms": 90},
-            },
-        },
-    })
-    self.generate (1)
-    hp = self.getCharacters ()["domob"].data["combat"]["hp"]
-    self.assertEqual (hp["current"], {"armour": 32, "shield": 15})
-    self.assertEqual (hp["max"], {"armour": 100, "shield": 90})
+    charIdStr = c.getIdStr ()
 
     self.mainLogger.info ("Testing build...")
     self.build ("checkmark", None, {"x": 100, "y": 150}, rot=2)
     self.build ("checkmark", "domob", {"x": -100, "y": -150}, rot=0)
     buildings = self.getBuildings ()
+    buildingId = buildings.values ()[0].getId ()
     self.assertEqual (buildings[1002].data, {
       "id": 1002,
       "type": "checkmark",
@@ -110,6 +89,49 @@ class GodModeTest (PXTest):
         },
       "inventories": {},
     })
+
+    self.mainLogger.info ("Testing teleport...")
+    target = {"x": 28, "y": 9}
+    assert pos != target
+    self.adminCommand ({"god": {"teleport": {charIdStr: target}}})
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["domob"].getPosition (), target)
+
+    self.mainLogger.info ("Testing sethp for characters...")
+    self.adminCommand ({
+      "god":
+        {
+          "sethp":
+            {
+              "c":
+                {
+                  charIdStr: {"a": 32, "s": 15, "ma": 100, "ms": 90},
+                },
+            },
+        },
+    })
+    self.generate (1)
+    hp = self.getCharacters ()["domob"].data["combat"]["hp"]
+    self.assertEqual (hp["current"], {"armour": 32, "shield": 15})
+    self.assertEqual (hp["max"], {"armour": 100, "shield": 90})
+
+    self.mainLogger.info ("Testing sethp for buildings...")
+    self.adminCommand ({
+      "god":
+        {
+          "sethp":
+            {
+              "b":
+                {
+                  ("%s" % buildingId): {"a": 32, "s": 15},
+                },
+            },
+        },
+    })
+    self.generate (1)
+    hp = self.getBuildings ()[buildingId].data["combat"]["hp"]
+    self.assertEqual (hp["current"], {"armour": 32, "shield": 15})
+    self.assertEqual (hp["max"], {"armour": 0, "shield": 0})
 
     self.mainLogger.info ("Testing drop loot...")
     self.dropLoot ({"x": 1, "y": 2}, {"foo": 1, "bar": 2})

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -282,7 +282,7 @@ class PXTest (XayaGameTest):
       idStr = chars[nm].getIdStr ()
       sethp[idStr] = c
 
-    self.adminCommand ({"god": {"sethp": sethp}})
+    self.adminCommand ({"god": {"sethp": {"c": sethp}}})
     self.generate (1)
 
   def build (self, typ, owner, centre, rot):

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -134,6 +134,9 @@ class Building (object):
       return self.data["owner"]
     return None
 
+  def getCentre (self):
+    return self.data["centre"]
+
   def getFungibleInventory (self, account):
     inv = self.data["inventories"]
     if account not in inv:

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -11,7 +11,8 @@ ROCONFIG_TEXT_PROTOS = \
   roconfig/buildings/ancient3.pb.text \
   roconfig/buildings/obelisk1.pb.text \
   roconfig/buildings/obelisk2.pb.text \
-  roconfig/buildings/obelisk3.pb.text
+  roconfig/buildings/obelisk3.pb.text \
+  roconfig/buildings/turrets.pb.text
 
 PROTOS = \
   building.proto \

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -18,6 +18,8 @@
 
 syntax = "proto2";
 
+import "combat.proto";
+
 package pxd.proto;
 
 /**
@@ -46,5 +48,12 @@ message Building
 
   /** The transformation applied to the building's base shape.  */
   optional ShapeTransformation shape_trafo = 1;
+
+  /**
+   * Static combat data for this building (besides regeneration).  This is
+   * mostly based on the building type, but may change if the building is
+   * upgraded or the account gains skills.
+   */
+  optional CombatData combat_data = 2;
 
 }

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -79,21 +79,12 @@ message Character
   optional Movement movement = 1;
 
   /**
-   * The attacked target (if any).  The presence of this field also tells us
-   * that there are enemies in range, which is important for area attacks.
-   * So even if e.g. a character has just area attacks, we need to select
-   * one target for them nevertheless, as we later on only process attacks
-   * of characters with a selected target.
-   */
-  optional TargetId target = 2;
-
-  /**
    * Static combat data for thie character.  That data is derived from other
    * information (e.g. equipped weapons, current vehicle), but it is cached
    * here for easy computation of combat.  The data here changes only
    * through explicit actions done by the owner.
    */
-  optional CombatData combat_data = 3;
+  optional CombatData combat_data = 2;
 
   /**
    * If the character is currently busy, then this holds data about the
@@ -101,17 +92,17 @@ message Character
    */
   oneof busy
   {
-    OngoingProspection prospection = 4;
+    OngoingProspection prospection = 3;
   }
 
   /** The character's mining data, if it can mine.  */
-  optional MiningData mining = 5;
+  optional MiningData mining = 4;
 
   /** Movement speed of the character.  */
-  optional uint32 speed = 6;
+  optional uint32 speed = 5;
 
   /** Total cargo space the character has.  */
-  optional uint64 cargo_space = 7;
+  optional uint64 cargo_space = 6;
 
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:
@@ -125,6 +116,7 @@ message Character
      - volatile movement proto (partial step, blocked for counter)
      - current HP proto
      - HP regeneration data proto
+     - selected target as TargetId proto (if any)
      - number of blocks the character is still "busy"
      - inventory proto
   */

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -41,7 +41,10 @@ message TargetId
   /** The type of this target.  */
   optional Type type = 1;
 
-  /** The database ID of this target entity (based on its type).  */
+  /**
+   * The database ID of this target entity (based on its type).  Absence of
+   * this field means that the target is "empty" / null / there is no target.
+   */
   optional uint64 id = 2;
 
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -18,6 +18,7 @@
 
 syntax = "proto2";
 
+import "combat.proto";
 import "geometry.proto";
 
 package pxd.proto;
@@ -51,6 +52,17 @@ message BuildingData
    * way.  The coordinates are relative to the building's centre.
    */
   repeated HexCoord shape_tiles = 2;
+
+  /**
+   * Combat data (attacks) the building has in its base (unupgraded)
+   * form, if any.
+   */
+  optional CombatData combat_data = 3;
+
+  /**
+   * Maximum HP and regeneration data the building has in its base form.
+   */
+  optional RegenData regen_data = 4;
 
 }
 

--- a/proto/roconfig/buildings/turrets.pb.text
+++ b/proto/roconfig/buildings/turrets.pb.text
@@ -1,0 +1,31 @@
+building_types:
+  {
+    key: "r_rt"
+    value:
+      {
+
+        enter_radius: 1
+        shape_tiles: { x: 0 y: 0 }
+
+        combat_data:
+          {
+            attacks:
+              {
+                range: 5
+                min_damage: 1
+                max_damage: 3
+              }
+          }
+
+        regen_data:
+          {
+            max_hp:
+              {
+                armour: 1000
+                shield: 200
+              }
+            shield_regeneration_mhp: 500
+          }
+
+      }
+  }

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -63,15 +63,32 @@ InitialiseBuildings (Database& db)
 
   auto h = tbl.CreateNew ("obelisk1", "", Faction::ANCIENT);
   h->SetCentre (HexCoord (-125, 810));
+  UpdateBuildingStats (*h);
   h.reset ();
 
   h = tbl.CreateNew ("obelisk2", "", Faction::ANCIENT);
   h->SetCentre (HexCoord (-1'301, 902));
+  UpdateBuildingStats (*h);
   h.reset ();
 
   h = tbl.CreateNew ("obelisk3", "", Faction::ANCIENT);
   h->SetCentre (HexCoord (-637, -291));
+  UpdateBuildingStats (*h);
   h.reset ();
+}
+
+void
+UpdateBuildingStats (Building& b)
+{
+  const auto& buildingData = RoConfigData ().building_types ();
+  const auto mit = buildingData.find (b.GetType ());
+  CHECK (mit != buildingData.end ())
+      << "Unknown building type: " << b.GetType ();
+  const auto& roData = mit->second;
+
+  *b.MutableProto ().mutable_combat_data () = roData.combat_data ();
+  b.MutableRegenData () = roData.regen_data ();
+  b.MutableHP () = roData.regen_data ().max_hp ();
 }
 
 void

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -130,7 +130,7 @@ ProcessEnterBuildings (Database& db)
       ++entered;
 
       c->SetBuildingId (buildingId);
-      c->MutableProto ().clear_target ();
+      c->MutableTarget ().clear_id ();
       c->SetEnterBuilding (Database::EMPTY_ID);
       StopCharacter (*c);
       StopMining (*c);

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -46,6 +46,12 @@ std::vector<HexCoord> GetBuildingShape (const Building& b);
 void InitialiseBuildings (Database& db);
 
 /**
+ * Computes and updates the stats of a building (e.g. combat data, HP) from
+ * its type and other attributes.
+ */
+void UpdateBuildingStats (Building& b);
+
+/**
  * Processes all characters that want to enter a building, and lets them in
  * if it is possible for them.
  */

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -152,7 +152,7 @@ TEST_F (ProcessEnterBuildingsTests, EnteringEffects)
   auto c = GetCharacter (10);
   c->SetPosition (HexCoord (5, 0));
   c->SetEnterBuilding (1);
-  c->MutableProto ().mutable_target ();
+  c->MutableTarget ().set_id (42);
   c->MutableProto ().mutable_movement ()->mutable_waypoints ();
   c->MutableProto ().mutable_mining ()->set_active (true);
   c.reset ();
@@ -163,7 +163,7 @@ TEST_F (ProcessEnterBuildingsTests, EnteringEffects)
   ASSERT_TRUE (c->IsInBuilding ());
   EXPECT_EQ (c->GetBuildingId (), 1);
   EXPECT_EQ (c->GetEnterBuilding (), Database::EMPTY_ID);
-  EXPECT_FALSE (c->GetProto ().has_target ());
+  EXPECT_FALSE (c->GetTarget ().has_id ());
   EXPECT_FALSE (c->GetProto ().has_movement ());
   EXPECT_FALSE (c->GetProto ().mining ().active ());
 }

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -71,6 +71,15 @@ TEST_F (BuildingsTests, GetBuildingShape)
   EXPECT_DEATH (GetBuildingShape (*tbl.GetById (id2)), "undefined type");
 }
 
+TEST_F (BuildingsTests, UpdateBuildingStats)
+{
+  auto h = tbl.CreateNew ("r_rt", "domob", Faction::RED);
+  UpdateBuildingStats (*h);
+  EXPECT_EQ (h->GetProto ().combat_data ().attacks_size (), 1);
+  EXPECT_GT (h->GetRegenData ().max_hp ().armour (), 0);
+  EXPECT_GT (h->GetHP ().armour (), 0);
+}
+
 /* ************************************************************************** */
 
 class ProcessEnterBuildingsTests : public BuildingsTests

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -98,8 +98,9 @@ SelectTarget (TargetFinder& targets, xaya::Random& rnd, Fighter f)
 void
 FindCombatTargets (Database& db, xaya::Random& rnd)
 {
+  BuildingsTable buildings(db);
   CharacterTable characters(db);
-  FighterTable fighters(characters);
+  FighterTable fighters(buildings, characters);
   TargetFinder targets(db);
 
   fighters.ProcessWithAttacks ([&] (Fighter f)
@@ -217,8 +218,9 @@ DealDamage (FighterTable& fighters, TargetFinder& targets,
 std::vector<proto::TargetId>
 DealCombatDamage (Database& db, DamageLists& dl, xaya::Random& rnd)
 {
+  BuildingsTable buildings(db);
   CharacterTable characters(db);
-  FighterTable fighters(characters);
+  FighterTable fighters(buildings, characters);
   TargetFinder targets(db);
 
   std::vector<proto::TargetId> dead;
@@ -462,8 +464,9 @@ RegenerateFighterHP (Fighter f)
 void
 RegenerateHP (Database& db)
 {
+  BuildingsTable buildings(db);
   CharacterTable characters(db);
-  FighterTable fighters(characters);
+  FighterTable fighters(buildings, characters);
 
   fighters.ProcessForRegen ([] (Fighter f)
     {

--- a/src/combat.hpp
+++ b/src/combat.hpp
@@ -53,7 +53,7 @@ std::vector<proto::TargetId> DealCombatDamage (Database& db, DamageLists& dl,
  */
 void ProcessKills (Database& db, DamageLists& dl, GroundLootTable& loot,
                    const std::vector<proto::TargetId>& dead,
-                   const Context& ctx);
+                   xaya::Random& rnd, const Context& ctx);
 
 /**
  * Handles HP regeneration.

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -102,7 +102,7 @@ UpdateHP (Database& db, xaya::Random& rnd, const Context& ctx)
   GroundLootTable loot(db);
 
   const auto dead = DealCombatDamage (db, dl, rnd);
-  ProcessKills (db, dl, loot, dead, ctx);
+  ProcessKills (db, dl, loot, dead, rnd, ctx);
   RegenerateHP (db);
 }
 

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -84,9 +84,9 @@ InsertCharacters (Database& db, const unsigned numIdle,
           attack->set_min_damage (1);
           attack->set_max_damage (1);
         }
-      auto* targetId = c->MutableProto ().mutable_target ();
-      targetId->set_type (proto::TargetId::TYPE_CHARACTER);
-      targetId->set_id (id);
+      auto& targetId = c->MutableTarget ();
+      targetId.set_type (proto::TargetId::TYPE_CHARACTER);
+      targetId.set_id (id);
       c.reset ();
     }
 }

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -96,29 +96,29 @@ TEST_F (TargetSelectionTests, NoTargets)
   auto c = characters.CreateNew ("domob", Faction::RED);
   const auto id1 = c->GetId ();
   c->SetPosition (HexCoord (-10, 0));
-  c->MutableProto ().mutable_target ();
+  c->MutableTarget ().set_id (42);
   AddAttackWithRange (c->MutableProto (), 10);
   c.reset ();
 
   c = characters.CreateNew ("domob",Faction::RED);
   const auto id2 = c->GetId ();
   c->SetPosition (HexCoord (-10, 1));
-  c->MutableProto ().mutable_target ();
+  c->MutableTarget ().set_id (42);
   AddAttackWithRange (c->MutableProto (), 10);
   c.reset ();
 
   c = characters.CreateNew ("domob", Faction::GREEN);
   const auto id3 = c->GetId ();
   c->SetPosition (HexCoord (10, 0));
-  c->MutableProto ().mutable_target ();
+  c->MutableTarget ().set_id (42);
   AddAttackWithRange (c->MutableProto (), 10);
   c.reset ();
 
   FindCombatTargets (db, rnd);
 
-  EXPECT_FALSE (characters.GetById (id1)->GetProto ().has_target ());
-  EXPECT_FALSE (characters.GetById (id2)->GetProto ().has_target ());
-  EXPECT_FALSE (characters.GetById (id3)->GetProto ().has_target ());
+  EXPECT_FALSE (characters.GetById (id1)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (id3)->GetTarget ().has_id ());
 }
 
 TEST_F (TargetSelectionTests, ClosestTarget)
@@ -147,10 +147,10 @@ TEST_F (TargetSelectionTests, ClosestTarget)
       FindCombatTargets (db, rnd);
 
       c = characters.GetById (idFighter);
-      const auto& pb = c->GetProto ();
-      ASSERT_TRUE (pb.has_target ());
-      EXPECT_EQ (pb.target ().type (), proto::TargetId::TYPE_CHARACTER);
-      EXPECT_EQ (pb.target ().id (), idTarget);
+      const auto& t = c->GetTarget ();
+      ASSERT_TRUE (t.has_id ());
+      EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
+      EXPECT_EQ (t.id (), idTarget);
     }
 }
 
@@ -159,7 +159,7 @@ TEST_F (TargetSelectionTests, InsideBuildings)
   auto c = characters.CreateNew ("domob", Faction::RED);
   const auto id1 = c->GetId ();
   c->SetPosition (HexCoord (0, 0));
-  c->MutableProto ().mutable_target ();
+  c->MutableTarget ().set_id (42);
   AddAttackWithRange (c->MutableProto (), 10);
   c.reset ();
 
@@ -175,8 +175,8 @@ TEST_F (TargetSelectionTests, InsideBuildings)
 
   FindCombatTargets (db, rnd);
 
-  EXPECT_FALSE (characters.GetById (id1)->GetProto ().has_target ());
-  EXPECT_FALSE (characters.GetById (id2)->GetProto ().has_target ());
+  EXPECT_FALSE (characters.GetById (id1)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
 }
 
 TEST_F (TargetSelectionTests, MultipleAttacks)
@@ -197,12 +197,12 @@ TEST_F (TargetSelectionTests, MultipleAttacks)
   FindCombatTargets (db, rnd);
 
   c = characters.GetById (id1);
-  const auto& pb = c->GetProto ();
-  ASSERT_TRUE (pb.has_target ());
-  EXPECT_EQ (pb.target ().type (), proto::TargetId::TYPE_CHARACTER);
-  EXPECT_EQ (pb.target ().id (), id2);
+  const auto& t = c->GetTarget ();
+  ASSERT_TRUE (t.has_id ());
+  EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
+  EXPECT_EQ (t.id (), id2);
 
-  EXPECT_FALSE (characters.GetById (id2)->GetProto ().has_target ());
+  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
 }
 
 TEST_F (TargetSelectionTests, OnlyAreaAttacks)
@@ -222,12 +222,12 @@ TEST_F (TargetSelectionTests, OnlyAreaAttacks)
   FindCombatTargets (db, rnd);
 
   c = characters.GetById (id1);
-  const auto& pb = c->GetProto ();
-  ASSERT_TRUE (pb.has_target ());
-  EXPECT_EQ (pb.target ().type (), proto::TargetId::TYPE_CHARACTER);
-  EXPECT_EQ (pb.target ().id (), id2);
+  const auto& t = c->GetTarget ();
+  ASSERT_TRUE (t.has_id ());
+  EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
+  EXPECT_EQ (t.id (), id2);
 
-  EXPECT_FALSE (characters.GetById (id2)->GetProto ().has_target ());
+  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
 }
 
 TEST_F (TargetSelectionTests, Randomisation)
@@ -259,11 +259,11 @@ TEST_F (TargetSelectionTests, Randomisation)
       FindCombatTargets (db, rnd);
 
       c = characters.GetById (idFighter);
-      const auto& pb = c->GetProto ();
-      ASSERT_TRUE (pb.has_target ());
-      EXPECT_EQ (pb.target ().type (), proto::TargetId::TYPE_CHARACTER);
+      const auto& t = c->GetTarget ();
+      ASSERT_TRUE (t.has_id ());
+      EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
 
-      const auto mit = targetMap.find (pb.target ().id ());
+      const auto mit = targetMap.find (t.id ());
       ASSERT_NE (mit, targetMap.end ());
       ++cnt[mit->second];
     }

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -141,20 +141,20 @@ GetMovementJsonObject (const Character& c)
 }
 
 /**
- * Computes the "combat" sub-object for a Character's JSON state.
+ * Computes the basic "combat" sub-object for a Character or Building.
  */
 Json::Value
-GetCombatJsonObject (const Character& c, const DamageLists& dl)
+GetCombatJsonObject (const CombatEntity& h)
 {
   Json::Value res(Json::objectValue);
 
-  const auto targetJson = TargetIdToJson (c.GetTarget ());
+  const auto targetJson = TargetIdToJson (h.GetTarget ());
   if (!targetJson.isNull ())
     res["target"] = targetJson;
 
-  const auto& pb = c.GetProto ();
+  const auto& pb = h.GetCombatData ();
   Json::Value attacks(Json::arrayValue);
-  for (const auto& attack : pb.combat_data ().attacks ())
+  for (const auto& attack : pb.attacks ())
     {
       Json::Value obj(Json::objectValue);
       obj["range"] = IntToJson (attack.range ());
@@ -166,12 +166,24 @@ GetCombatJsonObject (const Character& c, const DamageLists& dl)
   if (!attacks.empty ())
     res["attacks"] = attacks;
 
-  const auto& regen = c.GetRegenData ();
+  const auto& regen = h.GetRegenData ();
   Json::Value hp(Json::objectValue);
   hp["max"] = HpProtoToJson (regen.max_hp ());
-  hp["current"] = HpProtoToJson (c.GetHP ());
+  hp["current"] = HpProtoToJson (h.GetHP ());
   hp["regeneration"] = regen.shield_regeneration_mhp () / 1000.0;
   res["hp"] = hp;
+
+  return res;
+}
+
+/**
+ * Computes the "combat" sub-object for a Character's JSON state
+ * (which includes the attackers data from DamageLists).
+ */
+Json::Value
+GetCombatJsonObject (const Character& c, const DamageLists& dl)
+{
+  Json::Value res = GetCombatJsonObject (c);
 
   Json::Value attackers(Json::arrayValue);
   for (const auto id : dl.GetAttackers (c.GetId ()))
@@ -335,6 +347,8 @@ template <>
   for (const auto& c : GetBuildingShape (b))
     tiles.append (CoordToJson (c));
   res["tiles"] = tiles;
+
+  res["combat"] = GetCombatJsonObject (b);
 
   auto invRes = buildingInventories.QueryForBuilding (b.GetId ());
   Json::Value inv(Json::objectValue);

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -38,11 +38,15 @@ namespace
 {
 
 /**
- * Converts a TargetId proto to its JSON gamestate form.
+ * Converts a TargetId proto to its JSON gamestate form.  It may be a null
+ * JSON if the target is "empty".
  */
 Json::Value
 TargetIdToJson (const proto::TargetId& target)
 {
+  if (!target.has_id ())
+    return Json::Value ();
+
   Json::Value res(Json::objectValue);
   res["id"] = IntToJson (target.id ());
 
@@ -144,10 +148,11 @@ GetCombatJsonObject (const Character& c, const DamageLists& dl)
 {
   Json::Value res(Json::objectValue);
 
-  const auto& pb = c.GetProto ();
-  if (pb.has_target ())
-    res["target"] = TargetIdToJson (pb.target ());
+  const auto targetJson = TargetIdToJson (c.GetTarget ());
+  if (!targetJson.isNull ())
+    res["target"] = targetJson;
 
+  const auto& pb = c.GetProto ();
   Json::Value attacks(Json::arrayValue);
   for (const auto& attack : pb.combat_data ().attacks ())
     {

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -275,13 +275,13 @@ TEST_F (CharacterJsonTests, MultipleStep)
 TEST_F (CharacterJsonTests, Target)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);
-  auto* targetProto = c->MutableProto ().mutable_target ();
+  auto* targetProto = &c->MutableTarget ();
   targetProto->set_id (5);
   targetProto->set_type (proto::TargetId::TYPE_CHARACTER);
   c.reset ();
 
   c = tbl.CreateNew ("domob", Faction::GREEN);
-  targetProto = c->MutableProto ().mutable_target ();
+  targetProto = &c->MutableTarget ();
   targetProto->set_id (42);
   targetProto->set_type (proto::TargetId::TYPE_BUILDING);
   c.reset ();

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -652,6 +652,55 @@ TEST_F (BuildingJsonTests, Inventories)
   })");
 }
 
+TEST_F (BuildingJsonTests, CombatData)
+{
+  ASSERT_EQ (tbl.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId (), 1);
+
+  auto h = tbl.CreateNew ("checkmark", "daniel", Faction::RED);
+  ASSERT_EQ (h->GetId (), 2);
+  auto* att = h->MutableProto ().mutable_combat_data ()->add_attacks ();
+  att->set_range (5);
+  att->set_min_damage (1);
+  att->set_max_damage (2);
+  h->MutableHP ().set_armour (42);
+  h->MutableHP ().set_shield_mhp (1);
+  auto& regen = h->MutableRegenData ();
+  regen.set_shield_regeneration_mhp (1'001);
+  regen.mutable_max_hp ()->set_armour (100);
+  regen.mutable_max_hp ()->set_shield (50);
+  auto& t = h->MutableTarget ();
+  t.set_id (10);
+  t.set_type (proto::TargetId::TYPE_CHARACTER);
+  h.reset ();
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "combat": {"target": null}
+        },
+        {
+          "id": 2,
+          "combat":
+            {
+              "hp":
+                {
+                  "max": {"armour": 100, "shield": 50},
+                  "current": {"armour": 42, "shield": 0.001},
+                  "regeneration": 1.001
+                },
+              "attacks":
+                [
+                  {"range": 5, "area": false, "mindamage": 1, "maxdamage": 2}
+                ],
+              "target": { "id": 10 }
+            }
+        }
+      ]
+  })");
+}
+
 /* ************************************************************************** */
 
 class GroundLootJsonTests : public GameStateJsonTests

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -225,7 +225,7 @@ TEST_F (PXLogicTests, MovementBeforeTargeting)
   UpdateState ("[]");
 
   ASSERT_EQ (characters.GetById (id2)->GetPosition (), HexCoord (11, 0));
-  ASSERT_FALSE (characters.GetById (id1)->GetProto ().has_target ());
+  ASSERT_FALSE (characters.GetById (id1)->GetTarget ().has_id ());
 
   c = characters.GetById (id2);
   auto* wp = c->MutableProto ().mutable_movement ()->mutable_waypoints ();
@@ -237,8 +237,8 @@ TEST_F (PXLogicTests, MovementBeforeTargeting)
 
   ASSERT_EQ (characters.GetById (id2)->GetPosition (), HexCoord (10, 0));
   c = characters.GetById (id1);
-  ASSERT_TRUE (c->GetProto ().has_target ());
-  const auto& t = c->GetProto ().target ();
+  const auto& t = c->GetTarget ();
+  ASSERT_TRUE (t.has_id ());
   EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
   EXPECT_EQ (t.id (), id2);
 }
@@ -269,8 +269,7 @@ TEST_F (PXLogicTests, KilledVehicleNoLongerBlocks)
   /* Process one block to allow targeting.  */
   UpdateState ("[]");
   ASSERT_NE (characters.GetById (idObstacle), nullptr);
-  ASSERT_EQ (characters.GetById (idAttacker)->GetProto ().target ().id (),
-             idObstacle);
+  ASSERT_EQ (characters.GetById (idAttacker)->GetTarget ().id (), idObstacle);
 
   /* Next block, the obstacle should be killed and the moving vehicle
      can be moved into its spot.  */
@@ -838,8 +837,8 @@ TEST_F (PXLogicTests, EnterBuildingAndTargetFinding)
   /* Both characters will target and attack each other.  */
   UpdateState ("[]");
 
-  EXPECT_EQ (characters.GetById (2)->GetProto ().target ().id (), 3);
-  EXPECT_EQ (characters.GetById (3)->GetProto ().target ().id (), 2);
+  EXPECT_EQ (characters.GetById (2)->GetTarget ().id (), 3);
+  EXPECT_EQ (characters.GetById (3)->GetTarget ().id (), 2);
 
   /* Now the "domob" character will enter the building, and neither will
      target the other any more.  */
@@ -850,8 +849,8 @@ TEST_F (PXLogicTests, EnterBuildingAndTargetFinding)
     }
   ])");
 
-  EXPECT_FALSE (characters.GetById (2)->GetProto ().has_target ());
-  EXPECT_FALSE (characters.GetById (3)->GetProto ().has_target ());
+  EXPECT_FALSE (characters.GetById (2)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (3)->GetTarget ().has_id ());
 }
 
 TEST_F (PXLogicTests, EnterAndExitBuildingWhenOutside)

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -998,10 +998,13 @@ MaybeGodTeleport (CharacterTable& tbl, const Json::Value& cmd)
 }
 
 /**
- * Tries to parse and execute a god-mode command to set HP.
+ * Tries to parse and execute a god-mode command to set HP, either
+ * for characters or buildings (depending on which type of table
+ * is passed in).
  */
-void
-MaybeGodSetHp (CharacterTable& tbl, const Json::Value& cmd)
+template <typename T>
+  void
+  MaybeGodSetHp (T& tbl, const Json::Value& cmd)
 {
   if (!cmd.isObject ())
     return;
@@ -1042,6 +1045,20 @@ MaybeGodSetHp (CharacterTable& tbl, const Json::Value& cmd)
       if (val.isUInt64 ())
         maxHP.set_shield (val.asUInt64 ());
     }
+}
+
+/**
+ * Tries to parse and execute a full "set HP" command, which is expected
+ * to contain a list of buildings and/or characters to update.
+ */
+void
+MaybeGodAllSetHp (BuildingsTable& b, CharacterTable& c, const Json::Value& cmd)
+{
+  if (!cmd.isObject ())
+    return;
+
+  MaybeGodSetHp (b, cmd["b"]);
+  MaybeGodSetHp (c, cmd["c"]);
 }
 
 /**
@@ -1198,7 +1215,7 @@ MoveProcessor::HandleGodMode (const Json::Value& cmd)
     }
 
   MaybeGodTeleport (characters, cmd["teleport"]);
-  MaybeGodSetHp (characters, cmd["sethp"]);
+  MaybeGodAllSetHp (buildings, characters, cmd["sethp"]);
   MaybeGodBuild (accounts, buildings, cmd["build"]);
   MaybeGodDropLoot (groundLoot, cmd["drop"]);
 }

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1139,6 +1139,7 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl,
       auto h = tbl.CreateNew (type, owner, f);
       h->SetCentre (centre);
       h->MutableProto ().mutable_shape_trafo ()->set_rotation_steps (rot);
+      UpdateBuildingStats (*h);
       LOG (INFO)
           << "God building " << type
           << " for " << owner << " of faction " << FactionToString (f) << ":\n"

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1840,13 +1840,26 @@ TEST_F (GodModeTests, SetHp)
   regen.mutable_max_hp ()->set_shield (20);
   c.reset ();
 
+  auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  ASSERT_EQ (b->GetId (), 2);
+  b->MutableHP ().set_armour (50);
+  b->MutableHP ().set_shield (20);
+  b.reset ();
+
   ProcessAdmin (R"([{"cmd": {
     "god":
       {
         "sethp":
           {
-            "2": {"a": 5},
-            "1": {"a": 32, "s": 15, "ma": -5, "ms": false, "x": "y"}
+            "b":
+              {
+                "2": {"ma": 200, "a": 5}
+              },
+            "c":
+              {
+                "2": {"a": 5},
+                "1": {"a": 32, "s": 15, "ma": -5, "ms": false, "x": "y"}
+              }
           }
       }
   }}])");
@@ -1858,12 +1871,21 @@ TEST_F (GodModeTests, SetHp)
   EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 20);
   c.reset ();
 
+  b = buildings.GetById (2);
+  EXPECT_EQ (b->GetHP ().armour (), 5);
+  EXPECT_EQ (b->GetHP ().shield (), 20);
+  EXPECT_EQ (b->GetRegenData ().max_hp ().armour (), 200);
+  b.reset ();
+
   ProcessAdmin (R"([{"cmd": {
     "god":
       {
         "sethp":
           {
-            "1": {"a": 1.5, "s": -15, "ma": 100, "ms": 90}
+            "c":
+              {
+                "1": {"a": 1.5, "s": -15, "ma": 100, "ms": 90}
+              }
           }
       }
   }}])");


### PR DESCRIPTION
This implements combat with buildings (#85).  They now have HP, regeneration data and attacks, and can be destroyed.  When a building is destroyed, all characters inside it are killed, and some of the loot inside is dropped on the ground.

To test building combat, this also defines a new building type `r_rt` for a turret with some random stats and attacks.