### PR TITLE
Introduce vCHI coin balances

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -28,6 +28,7 @@ libdatabase_la_SOURCES = \
   schema.cpp \
   target.cpp
 noinst_HEADERS = \
+  amount.hpp \
   account.hpp \
   building.hpp \
   character.hpp \

--- a/database/account.cpp
+++ b/database/account.cpp
@@ -48,6 +48,8 @@ Account::~Account ()
     }
 
   VLOG (1) << "Updating account " << name << " in the database";
+  CHECK_GE (GetBalance (), 0);
+
   auto stmt = db.Prepare (R"(
     INSERT OR REPLACE INTO `accounts`
       (`name`, `faction`, `proto`)
@@ -59,6 +61,15 @@ Account::~Account ()
   stmt.BindProto (3, data);
 
   stmt.Execute ();
+}
+
+void
+Account::AddBalance (const Amount val)
+{
+  Amount balance = data.Get ().balance ();
+  balance += val;
+  CHECK_GE (balance, 0);
+  data.Mutable ().set_balance (balance);
 }
 
 AccountsTable::Handle

--- a/database/account.cpp
+++ b/database/account.cpp
@@ -22,27 +22,26 @@ namespace pxd
 {
 
 Account::Account (Database& d, const std::string& n, const Faction f)
-  : db(d), name(n), faction(f),
-    kills(0), fame(100),
-    dirty(true)
+  : db(d), name(n), faction(f), isNew(true)
 {
   VLOG (1) << "Created instance for newly initialised account " << name;
+  data.SetToDefault ();
+  data.Mutable ().set_fame (100);
 }
 
 Account::Account (Database& d, const Database::Result<AccountResult>& res)
-  : db(d), dirty(false)
+  : db(d), isNew(false)
 {
   name = res.Get<AccountResult::name> ();
   faction = GetFactionFromColumn (res);
-  kills = res.Get<AccountResult::kills> ();
-  fame = res.Get<AccountResult::fame> ();
+  data = res.GetProto<AccountResult::proto> ();
 
   VLOG (1) << "Created account instance for " << name << " from database";
 }
 
 Account::~Account ()
 {
-  if (!dirty)
+  if (!isNew && !data.IsDirty ())
     {
       VLOG (1) << "Account instance " << name << " is not dirty";
       return;
@@ -51,14 +50,13 @@ Account::~Account ()
   VLOG (1) << "Updating account " << name << " in the database";
   auto stmt = db.Prepare (R"(
     INSERT OR REPLACE INTO `accounts`
-      (`name`, `faction`, `kills`, `fame`)
-      VALUES (?1, ?2, ?3, ?4)
+      (`name`, `faction`, `proto`)
+      VALUES (?1, ?2, ?3)
   )");
 
   stmt.Bind (1, name);
   BindFactionParameter (stmt, 2, faction);
-  stmt.Bind (3, kills);
-  stmt.Bind (4, fame);
+  stmt.BindProto (3, data);
 
   stmt.Execute ();
 }

--- a/database/account.hpp
+++ b/database/account.hpp
@@ -21,6 +21,9 @@
 
 #include "database.hpp"
 #include "faction.hpp"
+#include "lazyproto.hpp"
+
+#include "proto/account.pb.h"
 
 #include <memory>
 #include <string>
@@ -34,8 +37,7 @@ namespace pxd
 struct AccountResult : public ResultWithFaction
 {
   RESULT_COLUMN (std::string, name, 1);
-  RESULT_COLUMN (int64_t, kills, 2);
-  RESULT_COLUMN (int64_t, fame, 3);
+  RESULT_COLUMN (pxd::proto::Account, proto, 2);
 };
 
 /**
@@ -56,17 +58,11 @@ private:
   /** The faction of this account.  */
   Faction faction;
 
-  /** The account's number of kills.  */
-  unsigned kills;
+  /** General proto data.  */
+  LazyProto<proto::Account> data;
 
-  /** The account's fame value.  */
-  unsigned fame;
-
-  /**
-   * Set to true if any modification has been made and we need to write
-   * the changes back to the database in the destructor.
-   */
-  bool dirty;
+  /** Whether or not this is a new account.  */
+  bool isNew;
 
   /**
    * Constructs an instance with "default / empty" data for the given name
@@ -108,30 +104,16 @@ public:
     return faction;
   }
 
-  unsigned
-  GetKills () const
+  const proto::Account&
+  GetProto () const
   {
-    return kills;
+    return data.Get ();
   }
 
-  void
-  SetKills (const unsigned val)
+  proto::Account&
+  MutableProto ()
   {
-    dirty = true;
-    kills = val;
-  }
-
-  unsigned
-  GetFame () const
-  {
-    return fame;
-  }
-
-  void
-  SetFame (const unsigned val)
-  {
-    dirty = true;
-    fame = val;
+    return data.Mutable ();
   }
 
 };

--- a/database/account.hpp
+++ b/database/account.hpp
@@ -19,6 +19,7 @@
 #ifndef DATABASE_ACCOUNT_HPP
 #define DATABASE_ACCOUNT_HPP
 
+#include "amount.hpp"
 #include "database.hpp"
 #include "faction.hpp"
 #include "lazyproto.hpp"
@@ -90,8 +91,6 @@ public:
   Account (const Account&) = delete;
   void operator= (const Account&) = delete;
 
-  /* Accessor methods.  */
-
   const std::string&
   GetName () const
   {
@@ -114,6 +113,19 @@ public:
   MutableProto ()
   {
     return data.Mutable ();
+  }
+
+  /**
+   * Updates the account balance by the given (signed) amount.  This should
+   * be used instead of manually editing the proto, so that there is a single
+   * place that controls all balance updates.
+   */
+  void AddBalance (Amount val);
+
+  Amount
+  GetBalance () const
+  {
+    return data.Get ().balance ();
   }
 
 };

--- a/database/account_tests.cpp
+++ b/database/account_tests.cpp
@@ -47,6 +47,7 @@ TEST_F (AccountTests, DefaultData)
   EXPECT_EQ (a->GetFaction (), Faction::BLUE);
   EXPECT_EQ (a->GetProto ().kills (), 0);
   EXPECT_EQ (a->GetProto ().fame (), 100);
+  EXPECT_EQ (a->GetBalance (), 0);
 }
 
 TEST_F (AccountTests, Update)
@@ -60,6 +61,20 @@ TEST_F (AccountTests, Update)
   EXPECT_EQ (a->GetName (), "foobar");
   EXPECT_EQ (a->GetProto ().kills (), 50);
   EXPECT_EQ (a->GetProto ().fame (), 200);
+}
+
+TEST_F (AccountTests, Balance)
+{
+  auto a = tbl.CreateNew ("foobar", Faction::RED);
+  a->AddBalance (10);
+  a->AddBalance (20);
+  a.reset ();
+
+  a = tbl.GetByName ("foobar");
+  EXPECT_EQ (a->GetBalance (), 30);
+  a->AddBalance (-30);
+  EXPECT_EQ (a->GetBalance (), 0);
+  a.reset ();
 }
 
 using AccountsTableTests = AccountTests;

