### PR TITLE
Remove Fighter class

### DIFF
--- a/database/building.cpp
+++ b/database/building.cpp
@@ -119,6 +119,15 @@ Building::SetCentre (const HexCoord& c)
   pos = c;
 }
 
+proto::TargetId
+Building::GetIdAsTarget () const
+{
+  proto::TargetId res;
+  res.set_type (proto::TargetId::TYPE_BUILDING);
+  res.set_id (id);
+  return res;
+}
+
 BuildingsTable::Handle
 BuildingsTable::CreateNew (const std::string& type,
                            const std::string& owner, const Faction faction)

--- a/database/building.hpp
+++ b/database/building.hpp
@@ -124,7 +124,7 @@ public:
   }
 
   Faction
-  GetFaction () const
+  GetFaction () const override
   {
     return faction;
   }
@@ -161,6 +161,14 @@ public:
   MutableProto ()
   {
     return data.Mutable ();
+  }
+
+  proto::TargetId GetIdAsTarget () const override;
+
+  const HexCoord&
+  GetCombatPosition () const override
+  {
+    return GetCentre ();
   }
 
   const proto::CombatData&

--- a/database/building_tests.cpp
+++ b/database/building_tests.cpp
@@ -137,12 +137,19 @@ TEST_F (BuildingTests, CombatFields)
 
   h = tbl.GetById (id);
   EXPECT_EQ (h->GetRegenData ().shield_regeneration_mhp (), 42);
-  h->MutableTarget ().set_id (50);
+  EXPECT_FALSE (h->HasTarget ());
+  proto::TargetId t;
+  t.set_id (50);
+  h->SetTarget (t);
   h.reset ();
 
   h = tbl.GetById (id);
+  ASSERT_TRUE (h->HasTarget ());
   EXPECT_EQ (h->GetTarget ().id (), 50);
+  h->ClearTarget ();
   h.reset ();
+
+  EXPECT_FALSE (tbl.GetById (id)->HasTarget ());
 }
 
 /* ************************************************************************** */
@@ -209,7 +216,9 @@ TEST_F (BuildingsTableTests, QueryWithTarget)
 {
   auto h = tbl.CreateNew ("turret", "domob", Faction::RED);
   const auto id1 = h->GetId ();
-  h->MutableTarget ().set_id (5);
+  proto::TargetId t;
+  t.set_id (5);
+  h->SetTarget (t);
   h.reset ();
 
   const auto id2 = tbl.CreateNew ("turret", "andy", Faction::GREEN)->GetId ();
@@ -219,8 +228,8 @@ TEST_F (BuildingsTableTests, QueryWithTarget)
   EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "domob");
   ASSERT_FALSE (res.Step ());
 
-  tbl.GetById (id1)->MutableTarget ().clear_id ();
-  tbl.GetById (id2)->MutableTarget ().set_id (42);
+  tbl.GetById (id1)->ClearTarget ();
+  tbl.GetById (id2)->SetTarget (t);
 
   res = tbl.QueryWithTarget ();
   ASSERT_TRUE (res.Step ());

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -232,6 +232,15 @@ Character::UsedCargoSpace () const
   return res;
 }
 
+proto::TargetId
+Character::GetIdAsTarget () const
+{
+  proto::TargetId res;
+  res.set_type (proto::TargetId::TYPE_CHARACTER);
+  res.set_id (id);
+  return res;
+}
+
 CharacterTable::Handle
 CharacterTable::CreateNew (const std::string& owner, const Faction faction)
 {

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -177,7 +177,7 @@ public:
   }
 
   Faction
-  GetFaction () const
+  GetFaction () const override
   {
     return faction;
   }
@@ -280,6 +280,14 @@ public:
    * Returns the used cargo space for the character's inventory.
    */
   uint64_t UsedCargoSpace () const;
+
+  proto::TargetId GetIdAsTarget () const override;
+
+  const HexCoord&
+  GetCombatPosition () const override
+  {
+    return GetPosition ();
+  }
 
   const proto::CombatData&
   GetCombatData () const override

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -200,18 +200,19 @@ TEST_F (CharacterTests, Target)
   h.reset ();
 
   h = tbl.GetById (id);
-  EXPECT_FALSE (h->GetTarget ().has_id ());
-  h->MutableTarget ().set_id (42);
+  EXPECT_FALSE (h->HasTarget ());
+  proto::TargetId t;
+  t.set_id(42);
+  h->SetTarget (t);
   h.reset ();
 
   h = tbl.GetById (id);
+  ASSERT_TRUE (h->HasTarget ());
   EXPECT_EQ (h->GetTarget ().id (), 42);
-  h->MutableTarget ().clear_id ();
+  h->ClearTarget ();
   h.reset ();
 
-  h = tbl.GetById (id);
-  EXPECT_FALSE (h->GetTarget ().has_id ());
-  h.reset ();
+  EXPECT_FALSE (tbl.GetById (id)->HasTarget ());
 }
 
 TEST_F (CharacterTests, Inventory)
@@ -422,7 +423,9 @@ TEST_F (CharacterTableTests, QueryWithTarget)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);
   const auto id1 = c->GetId ();
-  c->MutableTarget ().set_id (5);
+  proto::TargetId t;
+  t.set_id (5);
+  c->SetTarget (t);
   c.reset ();
 
   const auto id2 = tbl.CreateNew ("andy", Faction::GREEN)->GetId ();
@@ -432,8 +435,8 @@ TEST_F (CharacterTableTests, QueryWithTarget)
   EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "domob");
   ASSERT_FALSE (res.Step ());
 
-  tbl.GetById (id1)->MutableTarget ().clear_id ();
-  tbl.GetById (id2)->MutableTarget ().set_id (42);
+  tbl.GetById (id1)->ClearTarget ();
+  tbl.GetById (id2)->SetTarget (t);
 
   res = tbl.QueryWithTarget ();
   ASSERT_TRUE (res.Step ());

--- a/database/combat.cpp
+++ b/database/combat.cpp
@@ -40,7 +40,7 @@ CombatEntity::BindFullFields (Database::Statement& stmt,
   stmt.BindProto (indRegenData, regenData);
   stmt.Bind (indAttackRange, FindAttackRange (GetCombatData ()));
 
-  if (target.Get ().has_id ())
+  if (HasTarget ())
     stmt.BindProto (indTarget, target);
   else
     stmt.BindNull (indTarget);
@@ -67,6 +67,27 @@ CombatEntity::Validate () const
     CHECK_EQ (attackRange, FindAttackRange (pb.combat_data ()));
 
 #endif // ENABLE_SLOW_ASSERTS
+}
+
+const proto::TargetId&
+CombatEntity::GetTarget () const
+{
+  CHECK (HasTarget ());
+  return target.Get ();
+}
+
+void
+CombatEntity::ClearTarget ()
+{
+  if (HasTarget ())
+    target.Mutable ().Clear ();
+}
+
+void
+CombatEntity::SetTarget (const proto::TargetId& t)
+{
+  target.Mutable () = t;
+  CHECK (HasTarget ());
 }
 
 HexCoord::IntT

--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -200,17 +200,16 @@ public:
     return regenData.Mutable ();
   }
 
-  const proto::TargetId&
-  GetTarget () const
+  bool
+  HasTarget () const
   {
-    return target.Get ();
+    return target.Get ().has_id ();
   }
 
-  proto::TargetId&
-  MutableTarget ()
-  {
-    return target.Mutable ();
-  }
+  const proto::TargetId& GetTarget () const;
+
+  void ClearTarget ();
+  void SetTarget (const proto::TargetId& t);
 
   /**
    * Returns the entity's attack range or zero if there are no attacks.

--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -20,6 +20,7 @@
 #define DATABASE_COMBAT_HPP
 
 #include "database.hpp"
+#include "faction.hpp"
 #include "lazyproto.hpp"
 
 #include "hexagonal/coord.hpp"
@@ -221,7 +222,23 @@ public:
   HexCoord::IntT GetAttackRange () const;
 
   /**
-   * Subclasses must implement this to return the combat data proto.
+   * Returns this entity's target ID as a proto.
+   */
+  virtual proto::TargetId GetIdAsTarget () const = 0;
+
+  /**
+   * Returns the entity's faction (which is needed to determine friendliness).
+   */
+  virtual Faction GetFaction () const = 0;
+
+  /**
+   * Returns the position of this entity for attack targeting.
+   */
+  virtual const HexCoord& GetCombatPosition () const = 0;
+
+  /**
+   * Returns the CombatData proto for this entity, which is likely somewhere
+   * extracted from the (type-specific) main proto.
    */
   virtual const proto::CombatData& GetCombatData () const = 0;
 

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -23,143 +23,16 @@
 namespace pxd
 {
 
-proto::TargetId
-Fighter::GetId () const
-{
-  if (building != nullptr)
-    return building->GetIdAsTarget ();
-
-  CHECK (character != nullptr);
-  return character->GetIdAsTarget ();
-}
-
-Faction
-Fighter::GetFaction () const
-{
-  if (building != nullptr)
-    return building->GetFaction ();
-
-  CHECK (character != nullptr);
-  return character->GetFaction ();
-}
-
-const HexCoord&
-Fighter::GetPosition () const
-{
-  if (building != nullptr)
-    return building->GetCombatPosition ();
-
-  CHECK (character != nullptr);
-  return character->GetCombatPosition ();
-}
-
-const proto::RegenData&
-Fighter::GetRegenData () const
-{
-  if (building != nullptr)
-    return building->GetRegenData ();
-
-  CHECK (character != nullptr);
-  return character->GetRegenData ();
-}
-
-const proto::CombatData&
-Fighter::GetCombatData () const
-{
-  if (building != nullptr)
-    return building->GetCombatData ();
-
-  CHECK (character != nullptr);
-  return character->GetCombatData ();
-}
-
-HexCoord::IntT
-Fighter::GetAttackRange () const
-{
-  if (building != nullptr)
-    return building->GetAttackRange ();
-
-  CHECK (character != nullptr);
-  return character->GetAttackRange ();
-}
-
-const proto::TargetId&
-Fighter::GetTarget () const
-{
-  if (building != nullptr)
-    return building->GetTarget ();
-
-  CHECK (character != nullptr);
-  return character->GetTarget ();
-}
-
-void
-Fighter::SetTarget (const proto::TargetId& target)
-{
-  if (building != nullptr)
-    building->SetTarget (target);
-  else
-    {
-      CHECK (character != nullptr);
-      character->SetTarget (target);
-    }
-}
-
-void
-Fighter::ClearTarget ()
-{
-  if (building != nullptr)
-    building->ClearTarget ();
-  else
-    {
-      CHECK (character != nullptr);
-      character->ClearTarget ();
-    }
-}
-
-const proto::HP&
-Fighter::GetHP () const
-{
-  if (building != nullptr)
-    return building->GetHP ();
-
-  CHECK (character != nullptr);
-  return character->GetHP ();
-}
-
-proto::HP&
-Fighter::MutableHP ()
-{
-  if (building != nullptr)
-    return building->MutableHP ();
-
-  CHECK (character != nullptr);
-  return character->MutableHP ();
-}
-
-void
-Fighter::reset ()
-{
-  building.reset ();
-  character.reset ();
-}
-
-bool
-Fighter::empty () const
-{
-  return building == nullptr && character == nullptr;
-}
-
-Fighter
+FighterTable::Handle
 FighterTable::GetForTarget (const proto::TargetId& id)
 {
   switch (id.type ())
     {
     case proto::TargetId::TYPE_BUILDING:
-      return Fighter (buildings.GetById (id.id ()));
+      return buildings.GetById (id.id ());
 
     case proto::TargetId::TYPE_CHARACTER:
-      return Fighter (characters.GetById (id.id ()));
+      return characters.GetById (id.id ());
 
     default:
       LOG (FATAL) << "Invalid target type: " << static_cast<int> (id.type ());
@@ -172,13 +45,13 @@ FighterTable::ProcessWithAttacks (const Callback& cb)
   {
     auto res = buildings.QueryWithAttacks ();
     while (res.Step ())
-      cb (Fighter (buildings.GetFromResult (res)));
+      cb (buildings.GetFromResult (res));
   }
 
   {
     auto res = characters.QueryWithAttacks ();
     while (res.Step ())
-      cb (Fighter (characters.GetFromResult (res)));
+      cb (characters.GetFromResult (res));
   }
 }
 
@@ -188,13 +61,13 @@ FighterTable::ProcessForRegen (const Callback& cb)
   {
     auto res = buildings.QueryForRegen ();
     while (res.Step ())
-      cb (Fighter (buildings.GetFromResult (res)));
+      cb (buildings.GetFromResult (res));
   }
 
   {
     auto res = characters.QueryForRegen ();
     while (res.Step ())
-      cb (Fighter (characters.GetFromResult (res)));
+      cb (characters.GetFromResult (res));
   }
 }
 
@@ -204,13 +77,13 @@ FighterTable::ProcessWithTarget (const Callback& cb)
   {
     auto res = buildings.QueryWithTarget ();
     while (res.Step ())
-      cb (Fighter (buildings.GetFromResult (res)));
+      cb (buildings.GetFromResult (res));
   }
 
   {
     auto res = characters.QueryWithTarget ();
     while (res.Step ())
-      cb (Fighter (characters.GetFromResult (res)));
+      cb (characters.GetFromResult (res));
   }
 }
 

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -86,30 +86,22 @@ Fighter::GetAttackRange () const
 const proto::TargetId&
 Fighter::GetTarget () const
 {
-  const proto::TargetId* pb;
   if (building != nullptr)
-    pb = &building->GetTarget ();
-  else
-    {
-      CHECK (character != nullptr);
-      pb = &character->GetTarget ();
-    }
+    return building->GetTarget ();
 
-  CHECK (pb->has_id ());
-  return *pb;
+  CHECK (character != nullptr);
+  return character->GetTarget ();
 }
 
 void
 Fighter::SetTarget (const proto::TargetId& target)
 {
-  CHECK (target.has_id ());
-
   if (building != nullptr)
-    building->MutableTarget () = target;
+    building->SetTarget (target);
   else
     {
       CHECK (character != nullptr);
-      character->MutableTarget () = target;
+      character->SetTarget (target);
     }
 }
 