--- a/database/account_tests.cpp
+++ b/database/account_tests.cpp
@@ -45,21 +45,21 @@ TEST_F (AccountTests, DefaultData)
   auto a = tbl.CreateNew ("foobar", Faction::BLUE);
   EXPECT_EQ (a->GetName (), "foobar");
   EXPECT_EQ (a->GetFaction (), Faction::BLUE);
-  EXPECT_EQ (a->GetKills (), 0);
-  EXPECT_EQ (a->GetFame (), 100);
+  EXPECT_EQ (a->GetProto ().kills (), 0);
+  EXPECT_EQ (a->GetProto ().fame (), 100);
 }
 
 TEST_F (AccountTests, Update)
 {
   auto a = tbl.CreateNew ("foobar", Faction::RED);
-  a->SetKills (50);
-  a->SetFame (200);
+  a->MutableProto ().set_kills (50);
+  a->MutableProto ().set_fame (200);
   a.reset ();
 
   a = tbl.GetByName ("foobar");
   EXPECT_EQ (a->GetName (), "foobar");
-  EXPECT_EQ (a->GetKills (), 50);
-  EXPECT_EQ (a->GetFame (), 200);
+  EXPECT_EQ (a->GetProto ().kills (), 50);
+  EXPECT_EQ (a->GetProto ().fame (), 200);
 }
 
 using AccountsTableTests = AccountTests;