@@ -117,11 +109,11 @@ void
 Fighter::ClearTarget ()
 {
   if (building != nullptr)
-    building->MutableTarget ().clear_id ();
+    building->ClearTarget ();
   else
     {
       CHECK (character != nullptr);
-      character->MutableTarget ().clear_id ();
+      character->ClearTarget ();
     }
 }
 

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -26,21 +26,11 @@ namespace pxd
 proto::TargetId
 Fighter::GetId () const
 {
-  proto::TargetId res;
-
   if (building != nullptr)
-    {
-      res.set_type (proto::TargetId::TYPE_BUILDING);
-      res.set_id (building->GetId ());
-    }
-  else
-    {
-      CHECK (character != nullptr);
-      res.set_type (proto::TargetId::TYPE_CHARACTER);
-      res.set_id (character->GetId ());
-    }
+    return building->GetIdAsTarget ();
 
-  return res;
+  CHECK (character != nullptr);
+  return character->GetIdAsTarget ();
 }
 
 Faction
@@ -57,10 +47,10 @@ const HexCoord&
 Fighter::GetPosition () const
 {
   if (building != nullptr)
-    return building->GetCentre ();
+    return building->GetCombatPosition ();
 
   CHECK (character != nullptr);
-  return character->GetPosition ();
+  return character->GetCombatPosition ();
 }
 
 const proto::RegenData&