@@ -73,7 +73,7 @@ TEST_F (AccountsTableTests, CreateAlreadyExisting)
 TEST_F (AccountsTableTests, QueryInitialised)
 {
   tbl.CreateNew ("foo", Faction::RED);
-  tbl.CreateNew ("bar", Faction::GREEN)->SetFame (10);
+  tbl.CreateNew ("bar", Faction::GREEN)->MutableProto ().set_fame (10);
 
   auto res = tbl.QueryInitialised ();
 
@@ -81,15 +81,13 @@ TEST_F (AccountsTableTests, QueryInitialised)
   auto a = tbl.GetFromResult (res);
   EXPECT_EQ (a->GetName (), "bar");
   EXPECT_EQ (a->GetFaction (), Faction::GREEN);
-  EXPECT_EQ (a->GetKills (), 0);
-  EXPECT_EQ (a->GetFame (), 10);
+  EXPECT_EQ (a->GetProto ().fame (), 10);
 
   ASSERT_TRUE (res.Step ());
   a = tbl.GetFromResult (res);
   EXPECT_EQ (a->GetName (), "foo");
   EXPECT_EQ (a->GetFaction (), Faction::RED);
-  EXPECT_EQ (a->GetKills (), 0);
-  EXPECT_EQ (a->GetFame (), 100);
+  EXPECT_EQ (a->GetProto ().fame (), 100);
 
   ASSERT_FALSE (res.Step ());
 }

--- a/database/amount.hpp
+++ b/database/amount.hpp
@@ -16,8 +16,8 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef PXD_AMOUNT_HPP
-#define PXD_AMOUNT_HPP
+#ifndef DATABASE_AMOUNT_HPP
+#define DATABASE_AMOUNT_HPP
 
 #include <cstdint>
 
@@ -38,4 +38,4 @@ constexpr Amount MAX_AMOUNT = 80'000'000 * COIN;
 
 } // namespace pxd
 
-#endif // PXD_AMOUNT_HPP
+#endif // DATABASE_AMOUNT_HPP

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -218,11 +218,8 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   -- The faction (as integer corresponding to the Faction enum in C++).
   `faction` INTEGER NOT NULL,
 
-  -- The number of characters killed by the account in total.
-  `kills` INTEGER NOT NULL,
-
-  -- The fame of this account.
-  `fame` INTEGER NOT NULL
+  -- Additional data for the account as a serialised Account proto.
+  `proto` BLOB NOT NULL
 
 );
 

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -10,6 +10,7 @@ REGTESTS = \
   character_limit.py \
   characters.py \
   charon.py \
+  coinops.py \
   combat_damage.py \
   combat_targets.py \
   damage_lists.py \

--- a/gametest/buildings_enterexit.py
+++ b/gametest/buildings_enterexit.py
@@ -27,12 +27,7 @@ class BuildingsEnterExitTest (PXTest):
 
   def run (self):
     self.collectPremine ()
-
-    # Somehow we need to split the premine coin like this, or else the
-    # wallet will show empty balance in the reorg test.
-    for i in range (10):
-      self.rpc.xaya.sendtoaddress (self.rpc.xaya.getnewaddress (), 100)
-    self.generate (1)
+    self.splitPremine ()
 
     self.mainLogger.info ("Placing a building...")
     self.build ("checkmark", None, {"x": 0, "y": 0}, rot=0)

--- a/gametest/charon.py
+++ b/gametest/charon.py
@@ -180,6 +180,7 @@ class CharonTest (PXTest):
           [
             {"name": "domob", "creations": [{"faction": "r"}]},
           ],
+        "accounts": [],
       })
 
 