@@ -77,22 +67,10 @@ const proto::CombatData&
 Fighter::GetCombatData () const
 {
   if (building != nullptr)
-    {
-      const auto& pb = building->GetProto ();
-
-      /* Every fighter must have combat data to be valid.  This is set when
-         first created and then only updated.  Enforce this requirement here,
-         so that we do not accidentally work with an empty proto just because it
-         has not been initialised due to a bug.  */
-      CHECK (pb.has_combat_data ());
-
-      return pb.combat_data ();
-    }
+    return building->GetCombatData ();
 
   CHECK (character != nullptr);
-  const auto& pb = character->GetProto ();
-  CHECK (pb.has_combat_data ());
-  return pb.combat_data ();
+  return character->GetCombatData ();
 }
 
 HexCoord::IntT

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -33,118 +33,8 @@ namespace pxd
 {
 
 /**
- * Database abstraction for a fighter (entity that can attack another or take
- * damage from another one's attack).  This can be either a character or a
- * building.  This class makes both look the same for the processing code.
- */
-class Fighter
-{
-
-private:
-
-  /** The handle if this is a building.  */
-  std::unique_ptr<CombatEntity> building;
-
-  /** The handle if this is a character.  */
-  std::unique_ptr<CombatEntity> character;
-
-  /**
-   * Construct a fighter based on a building handle.
-   */
-  explicit Fighter (BuildingsTable::Handle b)
-    : building(std::move (b))
-  {}
-
-  /**
-   * Construct a fighter based on a character handle.
-   */
-  explicit Fighter (CharacterTable::Handle c)
-    : character(std::move (c))
-  {}
-
-  friend class FighterTable;
-
-public:
-
-  Fighter () = default;
-  Fighter (Fighter&&) = default;
-  Fighter& operator= (Fighter&&) = default;
-
-  Fighter (const Fighter&) = delete;
-  void operator= (const Fighter&) = delete;
-
-  /**
-   * Returns this fighter's type and ID.
-   */
-  proto::TargetId GetId () const;
-
-  /**
-   * Returns this fighter's faction association.  This is used to determine
-   * friendlyness towards potential targets.
-   */
-  Faction GetFaction () const;
-
-  /**
-   * Returns the figher's position.  Must not be called if this is an
-   * empty handle.
-   */
-  const HexCoord& GetPosition () const;
-
-  /**
-   * Returns the HP regeneration data for this fighter.
-   */
-  const proto::RegenData& GetRegenData () const;
-
-  /**
-   * Returns the combat data proto for this fighter.
-   */
-  const proto::CombatData& GetCombatData () const;
-
-  /**
-   * Returns the fighter's attack range or zero if there are no attacks.
-   */
-  HexCoord::IntT GetAttackRange () const;
-
-  /**
-   * Returns the target.  This must only be called if there is one.
-   */
-  const proto::TargetId& GetTarget () const;
-
-  /**
-   * Sets the target of this fighter to the given proto.
-   */
-  void SetTarget (const proto::TargetId& target);
-
-  /**
-   * Clears target selection (i.e. no target is selected).
-   */
-  void ClearTarget ();
-
-  /**
-   * Returns a read-only reference to the current HP.
-   */
-  const proto::HP& GetHP () const;
-
-  /**
-   * Returns a mutable reference to the current HP so that they can be modified
-   * (for dealing damage and for regenerating the shield).
-   */
-  proto::HP& MutableHP ();
-
-  /**
-   * Resets the handle to be empty.
-   */
-  void reset ();
-
-  /**
-   * Checks whether or not this is an "empty" pointer.
-   */
-  bool empty () const;
-
-};
-
-/**
- * Database interface for retrieving handles to all fighters.
+ * Database interface for retrieving handles to all fighters (i.e. entities
+ * that need to be processed for combat).
  */
 class FighterTable
 {
@@ -159,8 +49,11 @@ private:
 
 public:
 
+  /** Handle to a generic fighter entity.  */
+  using Handle = std::unique_ptr<CombatEntity>;
+
   /** Type for callbacks when querying for all fighters.  */
-  using Callback = std::function<void (Fighter f)>;
+  using Callback = std::function<void (Handle f)>;
 
   /**
    * Constructs a fighter table drawing buildings and characters from the given
@@ -177,7 +70,7 @@ public:
   /**
    * Retrieves the fighter handle for the given target ID.
    */
-  Fighter GetForTarget (const proto::TargetId& id);
+  Handle GetForTarget (const proto::TargetId& id);
 
   /**
    * Retrieves all fighters from the database that have an attack and runs

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -21,11 +21,13 @@
 
 #include "building.hpp"
 #include "character.hpp"
+#include "combat.hpp"
 
 #include "hexagonal/coord.hpp"
 #include "proto/combat.pb.h"
 
 #include <functional>
+#include <memory>
 
 namespace pxd
 {
@@ -40,11 +42,11 @@ class Fighter
 
 private:
 
-  /** The character handle if this is a building.  */
-  BuildingsTable::Handle building;
+  /** The handle if this is a building.  */
+  std::unique_ptr<CombatEntity> building;
 
-  /** The character handle if this is a character.  */
-  CharacterTable::Handle character;
+  /** The handle if this is a character.  */
+  std::unique_ptr<CombatEntity> character;
 
   /**
    * Construct a fighter based on a building handle.

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -33,7 +33,7 @@ namespace pxd
 namespace
 {
 
-class FighterTests : public DBTestWithSchema
+class FighterTableTests : public DBTestWithSchema
 {
 
 protected:
@@ -43,115 +43,13 @@ protected:
 
   FighterTable tbl;
 
-  FighterTests ()
+  FighterTableTests ()
     : buildings(db), characters(db), tbl(buildings, characters)
   {}
 
 };
 
-TEST_F (FighterTests, Characters)
-{
-  auto c = characters.CreateNew ("domob", Faction::RED);
-  const auto id1 = c->GetId ();
-  c->SetPosition (HexCoord (2, 5));
-  c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (5);
-  c->MutableHP ().set_armour (10);
-  c.reset ();
-
-  c = characters.CreateNew ("domob", Faction::GREEN);
-  const auto id2 = c->GetId ();
-  proto::TargetId t;
-  t.set_id (42);
-  c->SetTarget (t);
-  c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (10);
-  c->MutableRegenData ().set_shield_regeneration_mhp (2);
-  c.reset ();
-
-  proto::TargetId targetId;
-  targetId.set_type (proto::TargetId::TYPE_CHARACTER);
-
-  /* Read and modify first character through Fighter interface.  */
-  targetId.set_id (id1);
-  auto f = tbl.GetForTarget (targetId);
-
-  EXPECT_EQ (f.GetFaction (), Faction::RED);
-  EXPECT_EQ (f.GetPosition (), HexCoord (2, 5));
-  EXPECT_EQ (f.GetCombatData ().attacks_size (), 1);
-  EXPECT_EQ (f.GetAttackRange (), 5);
-
-  const auto id = f.GetId ();
-  EXPECT_EQ (id.type (), proto::TargetId::TYPE_CHARACTER);
-  EXPECT_EQ (id.id (), id1);
-
-  auto& hp = f.MutableHP ();
-  EXPECT_EQ (hp.armour (), 10);
-  hp.set_armour (5);
-
-  t.set_id (5);
-  f.SetTarget (t);
-  f.reset ();
-
-  /* Read and modify second character through Fighter interface.  */
-  targetId.set_id (id2);
-  f = tbl.GetForTarget (targetId);
-
-  EXPECT_EQ (f.GetFaction (), Faction::GREEN);
-  EXPECT_EQ (f.GetTarget ().id (), 42);
-  EXPECT_EQ (f.GetAttackRange (), 10);
-  EXPECT_EQ (f.GetRegenData ().shield_regeneration_mhp (), 2);
-  f.ClearTarget ();
-  f.reset ();
-
-  /* Verify modifications through the CharacterTable.  */
-  c = characters.GetById (id1);
-  EXPECT_EQ (c->GetTarget ().id (), 5);
-  EXPECT_EQ (c->GetHP ().armour (), 5);
-  EXPECT_FALSE (characters.GetById (id2)->HasTarget ());
-}
-
-TEST_F (FighterTests, Buildings)
-{
-  auto b = buildings.CreateNew ("checkmark", "domob", Faction::BLUE);
-  const auto id = b->GetId ();
-  b->SetCentre (HexCoord (10, -12));
-  b->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (10);
-  b->MutableHP ().set_armour (10);
-  b->MutableRegenData ().set_shield_regeneration_mhp (2);
-  b.reset ();
-
-  proto::TargetId targetId;
-  targetId.set_type (proto::TargetId::TYPE_BUILDING);
-  targetId.set_id (id);
-
-  auto f = tbl.GetForTarget (targetId);
-  EXPECT_EQ (f.GetFaction (), Faction::BLUE);
-  EXPECT_EQ (f.GetPosition (), HexCoord (10, -12));
-  EXPECT_EQ (f.GetCombatData ().attacks_size (), 1);
-  EXPECT_EQ (f.GetAttackRange (), 10);
-  EXPECT_EQ (f.GetId ().type (), proto::TargetId::TYPE_BUILDING);
-  EXPECT_EQ (f.GetId ().id (), id);
-  EXPECT_EQ (f.GetRegenData ().shield_regeneration_mhp (), 2);
-
-  auto& hp = f.MutableHP ();
-  EXPECT_EQ (hp.armour (), 10);
-  hp.set_armour (5);
-
-  proto::TargetId t;
-  t.set_id (5);
-  f.SetTarget (t);
-  f.reset ();
-
-  f = tbl.GetForTarget (targetId);
-  EXPECT_EQ (f.GetTarget ().id (), 5);
-  EXPECT_EQ (f.GetHP ().armour (), 5);
-  f.ClearTarget ();
-  f.reset ();
-
-  b = buildings.GetById (id);
-  EXPECT_FALSE (b->HasTarget ());
-}
-
-TEST_F (FighterTests, GetForTarget)
+TEST_F (FighterTableTests, GetForTarget)
 {
   auto c = characters.CreateNew ("domob", Faction::RED);
   const auto idChar = c->GetId ();
@@ -166,33 +64,24 @@ TEST_F (FighterTests, GetForTarget)
   proto::TargetId targetId;
   targetId.set_type (proto::TargetId::TYPE_CHARACTER);
   targetId.set_id (idChar);
-  auto f = tbl.GetForTarget (targetId);
-  EXPECT_EQ (f.GetPosition (), HexCoord (42, -35));
-  f.MutableHP ().set_shield (42);
-  f.reset ();
+  EXPECT_EQ (tbl.GetForTarget (targetId)->GetCombatPosition (),
+             HexCoord (42, -35));
 
   targetId.set_type (proto::TargetId::TYPE_BUILDING);
   targetId.set_id (idBuilding);
-  f = tbl.GetForTarget (targetId);
-  EXPECT_EQ (f.GetPosition (), HexCoord (100, -100));
-  f.MutableHP ().set_shield (80);
-  f.reset ();
+  EXPECT_EQ (tbl.GetForTarget (targetId)->GetCombatPosition (),
+             HexCoord (100, -100));
 
   targetId.set_type (proto::TargetId::TYPE_CHARACTER);
   targetId.set_id (idBuilding);
-  EXPECT_TRUE (tbl.GetForTarget (targetId).empty ());
+  EXPECT_EQ (tbl.GetForTarget (targetId), nullptr);
 
   targetId.set_type (proto::TargetId::TYPE_BUILDING);
   targetId.set_id (idChar);
-  EXPECT_TRUE (tbl.GetForTarget (targetId).empty ());
-
-  c = characters.GetById (idChar);
-  EXPECT_EQ (c->GetHP ().shield (), 42);
-  b = buildings.GetById (idBuilding);
-  EXPECT_EQ (b->GetHP ().shield (), 80);
+  EXPECT_EQ (tbl.GetForTarget (targetId), nullptr);
 }
 
-TEST_F (FighterTests, ProcessWithAttacks)
+TEST_F (FighterTableTests, ProcessWithAttacks)
 {
   buildings.CreateNew ("checkmark", "domob", Faction::GREEN);
   characters.CreateNew ("domob", Faction::GREEN);
@@ -208,19 +97,21 @@ TEST_F (FighterTests, ProcessWithAttacks)
   b.reset ();
 
   unsigned cnt = 0;
-  tbl.ProcessWithAttacks ([&] (Fighter f)
+  tbl.ProcessWithAttacks ([&] (FighterTable::Handle f)
     {
       ++cnt;
       switch (cnt)
         {
         case 1:
-          EXPECT_EQ (f.GetId ().type (), proto::TargetId::TYPE_BUILDING);
-          EXPECT_EQ (f.GetId ().id (), idBuilding);
+          EXPECT_EQ (f->GetIdAsTarget ().type (),
+                     proto::TargetId::TYPE_BUILDING);
+          EXPECT_EQ (f->GetIdAsTarget ().id (), idBuilding);
           break;
 
         case 2:
-          EXPECT_EQ (f.GetId ().type (), proto::TargetId::TYPE_CHARACTER);
-          EXPECT_EQ (f.GetId ().id (), idChar);
+          EXPECT_EQ (f->GetIdAsTarget ().type (),
+                     proto::TargetId::TYPE_CHARACTER);
+          EXPECT_EQ (f->GetIdAsTarget ().id (), idChar);
           break;
 
         default:
@@ -231,7 +122,7 @@ TEST_F (FighterTests, ProcessWithAttacks)
   EXPECT_EQ (cnt, 2);
 }
 
-TEST_F (FighterTests, ProcessForRegen)
+TEST_F (FighterTableTests, ProcessForRegen)
 {
   buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
   buildings.CreateNew ("checkmark", "domob", Faction::GREEN);
@@ -252,19 +143,21 @@ TEST_F (FighterTests, ProcessForRegen)
   b.reset ();
 
   unsigned cnt = 0;
-  tbl.ProcessForRegen ([&] (Fighter f)
+  tbl.ProcessForRegen ([&] (FighterTable::Handle f)
     {
       ++cnt;
       switch (cnt)
         {
         case 1:
-          EXPECT_EQ (f.GetId ().type (), proto::TargetId::TYPE_BUILDING);
-          EXPECT_EQ (f.GetId ().id (), idBuilding);
+          EXPECT_EQ (f->GetIdAsTarget ().type (),
+                     proto::TargetId::TYPE_BUILDING);
+          EXPECT_EQ (f->GetIdAsTarget ().id (), idBuilding);
           break;
 
         case 2:
-          EXPECT_EQ (f.GetId ().type (), proto::TargetId::TYPE_CHARACTER);
-          EXPECT_EQ (f.GetId ().id (), idChar);
+          EXPECT_EQ (f->GetIdAsTarget ().type (),
+                     proto::TargetId::TYPE_CHARACTER);
+          EXPECT_EQ (f->GetIdAsTarget ().id (), idChar);
           break;
 
         default:
@@ -275,7 +168,7 @@ TEST_F (FighterTests, ProcessForRegen)
   EXPECT_EQ (cnt, 2);
 }
 
-TEST_F (FighterTests, ProcessWithTarget)
+TEST_F (FighterTableTests, ProcessWithTarget)
 {
   buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
   buildings.CreateNew ("checkmark", "domob", Faction::GREEN);
@@ -295,19 +188,21 @@ TEST_F (FighterTests, ProcessWithTarget)
   b.reset ();
 
   unsigned cnt = 0;
-  tbl.ProcessWithTarget ([&] (Fighter f)
+  tbl.ProcessWithTarget ([&] (FighterTable::Handle f)
     {
       ++cnt;
       switch (cnt)
         {
         case 1:
-          EXPECT_EQ (f.GetId ().type (), proto::TargetId::TYPE_BUILDING);
-          EXPECT_EQ (f.GetId ().id (), idBuilding);
+          EXPECT_EQ (f->GetIdAsTarget ().type (),
+                     proto::TargetId::TYPE_BUILDING);
+          EXPECT_EQ (f->GetIdAsTarget ().id (), idBuilding);
           break;
 
         case 2:
-          EXPECT_EQ (f.GetId ().type (), proto::TargetId::TYPE_CHARACTER);
-          EXPECT_EQ (f.GetId ().id (), idChar);
+          EXPECT_EQ (f->GetIdAsTarget ().type (),
+                     proto::TargetId::TYPE_CHARACTER);
+          EXPECT_EQ (f->GetIdAsTarget ().id (), idChar);
           break;
 
         default:

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -60,7 +60,9 @@ TEST_F (FighterTests, Characters)
 
   c = characters.CreateNew ("domob", Faction::GREEN);
   const auto id2 = c->GetId ();
-  c->MutableTarget ().set_id (42);
+  proto::TargetId t;
+  t.set_id (42);
+  c->SetTarget (t);
   c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (10);
   c->MutableRegenData ().set_shield_regeneration_mhp (2);
   c.reset ();
@@ -85,7 +87,6 @@ TEST_F (FighterTests, Characters)
   EXPECT_EQ (hp.armour (), 10);
   hp.set_armour (5);
 
-  proto::TargetId t;
   t.set_id (5);
   f.SetTarget (t);
   f.reset ();
@@ -105,7 +106,7 @@ TEST_F (FighterTests, Characters)
   c = characters.GetById (id1);
   EXPECT_EQ (c->GetTarget ().id (), 5);
   EXPECT_EQ (c->GetHP ().armour (), 5);
-  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (id2)->HasTarget ());
 }
 
 TEST_F (FighterTests, Buildings)
@@ -147,7 +148,7 @@ TEST_F (FighterTests, Buildings)
   f.reset ();
 
   b = buildings.GetById (id);
-  EXPECT_FALSE (b->GetTarget ().has_id ());
+  EXPECT_FALSE (b->HasTarget ());
 }
 
 TEST_F (FighterTests, GetForTarget)
@@ -282,12 +283,15 @@ TEST_F (FighterTests, ProcessWithTarget)
 
   auto c = characters.CreateNew ("domob", Faction::RED);
   const auto idChar = c->GetId ();
-  c->MutableTarget ().set_id (5);
+  proto::TargetId t;
+  t.set_id (5);
+  c->SetTarget (t);
   c.reset ();
 
   auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
   const auto idBuilding = b->GetId ();
-  b->MutableTarget ().set_id (42);
+  t.set_id (42);
+  b->SetTarget (t);
   b.reset ();
 
   unsigned cnt = 0;

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -147,7 +147,7 @@ ProcessEnterBuildings (Database& db)
       ++entered;
 
       c->SetBuildingId (buildingId);
-      c->MutableTarget ().clear_id ();
+      c->ClearTarget ();
       c->SetEnterBuilding (Database::EMPTY_ID);
       StopCharacter (*c);
       StopMining (*c);

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -161,7 +161,9 @@ TEST_F (ProcessEnterBuildingsTests, EnteringEffects)
   auto c = GetCharacter (10);
   c->SetPosition (HexCoord (5, 0));
   c->SetEnterBuilding (1);
-  c->MutableTarget ().set_id (42);
+  proto::TargetId t;
+  t.set_id (42);
+  c->SetTarget (t);
   c->MutableProto ().mutable_movement ()->mutable_waypoints ();
   c->MutableProto ().mutable_mining ()->set_active (true);
   c.reset ();
@@ -172,7 +174,7 @@ TEST_F (ProcessEnterBuildingsTests, EnteringEffects)
   ASSERT_TRUE (c->IsInBuilding ());
   EXPECT_EQ (c->GetBuildingId (), 1);
   EXPECT_EQ (c->GetEnterBuilding (), Database::EMPTY_ID);
-  EXPECT_FALSE (c->GetTarget ().has_id ());
+  EXPECT_FALSE (c->HasTarget ());
   EXPECT_FALSE (c->GetProto ().has_movement ());
   EXPECT_FALSE (c->GetProto ().mining ().active ());
 }

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -84,9 +84,11 @@ InsertCharacters (Database& db, const unsigned numIdle,
           attack->set_min_damage (1);
           attack->set_max_damage (1);
         }
-      auto& targetId = c->MutableTarget ();
-      targetId.set_type (proto::TargetId::TYPE_CHARACTER);
-      targetId.set_id (id);
+
+      proto::TargetId t;
+      t.set_type (proto::TargetId::TYPE_CHARACTER);
+      t.set_id (id);
+      c->SetTarget (t);
       c.reset ();
     }
 }

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -96,29 +96,31 @@ TEST_F (TargetSelectionTests, NoTargets)
   auto c = characters.CreateNew ("domob", Faction::RED);
   const auto id1 = c->GetId ();
   c->SetPosition (HexCoord (-10, 0));
-  c->MutableTarget ().set_id (42);
+  proto::TargetId t;
+  t.set_id (42);
+  c->SetTarget (t);
   AddAttackWithRange (*c->MutableProto ().mutable_combat_data (), 10);
   c.reset ();
 
   c = characters.CreateNew ("domob",Faction::RED);
   const auto id2 = c->GetId ();
   c->SetPosition (HexCoord (-10, 1));
-  c->MutableTarget ().set_id (42);
+  c->SetTarget (t);
   AddAttackWithRange (*c->MutableProto ().mutable_combat_data (), 10);
   c.reset ();
 
   c = characters.CreateNew ("domob", Faction::GREEN);
   const auto id3 = c->GetId ();
   c->SetPosition (HexCoord (10, 0));
-  c->MutableTarget ().set_id (42);
+  c->SetTarget (t);
   AddAttackWithRange (*c->MutableProto ().mutable_combat_data (), 10);
   c.reset ();
 
   FindCombatTargets (db, rnd);
 
-  EXPECT_FALSE (characters.GetById (id1)->GetTarget ().has_id ());
-  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
-  EXPECT_FALSE (characters.GetById (id3)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (id1)->HasTarget ());
+  EXPECT_FALSE (characters.GetById (id2)->HasTarget ());
+  EXPECT_FALSE (characters.GetById (id3)->HasTarget ());
 }
 
 TEST_F (TargetSelectionTests, ClosestTarget)
@@ -148,7 +150,6 @@ TEST_F (TargetSelectionTests, ClosestTarget)
 
       c = characters.GetById (idFighter);
       const auto& t = c->GetTarget ();
-      ASSERT_TRUE (t.has_id ());
       EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
       EXPECT_EQ (t.id (), idTarget);
     }
@@ -184,13 +185,11 @@ TEST_F (TargetSelectionTests, WithBuildings)
 
   c = characters.GetById (idChar);
   const auto* t = &c->GetTarget ();
-  ASSERT_TRUE (t->has_id ());
   EXPECT_EQ (t->type (), proto::TargetId::TYPE_BUILDING);
   EXPECT_EQ (t->id (), idBuilding);
 
   b = buildings.GetById (idBuilding);
   t = &b->GetTarget ();
-  ASSERT_TRUE (t->has_id ());
   EXPECT_EQ (t->type (), proto::TargetId::TYPE_CHARACTER);
   EXPECT_EQ (t->id (), idChar);
 }
@@ -200,7 +199,9 @@ TEST_F (TargetSelectionTests, InsideBuildings)
   auto c = characters.CreateNew ("domob", Faction::RED);
   const auto id1 = c->GetId ();
   c->SetPosition (HexCoord (0, 0));
-  c->MutableTarget ().set_id (42);
+  proto::TargetId t;
+  t.set_id (42);
+  c->SetTarget (t);
   AddAttackWithRange (*c->MutableProto ().mutable_combat_data (), 10);
   c.reset ();
 
@@ -216,8 +217,8 @@ TEST_F (TargetSelectionTests, InsideBuildings)
 
   FindCombatTargets (db, rnd);
 
-  EXPECT_FALSE (characters.GetById (id1)->GetTarget ().has_id ());
-  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (id1)->HasTarget ());
+  EXPECT_FALSE (characters.GetById (id2)->HasTarget ());
 }
 
 TEST_F (TargetSelectionTests, MultipleAttacks)
@@ -239,11 +240,10 @@ TEST_F (TargetSelectionTests, MultipleAttacks)
 
   c = characters.GetById (id1);
   const auto& t = c->GetTarget ();
-  ASSERT_TRUE (t.has_id ());
   EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
   EXPECT_EQ (t.id (), id2);
 
-  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (id2)->HasTarget ());
 }
 
 TEST_F (TargetSelectionTests, OnlyAreaAttacks)
@@ -266,11 +266,10 @@ TEST_F (TargetSelectionTests, OnlyAreaAttacks)
 
   c = characters.GetById (id1);
   const auto& t = c->GetTarget ();
-  ASSERT_TRUE (t.has_id ());
   EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
   EXPECT_EQ (t.id (), id2);
 
-  EXPECT_FALSE (characters.GetById (id2)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (id2)->HasTarget ());
 }
 
 TEST_F (TargetSelectionTests, Randomisation)