--- a/gametest/coinops.py
+++ b/gametest/coinops.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests coin operations (transfers / burns) and account balances.
+"""
+
+from pxtest import PXTest
+
+
+class CoinOpsTest (PXTest):
+
+  def expectBalances (self, expected):
+    """
+    Verifies that a set of accounts has given balances, as stated
+    in the dictionary passed in.
+    """
+
+    acc = self.getAccounts ()
+    for k, v in expected.iteritems ():
+      self.assertEqual (acc[k].getBalance (), v)
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.mainLogger.info ("Creating test accounts...")
+    self.initAccount ("domob", "r")
+    self.initAccount ("andy", "g")
+    self.initAccount ("daniel", "b")
+    self.generate (1)
+    self.giftCoins ({"domob": 100})
+
+    self.generate (1)
+    reorgBlk = self.rpc.xaya.getbestblockhash ()
+
+    self.mainLogger.info ("Coin transfers and burns...")
+    self.sendMove ("domob", {"vc": {"b": 10, "t": {"andy": 2, "domob": 10}}})
+    self.generate (1)
+
+    self.expectBalances ({
+      "domob": 88,
+      "andy": 2,
+      "daniel": 0,
+    })
+
+    self.generate (20)
+    self.testReorg (reorgBlk)
+
+  def testReorg (self, blk):
+    self.mainLogger.info ("Testing reorg...")
+
+    originalState = self.getGameState ()
+    self.rpc.xaya.invalidateblock (blk)
+
+    self.sendMove ("domob", {"vc": {"t": {"daniel": 100}}})
+    self.generate (1)
+
+    self.expectBalances ({
+      "domob": 0,
+      "andy": 0,
+      "daniel": 100,
+    })
+
+    self.rpc.xaya.reconsiderblock (blk)
+    self.expectGameState (originalState)
+
+
+if __name__ == "__main__":
+  CoinOpsTest ().main ()

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -29,6 +29,7 @@ class GodModeTest (PXTest):
     self.collectPremine ()
 
     self.initAccount ("domob", "r")
+    self.initAccount ("andy", "b")
     self.createCharacters ("domob")
     self.generate (1)
     c = self.getCharacters ()["domob"]
@@ -144,6 +145,13 @@ class GodModeTest (PXTest):
           },
       },
     ])
+
+    self.mainLogger.info ("Testing gift coins...")
+    self.giftCoins ({"domob": 20, "andy": 42})
+    self.giftCoins ({"domob": 30})
+    acc = self.getAccounts ()
+    self.assertEqual (acc["andy"].getBalance (), 42)
+    self.assertEqual (acc["domob"].getBalance (), 50)
     
 
 if __name__ == "__main__":

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -59,6 +59,7 @@ class PendingTest (PXTest):
     self.createCharacters ("inbuilding", 2)
     self.generate (1)
 
+    self.giftCoins ({"domob": 100})
     self.moveCharactersTo ({
       "domob": positionProspect,
       "miner": positionMining,
@@ -79,6 +80,7 @@ class PendingTest (PXTest):
     self.assertEqual (self.getPendingState (), {
       "characters": [],
       "newcharacters": [],
+      "accounts": [],
     })
 
     self.mainLogger.info ("Performing pending updates...")
@@ -101,6 +103,7 @@ class PendingTest (PXTest):
         [
           {"name": "domob", "creations": [{"faction": "r"}]},
         ],
+      "accounts": [],
     })
 
     self.createCharacters ("domob")
@@ -141,6 +144,7 @@ class PendingTest (PXTest):
           {"name": "andy", "creations": [{"faction": "b"}]},
           {"name": "domob", "creations": [{"faction": "r"}] * 2},
         ],
+      "accounts": [],
     })
 
     c1.sendMove ({"prospect": {}})
@@ -148,6 +152,11 @@ class PendingTest (PXTest):
     c2 = self.getCharacters ()["miner"]
     c2.sendMove ({"mine": {}})
     self.getCharacters ()["inbuilding 2"].sendMove ({"eb": None})
+
+    self.sendMove ("domob", {
+      "vc": {"b": 10, "t": {"miner": 20}},
+    })
+
     sleepSome ()
     oldPending = self.getPendingState ()
     self.assertEqual (oldPending, {
@@ -183,6 +192,13 @@ class PendingTest (PXTest):
           {"name": "andy", "creations": [{"faction": "b"}]},
           {"name": "domob", "creations": [{"faction": "r"}, {"faction": "r"}]},
         ],
+      "accounts":
+        [
+          {
+            "name": "domob",
+            "coinops": {"burnt": 10, "transfers": {"miner": 20}},
+          },
+        ],
     })
 
     self.mainLogger.info ("Confirming the moves...")
@@ -191,6 +207,7 @@ class PendingTest (PXTest):
     self.assertEqual (self.getPendingState (), {
       "characters": [],
       "newcharacters": [],
+      "accounts": [],
     })
 
     self.mainLogger.info ("Unconfirming the moves...")

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -197,6 +197,17 @@ class PXTest (XayaGameTest):
     binary = os.path.join (top_builddir, "src", "tauriond")
     super (PXTest, self).__init__ (GAMEID, binary)
 
+  def splitPremine (self):
+    """
+    Splits the premine coin into smaller outputs, so that there are more
+    than a single outputs in the wallet.  Some tests require this or else
+    name_update's will fail for some reason.
+    """
+
+    for i in range (10):
+      self.rpc.xaya.sendtoaddress (self.rpc.xaya.getnewaddress (), 100)
+    self.generate (1)
+
   def getRpc (self, method, *args, **kwargs):
     """
     Calls the given "read-type" RPC method on the game daemon and returns

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -158,6 +158,9 @@ class Account (object):
   def getFaction (self):
     return self.data["faction"]
 
+  def getBalance (self):
+    return self.data["balance"]
+
 
 class Region (object):
   """
@@ -312,6 +315,15 @@ class PXTest (XayaGameTest):
       "pos": position,
       "fungible": fungible,
     }]}})
+    self.generate (1)
+
+  def giftCoins (self, gifts):
+    """
+    Issues a gift-coins god-mode command, adding coins to the balance of the
+    accounts as per the dictionary.
+    """
+
+    self.adminCommand ({"god": {"giftcoins": gifts}})
     self.generate (1)
 
   def getAccounts (self):

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -15,6 +15,7 @@ ROCONFIG_TEXT_PROTOS = \
   roconfig/buildings/turrets.pb.text
 
 PROTOS = \
+  account.proto \
   building.proto \
   character.proto \
   combat.proto \

--- a/proto/account.proto
+++ b/proto/account.proto
@@ -1,0 +1,44 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+syntax = "proto2";
+
+package pxd.proto;
+
+/**
+ * General data associated to an account.
+ */
+message Account
+{
+
+  /**
+   * The number of characters killed by the account in total.
+   */
+  optional uint32 kills = 1;
+
+  /**
+   * The fame of this account.
+   */
+  optional uint32 fame = 2;
+
+  /**
+   * Balance of vCHI for this account.
+   */
+  optional uint64 balance = 3;
+
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,7 +38,6 @@ libtaurion_la_SOURCES = \
   resourcedist.cpp \
   spawn.cpp
 libtaurionheaders = \
-  amount.hpp \
   buildings.hpp \
   combat.hpp \
   context.hpp \

--- a/src/fame.cpp
+++ b/src/fame.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -48,10 +48,10 @@ FameUpdater::~FameUpdater ()
 
       auto h = accounts.GetByName (entry.first);
       CHECK (h != nullptr);
-      int fame = h->GetFame ();
+      int fame = h->GetProto ().fame ();
       fame += entry.second;
       fame = std::min<int> (MAX_FAME, std::max (0, fame));
-      h->SetFame (fame);
+      h->MutableProto ().set_fame (fame);
     }
 }
 
@@ -73,7 +73,7 @@ FameUpdater::UpdateForKill (const Database::IdT victim,
   const std::string& victimOwner = victimCharacter->GetOwner ();
   auto victimAccount = accounts.GetByName (victimOwner);
   CHECK (victimAccount != nullptr);
-  const unsigned victimFame = victimAccount->GetFame ();
+  const unsigned victimFame = victimAccount->GetProto ().fame ();
   const int victimLevel = GetLevel (victimFame);
   VLOG (1)
       << "Victim fame: " << victimFame << " (level: " << victimLevel << ")";
@@ -96,9 +96,10 @@ FameUpdater::UpdateForKill (const Database::IdT victim,
       VLOG (1) << "Killing account: " << owner;
       auto a = accounts.GetByName (owner);
       CHECK (a != nullptr);
-      a->SetKills (a->GetKills () + 1);
+      auto& pb = a->MutableProto ();
+      pb.set_kills (pb.kills () + 1);
 
-      const unsigned fame = a->GetFame ();
+      const unsigned fame = pb.fame ();
       const int level = GetLevel (fame);
       VLOG (1) << "Killer fame: " << fame << " (level: " << level << ")";
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -318,6 +318,7 @@ template <>
   Json::Value res(Json::objectValue);
   res["name"] = a.GetName ();
   res["faction"] = FactionToString (a.GetFaction ());
+  res["balance"] = IntToJson (a.GetBalance ());
 
   const auto& pb = a.GetProto ();
   res["kills"] = IntToJson (pb.kills ());

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -318,8 +318,10 @@ template <>
   Json::Value res(Json::objectValue);
   res["name"] = a.GetName ();
   res["faction"] = FactionToString (a.GetFaction ());
-  res["kills"] = IntToJson (a.GetKills ());
-  res["fame"] = IntToJson (a.GetFame ());
+
+  const auto& pb = a.GetProto ();
+  res["kills"] = IntToJson (pb.kills ());
+  res["fame"] = IntToJson (pb.fame ());
 
   return res;
 }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -544,8 +544,8 @@ protected:
 
 TEST_F (AccountJsonTests, KillsAndFame)
 {
-  tbl.CreateNew ("foo", Faction::RED)->SetKills (10);
-  tbl.CreateNew ("bar", Faction::BLUE)->SetFame (42);
+  tbl.CreateNew ("foo", Faction::RED)->MutableProto ().set_kills (10);
+  tbl.CreateNew ("bar", Faction::BLUE)->MutableProto ().set_fame (42);
 
   ExpectStateJson (R"({
     "accounts":

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -556,6 +556,20 @@ TEST_F (AccountJsonTests, KillsAndFame)
   })");
 }
 
+TEST_F (AccountJsonTests, Balance)
+{
+  tbl.CreateNew ("foo", Faction::RED);
+  tbl.CreateNew ("bar", Faction::BLUE)->AddBalance (42);
+
+  ExpectStateJson (R"({
+    "accounts":
+      [
+        {"name": "bar", "faction": "b", "balance": 42},
+        {"name": "foo", "faction": "r", "balance": 0}
+      ]
+  })");
+}
+
 /* ************************************************************************** */
 
 class BuildingJsonTests : public GameStateJsonTests

--- a/src/jsonutils.hpp
+++ b/src/jsonutils.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,8 +19,7 @@
 #ifndef PXD_JSONUTILS_HPP
 #define PXD_JSONUTILS_HPP
 
-#include "amount.hpp"
-
+#include "database/amount.hpp"
 #include "database/database.hpp"
 #include "hexagonal/coord.hpp"
 

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -19,11 +19,11 @@
 #ifndef PXD_MOVEPROCESSOR_HPP
 #define PXD_MOVEPROCESSOR_HPP
 
-#include "amount.hpp"
 #include "context.hpp"
 #include "dynobstacles.hpp"
 
 #include "database/account.hpp"
+#include "database/amount.hpp"
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/database.hpp"

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -2026,6 +2026,48 @@ TEST_F (GodModeTests, ValidDropLoot)
   EXPECT_EQ (h->GetInventory ().GetFungibleCount ("bar"), MAX_ITEM_QUANTITY);
 }
 
+TEST_F (GodModeTests, GiftCoins)
+{
+  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("domob", Faction::RED);
+
+  ProcessAdmin (R"([{"cmd": {
+    "god":
+      {
+        "x": "foo",
+        "giftcoins": "invalid"
+      }
+  }}])");
+
+  ProcessAdmin (R"([{"cmd": {
+    "god":
+      {
+        "x": "foo",
+        "giftcoins":
+          {
+            "invalid": 20,
+            "andy": 5.42,
+            "domob": 10
+          }
+      }
+  }}])");
+
+  ProcessAdmin (R"([{"cmd": {
+    "god":
+      {
+        "x": "foo",
+        "giftcoins":
+          {
+            "andy": 5,
+            "domob": 10
+          }
+      }
+  }}])");
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 5);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 20);
+}
+
 /**
  * Test fixture for god mode but set up on mainnet, so that god mode is
  * actually not allowed.

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -229,6 +229,159 @@ TEST_F (AccountUpdateTests, InitialisationAndCharacterCreation)
 
 /* ************************************************************************** */
 
+class CoinOperationTests : public MoveProcessorTests
+{
+
+protected:
+
+  /**
+   * Expects that the balances of the given accounts are as stated.
+   */
+  void
+  ExpectBalances (const std::map<std::string, Amount>& expected)
+  {
+    for (const auto& entry : expected)
+      {
+        auto a = accounts.GetByName (entry.first);
+        ASSERT_NE (a, nullptr) << "Account does not exist: " << entry.first;
+        ASSERT_EQ (a->GetBalance (), entry.second);
+      }
+  }
+
+};
+
+TEST_F (CoinOperationTests, Invalid)
+{
+  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  accounts.CreateNew ("other", Faction::RED);
+
+  Process (R"([
+    {"name": "domob", "move": {"vc": 42}},
+    {"name": "domob", "move": {"vc": []}},
+    {"name": "domob", "move": {"vc": {}}},
+    {"name": "domob", "move": {"vc": {"x": 10}}},
+    {"name": "domob", "move": {"vc": {"b": -1}}},
+    {"name": "domob", "move": {"vc": {"b": 1000000001}}},
+    {"name": "domob", "move": {"vc": {"b": 999999999999999999}}},
+    {"name": "domob", "move": {"vc": {"t": 42}}},
+    {"name": "domob", "move": {"vc": {"t": "other"}}},
+    {"name": "domob", "move": {"vc": {"t": {"invalid": 10}}}},
+    {"name": "domob", "move": {"vc": {"t": {"other": -1}}}},
+    {"name": "domob", "move": {"vc": {"t": {"other": 1000000001}}}},
+    {"name": "domob", "move": {"vc": {"t": {"other": 1.999999}}}},
+    {"name": "domob", "move": {"vc": {"t": {"other": 101}}}}
+  ])");
+
+  ExpectBalances ({{"domob", 100}, {"other", 0}});
+}
+
+TEST_F (CoinOperationTests, BurnAndTransfer)
+{
+  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  accounts.CreateNew ("second", Faction::RED);
+  accounts.CreateNew ("third", Faction::RED);
+
+  /* Some of the burns and transfers are invalid.  They should just be ignored,
+     without affecting the rest of the operation (valid parts).  */
+  Process (R"([
+    {"name": "domob", "move": {"vc":
+      {
+        "b": 10,
+        "t": {"a": "invalid", "b": -5, "c": 1000, "second": 5, "third": 3}
+      }}
+    },
+    {"name": "domob", "move": {"vc":
+      {
+        "b": 1000,
+        "t": {"third": 2}
+      }}
+    }
+  ])");
+
+  ExpectBalances ({
+    {"domob", 80},
+    {"second", 5},
+    {"third", 5},
+  });
+}
+
+TEST_F (CoinOperationTests, BurnAll)
+{
+  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  Process (R"([
+    {"name": "domob", "move": {"vc": {"b": 100}}}
+  ])");
+  ExpectBalances ({{"domob", 0}});
+}
+
+TEST_F (CoinOperationTests, TransferAll)
+{
+  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  accounts.CreateNew ("other", Faction::RED);
+  Process (R"([
+    {"name": "domob", "move": {"vc": {"t": {"other": 100}}}}
+  ])");
+  ExpectBalances ({{"domob", 0}, {"other", 100}});
+}
+
+TEST_F (CoinOperationTests, SelfTransfer)
+{
+  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  accounts.CreateNew ("other", Faction::GREEN);
+  Process (R"([
+    {"name": "domob", "move": {"vc": {"t": {"domob": 90, "other": 20}}}}
+  ])");
+  ExpectBalances ({{"domob", 80}, {"other", 20}});
+}
+
+TEST_F (CoinOperationTests, BurnBeforeTransfer)
+{
+  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  accounts.CreateNew ("other", Faction::RED);
+
+  Process (R"([
+    {"name": "domob", "move": {"vc":
+      {
+        "b": 90,
+        "t": {"other": 20}
+      }}
+    }
+  ])");
+
+  ExpectBalances ({
+    {"domob", 10},
+    {"other", 0},
+  });
+}
+
+TEST_F (CoinOperationTests, TransferOrder)
+{
+  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  accounts.CreateNew ("a", Faction::RED);
+  accounts.CreateNew ("middle", Faction::RED);
+  accounts.CreateNew ("z", Faction::RED);
+
+  Process (R"([
+    {"name": "domob", "move": {"vc":
+      {
+        "t": {"z": 10, "a": 101, "middle": 99}
+      }}
+    }
+  ])");
+
+  ExpectBalances ({
+    {"domob", 1},
+    {"a", 0},
+    {"middle", 99},
+    {"z", 0},
+  });
+}
+
+/* FIXME: Once there are game operations that cost coins, we should add a
+   test that verifies that burns/transfers take priority over them.  */
+
+/* ************************************************************************** */
+
 class CharacterCreationTests : public MoveProcessorTests
 {
 

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -19,9 +19,8 @@
 #ifndef PXD_PARAMS_HPP
 #define PXD_PARAMS_HPP
 
-#include "amount.hpp"
-
 #include "hexagonal/coord.hpp"
+#include "database/amount.hpp"
 #include "database/faction.hpp"
 #include "database/inventory.hpp"
 #include "proto/character.pb.h"

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -122,11 +122,30 @@ private:
 
   };
 
+  /**
+   * Pending state updates associated to an account.
+   */
+  struct AccountState
+  {
+
+    /** The combined coin transfer / burn for this account.  */
+    std::unique_ptr<CoinTransferBurn> coinOps;
+
+    /**
+     * Returns the JSON representation of the pending state.
+     */
+    Json::Value ToJson () const;
+
+  };
+
   /** Pending modifications to characters.  */
   std::map<Database::IdT, CharacterState> characters;
 
   /** Pending creations of new characters (by account name).  */
   std::map<std::string, std::vector<NewCharacter>> newCharacters;
+
+  /** Pending updates by account name.  */
+  std::map<std::string, AccountState> accounts;
 
   /**
    * Returns the pending character state for the given instance, creating one
@@ -134,6 +153,12 @@ private:
    * rules for "characters".
    */
   CharacterState& GetCharacterState (const Character& c);
+
+  /**
+   * Returns the pending state for the given account instance, creating a new
+   * (empty) one if there is not already one.
+   */
+  AccountState& GetAccountState (const Account& a);
 
 public:
 
@@ -199,6 +224,11 @@ public:
    * Updates the state for a new pending character creation.
    */
   void AddCharacterCreation (const std::string& name, Faction f);
+
+  /**
+   * Updates the state for a new coin transfer / burn.
+   */
+  void AddCoinTransferBurn (const Account& a, const CoinTransferBurn& op);
 
   /**
    * Returns the JSON representation of the pending state.


### PR DESCRIPTION
This adds a coin balance as new data field per account, and allows users to burn coins as well as transfer coins to some other account with moves.  The account balance is returned inside the `accounts` game-state JSON.

To burn coins and/or transfer them, a move like this can be used:

    {"vc": {"b": 42, "t": {"daniel": 10, "andy": 50}}}

These moves are also tracked while pending, with a combined JSON object representing all burns/transfers of an account being returned from the pending state.

A new god-mode command is also available to "gift" coins for testing:

    {"giftcoins": {"daniel": 10, "andy": 100}}