@@ -303,7 +302,6 @@ TEST_F (TargetSelectionTests, Randomisation)
 
       c = characters.GetById (idFighter);
       const auto& t = c->GetTarget ();
-      ASSERT_TRUE (t.has_id ());
       EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
 
       const auto mit = targetMap.find (t.id ());

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -44,9 +44,6 @@ namespace
 Json::Value
 TargetIdToJson (const proto::TargetId& target)
 {
-  if (!target.has_id ())
-    return Json::Value ();
-
   Json::Value res(Json::objectValue);
   res["id"] = IntToJson (target.id ());
 
@@ -148,9 +145,8 @@ GetCombatJsonObject (const CombatEntity& h)
 {
   Json::Value res(Json::objectValue);
 
-  const auto targetJson = TargetIdToJson (h.GetTarget ());
-  if (!targetJson.isNull ())
-    res["target"] = targetJson;
+  if (h.HasTarget ())
+    res["target"] = TargetIdToJson (h.GetTarget ());
 
   const auto& pb = h.GetCombatData ();
   Json::Value attacks(Json::arrayValue);

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -275,15 +275,16 @@ TEST_F (CharacterJsonTests, MultipleStep)
 TEST_F (CharacterJsonTests, Target)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);
-  auto* targetProto = &c->MutableTarget ();
-  targetProto->set_id (5);
-  targetProto->set_type (proto::TargetId::TYPE_CHARACTER);
+  proto::TargetId t;
+  t.set_id (5);
+  t.set_type (proto::TargetId::TYPE_CHARACTER);
+  c->SetTarget (t);
   c.reset ();
 
   c = tbl.CreateNew ("domob", Faction::GREEN);
-  targetProto = &c->MutableTarget ();
-  targetProto->set_id (42);
-  targetProto->set_type (proto::TargetId::TYPE_BUILDING);
+  t.set_id (42);
+  t.set_type (proto::TargetId::TYPE_BUILDING);
+  c->SetTarget (t);
   c.reset ();
 
   tbl.CreateNew ("domob", Faction::BLUE);
@@ -668,9 +669,10 @@ TEST_F (BuildingJsonTests, CombatData)
   regen.set_shield_regeneration_mhp (1'001);
   regen.mutable_max_hp ()->set_armour (100);
   regen.mutable_max_hp ()->set_shield (50);
-  auto& t = h->MutableTarget ();
+  proto::TargetId t;
   t.set_id (10);
   t.set_type (proto::TargetId::TYPE_CHARACTER);
+  h->SetTarget (t);
   h.reset ();
 
   ExpectStateJson (R"({

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -225,7 +225,7 @@ TEST_F (PXLogicTests, MovementBeforeTargeting)
   UpdateState ("[]");
 
   ASSERT_EQ (characters.GetById (id2)->GetPosition (), HexCoord (11, 0));
-  ASSERT_FALSE (characters.GetById (id1)->GetTarget ().has_id ());
+  ASSERT_FALSE (characters.GetById (id1)->HasTarget ());
 
   c = characters.GetById (id2);
   auto* wp = c->MutableProto ().mutable_movement ()->mutable_waypoints ();
@@ -238,7 +238,6 @@ TEST_F (PXLogicTests, MovementBeforeTargeting)
   ASSERT_EQ (characters.GetById (id2)->GetPosition (), HexCoord (10, 0));
   c = characters.GetById (id1);
   const auto& t = c->GetTarget ();
-  ASSERT_TRUE (t.has_id ());
   EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
   EXPECT_EQ (t.id (), id2);
 }
@@ -849,8 +848,8 @@ TEST_F (PXLogicTests, EnterBuildingAndTargetFinding)
     }
   ])");
 
-  EXPECT_FALSE (characters.GetById (2)->GetTarget ().has_id ());
-  EXPECT_FALSE (characters.GetById (3)->GetTarget ().has_id ());
+  EXPECT_FALSE (characters.GetById (2)->HasTarget ());
+  EXPECT_FALSE (characters.GetById (3)->HasTarget ());
 }
 
 TEST_F (PXLogicTests, EnterAndExitBuildingWhenOutside)


### PR DESCRIPTION
This refactors the code to get rid of the `Fighter` class.  Instead, we just use `std::unique_ptr<CombatEntity>`, with all of the functionality of `Fighter` moved to `CombatEntity`.  This simplifies the code, as it gets rid of the "manual polymorphism" that `Fighter` was.

The `FighterTable` is still around, because we use it to abstract the database queries that retrieve a union of buildings and characters.

Fixes #87.