### PR TITLE
Implement refining service

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -28,6 +28,7 @@ REGTESTS = \
   prospecting_basic.py \
   prospecting_prizes.py \
   prospecting_resources.py \
+  services_refining.py \
   splitstaterpcs.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -136,6 +136,7 @@ class GodModeTest (PXTest):
 
     self.mainLogger.info ("Testing drop loot...")
     self.dropLoot ({"x": 1, "y": 2}, {"foo": 1, "bar": 2})
+    self.dropIntoBuilding (buildingId, "domob", {"bar": 42})
     self.assertEqual (self.getRpc ("getgroundloot"), [
       {
         "position": {"x": 1, "y": 2},
@@ -145,6 +146,8 @@ class GodModeTest (PXTest):
           },
       },
     ])
+    b = self.getBuildings ()[buildingId]
+    self.assertEqual (b.getFungibleInventory ("domob"), {"bar": 42})
 
     self.mainLogger.info ("Testing gift coins...")
     self.giftCoins ({"domob": 20, "andy": 42})

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -60,15 +60,17 @@ class PendingTest (PXTest):
     self.generate (1)
 
     self.giftCoins ({"domob": 100})
+    self.giftCoins ({"andy": 100})
     self.moveCharactersTo ({
       "domob": positionProspect,
       "miner": positionMining,
-      "inbuilding": offsetCoord (positionBuilding, {"x": 3, "y": 0}, False),
-      "inbuilding 2": offsetCoord (positionBuilding, {"x": -3, "y": 0}, False),
+      "inbuilding": offsetCoord (positionBuilding, {"x": 30, "y": 0}, False),
+      "inbuilding 2": offsetCoord (positionBuilding, {"x": -30, "y": 0}, False),
     })
 
-    self.build ("checkmark", None, positionBuilding, 0)
+    self.build ("ancient1", None, positionBuilding, 0)
     building = self.getBuildings ().keys ()[-1]
+    self.dropIntoBuilding (building, "andy", {"foo": 100})
     self.getCharacters ()["inbuilding"].sendMove ({"eb": building})
 
     self.getCharacters ()["miner"].sendMove ({"prospect": {}})
@@ -156,6 +158,9 @@ class PendingTest (PXTest):
     self.sendMove ("domob", {
       "vc": {"b": 10, "t": {"miner": 20}},
     })
+    self.sendMove ("andy", {
+      "s": [{"b": building, "t": "ref", "i": "foo", "n": 9}],
+    })
 
     sleepSome ()
     oldPending = self.getPendingState ()
@@ -194,6 +199,19 @@ class PendingTest (PXTest):
         ],
       "accounts":
         [
+          {
+            "name": "andy",
+            "serviceops":
+              [
+                {
+                  "building": building,
+                  "type": "refining",
+                  "cost": 30,
+                  "input": {"foo": 9},
+                  "output": {"bar": 6, "zerospace": 3},
+                }
+              ],
+          },
           {
             "name": "domob",
             "coinops": {"burnt": 10, "transfers": {"miner": 20}},

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -328,6 +328,18 @@ class PXTest (XayaGameTest):
     }]}})
     self.generate (1)
 
+  def dropIntoBuilding (self, buildingId, account, fungible):
+    """
+    Issues a god-mode command to add loot into the inventory of a user
+    account inside some building.
+    """
+
+    self.adminCommand ({"god": {"drop": [{
+      "building": {"id": buildingId, "a": account},
+      "fungible": fungible,
+    }]}})
+    self.generate (1)
+
   def giftCoins (self, gifts):
     """
     Issues a gift-coins god-mode command, adding coins to the balance of the

--- a/gametest/services_refining.py
+++ b/gametest/services_refining.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests basic refining service operations.
+"""
+
+from pxtest import PXTest
+
+
+class ServicesRefiningTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.mainLogger.info ("Setting up initial situation...")
+    self.build ("ancient1", None, {"x": 100, "y": 0}, 0)
+    self.build ("ancient1", None, {"x": 0, "y": 100}, 0)
+    buildings = [1001, 1002]
+    for b in buildings:
+      self.assertEqual (self.getBuildings ()[b].getType (), "ancient1")
+
+    self.initAccount ("domob", "r")
+    self.generate (1)
+    self.giftCoins ({"domob": 10})
+
+    for b in buildings:
+      self.dropIntoBuilding (b, "domob", {"foo": 3})
+
+    self.generate (1)
+    reorgBlk = self.rpc.xaya.getbestblockhash ()
+
+    self.mainLogger.info ("Performing refine operation...")
+    self.sendMove ("domob", {"s": [
+      {"b": b, "t": "ref", "i": "foo", "n": 3}
+    for b in buildings]})
+    self.generate (1)
+
+    self.assertEqual (self.getAccounts ()["domob"].getBalance (), 0)
+    b = self.getBuildings ()
+    self.assertEqual (b[buildings[0]].getFungibleInventory ("domob"), {
+      "bar": 2,
+      "zerospace": 1,
+    })
+    self.assertEqual (b[buildings[1]].getFungibleInventory ("domob"), {
+      "foo": 3,
+    })
+
+    self.generate (20)
+    self.testReorg (reorgBlk, buildings)
+
+  def testReorg (self, blk, buildings):
+    self.mainLogger.info ("Testing reorg...")
+
+    originalState = self.getGameState ()
+    self.rpc.xaya.invalidateblock (blk)
+
+    self.sendMove ("domob", {"s": [
+      {"b": b, "t": "ref", "i": "foo", "n": 3}
+    for b in buildings[::-1]]})
+    self.generate (1)
+
+    self.assertEqual (self.getAccounts ()["domob"].getBalance (), 0)
+    b = self.getBuildings ()
+    self.assertEqual (b[buildings[1]].getFungibleInventory ("domob"), {
+      "bar": 2,
+      "zerospace": 1,
+    })
+    self.assertEqual (b[buildings[0]].getFungibleInventory ("domob"), {
+      "foo": 3,
+    })
+
+    self.rpc.xaya.reconsiderblock (blk)
+    self.expectGameState (originalState)
+
+
+if __name__ == "__main__":
+  ServicesRefiningTest ().main ()

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -32,6 +32,30 @@ message ItemData
   /** The cargo space it uses per unit.  */
   optional uint32 space = 1;
 
+  /**
+   * Data about the ability to refine items of this type to other item types
+   * (i.e. raw materials into refined resources).
+   */
+  message RefiningData
+  {
+
+    /** Number of instances going into one "refining unit".  */
+    optional uint32 input_units = 1;
+
+    /** Base cost (burnt) in vCHI for one refinement step.  */
+    optional uint32 cost = 2;
+
+    /**
+     * The outputs (as item type, amount) for one refining step (i.e.
+     * "input_units" input units).
+     */
+    map<string, uint32> outputs = 3;
+
+  }
+
+  /** If this type of item can be refined, then the stats for doing so.  */
+  optional RefiningData refines = 2;
+
 }
 
 /**
@@ -63,6 +87,19 @@ message BuildingData
    * Maximum HP and regeneration data the building has in its base form.
    */
   optional RegenData regen_data = 4;
+
+  /**
+   * The set of services offered by a building.  Since "false" is the default
+   * value for a boolean field, only those services that are offered need to
+   * be listed in the actual config data.
+   */
+  message Services
+  {
+    optional bool refining = 1;
+  }
+
+  /** Services this building type offers.  */
+  optional Services offered_services = 5;
 
 }
 

--- a/proto/roconfig/buildings/ancient1.pb.text
+++ b/proto/roconfig/buildings/ancient1.pb.text
@@ -4,6 +4,10 @@ building_types:
     value:
       {
         enter_radius: 50
+        offered_services:
+          {
+            refining: true
+          }
         shape_tiles: { x: -13 y: -6 }
         shape_tiles: { x: -14 y: -5 }
         shape_tiles: { x: -14 y: -4 }

--- a/proto/roconfig/buildings/ancient2.pb.text
+++ b/proto/roconfig/buildings/ancient2.pb.text
@@ -4,6 +4,10 @@ building_types:
     value:
       {
         enter_radius: 50
+        offered_services:
+          {
+            refining: true
+          }
         shape_tiles: { x: -15 y: -14 }
         shape_tiles: { x: -29 y: 14 }
         shape_tiles: { x: -14 y: -14 }

--- a/proto/roconfig/buildings/ancient3.pb.text
+++ b/proto/roconfig/buildings/ancient3.pb.text
@@ -4,6 +4,10 @@ building_types:
     value:
       {
         enter_radius: 50
+        offered_services:
+          {
+            refining: true
+          }
         shape_tiles: { x: -19 y: -1 }
         shape_tiles: { x: -21 y: 0 }
         shape_tiles: { x: -20 y: 1 }

--- a/proto/roconfig/items.pb.text
+++ b/proto/roconfig/items.pb.text
@@ -132,7 +132,17 @@ fungible_items: { key: "500 ZNZ tokens prize" value: { space: 0 } }
 fungible_items:
   {
     key: "foo"
-    value: { space: 10 }
+    value:
+      {
+        space: 10
+        refines:
+          {
+            input_units: 3
+            cost: 10
+            outputs: { key: "bar" value: 2 }
+            outputs: { key: "zerospace" value: 1 }
+          }
+      }
   }
 fungible_items:
   {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,6 +36,7 @@ libtaurion_la_SOURCES = \
   prospecting.cpp \
   protoutils.cpp \
   resourcedist.cpp \
+  services.cpp \
   spawn.cpp
 libtaurionheaders = \
   buildings.hpp \
@@ -54,6 +55,7 @@ libtaurionheaders = \
   prospecting.hpp \
   protoutils.hpp \
   resourcedist.hpp \
+  services.hpp \
   spawn.hpp
 
 tauriond_CXXFLAGS = \
@@ -124,6 +126,7 @@ tests_SOURCES = \
   prospecting_tests.cpp \
   protoutils_tests.cpp \
   resourcedist_tests.cpp \
+  services_tests.cpp \
   spawn_tests.cpp \
   testutils_tests.cpp
 check_HEADERS = \

--- a/src/jsonutils.cpp
+++ b/src/jsonutils.cpp
@@ -56,7 +56,7 @@ CoordFromJson (const Json::Value& val, HexCoord& c)
 {
   if (!val.isObject ())
     {
-      LOG (ERROR)
+      VLOG (1)
           << "Invalid HexCoord: JSON value " << val << " is not an object";
       return false;
     }
@@ -66,7 +66,7 @@ CoordFromJson (const Json::Value& val, HexCoord& c)
 
   if (xMember == nullptr || yMember == nullptr)
     {
-      LOG (ERROR)
+      VLOG (1)
           << "Invalid HexCoord: JSON value " << val
           << " must have 'x' and 'y' members";
       return false;
@@ -74,7 +74,7 @@ CoordFromJson (const Json::Value& val, HexCoord& c)
 
   if (val.size () != 2)
     {
-      LOG (ERROR)
+      VLOG (1)
           << "Invalid HexCoord: JSON value " << val
           << " has extra members";
       return false;
@@ -82,7 +82,7 @@ CoordFromJson (const Json::Value& val, HexCoord& c)
 
   if (!xMember->isInt64 () || !yMember->isInt64 ())
     {
-      LOG (ERROR)
+      VLOG (1)
           << "Invalid HexCoord: JSON value " << val
           << " has non-int64 coordinates";
       return false;
@@ -94,13 +94,13 @@ CoordFromJson (const Json::Value& val, HexCoord& c)
   using intLimits = std::numeric_limits<HexCoord::IntT>;
   if (x < intLimits::min () || x > intLimits::max ())
     {
-      LOG (ERROR)
+      VLOG (1)
           << "Invalid HexCoord: x coordinate " << x << " is out of range";
       return false;
     }
   if (y < intLimits::min () || y > intLimits::max ())
     {
-      LOG (ERROR)
+      VLOG (1)
           << "Invalid HexCoord: y coordinate " << y << " is out of range";
       return false;
     }

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -21,6 +21,7 @@
 
 #include "context.hpp"
 #include "dynobstacles.hpp"
+#include "services.hpp"
 
 #include "database/account.hpp"
 #include "database/amount.hpp"
@@ -199,6 +200,13 @@ protected:
   void TryCharacterUpdates (const std::string& name, const Json::Value& mv);
 
   /**
+   * Parses and handles a potential move with requested service operations.
+   * Each valid operation will be passed to PerformServiceOperation for
+   * either execution or recording in the pending state.
+   */
+  void TryServiceOperations (const std::string& name, const Json::Value& mv);
+
+  /**
    * This function is called when TryCharacterCreation found a creation that
    * is valid and should be performed.
    */
@@ -212,6 +220,14 @@ protected:
    */
   virtual void
   PerformCharacterUpdate (Character& c, const Json::Value& upd)
+  {}
+
+  /**
+   * This function is called when TryServiceOperations found a valid
+   * service operation.
+   */
+  virtual void
+  PerformServiceOperation (ServiceOperation& op)
   {}
 
 public:
@@ -318,6 +334,7 @@ protected:
 
   void PerformCharacterCreation (const std::string& name, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& mv) override;
+  void PerformServiceOperation (ServiceOperation& op) override;
 
 public:
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -2003,11 +2003,12 @@ class GodModeTests : public MoveProcessorTests
 protected:
 
   BuildingsTable buildings;
+  BuildingInventoriesTable buildingInv;
   CharacterTable tbl;
   GroundLootTable loot;
 
   GodModeTests ()
-    : buildings(db), tbl(db), loot(db)
+    : buildings(db), buildingInv(db), tbl(db), loot(db)
   {
     ctx.SetChain (xaya::Chain::REGTEST);
   }
@@ -2188,6 +2189,8 @@ TEST_F (GodModeTests, Build)
 TEST_F (GodModeTests, InvalidDropLoot)
 {
   const HexCoord pos(1, 2);
+  db.SetNextId (100);
+  buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
 
   ProcessAdmin (R"([{"cmd": {
     "god":
@@ -2216,23 +2219,41 @@ TEST_F (GodModeTests, InvalidDropLoot)
             },
             {
               "pos": {"x": 1, "y": 2},
-              "fungible": {"foo": 10},
-              "extra": "value"
+              "building": {"id": 100, "a": "domob"},
+              "fungible": {"foo": 10}
             },
             {
               "pos": {"x": 1, "y": 2},
               "fungible": {"foo": 1000000001}
+            },
+            {
+              "fungible": {"foo": 10}
+            },
+            {
+              "building": {"id": -5, "a": "domob"},
+              "fungible": {"foo": 10}
+            },
+            {
+              "building": {"id": 100, "a": false},
+              "fungible": {"foo": 10}
+            },
+            {
+              "building": {"id": 100, "a": "domob", "x": 5},
+              "fungible": {"foo": 10}
             }
           ]
       }
   }}])");
 
   EXPECT_TRUE (loot.GetByCoord (pos)->GetInventory ().IsEmpty ());
+  EXPECT_TRUE (buildingInv.Get (100, "domob")->GetInventory ().IsEmpty ());
 }
 
 TEST_F (GodModeTests, ValidDropLoot)
 {
   const HexCoord pos(1, 2);
+  db.SetNextId (100);
+  buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
 
   ProcessAdmin (R"([{"cmd": {
     "god":
@@ -2247,6 +2268,10 @@ TEST_F (GodModeTests, ValidDropLoot)
             {
               "pos": {"x": 1, "y": 2},
               "fungible": {"foo": 10, "bar": 1000000000}
+            },
+            {
+              "building": {"id": 100, "a": "domob"},
+              "fungible": {"foo": 42}
             }
           ]
       }
@@ -2255,6 +2280,8 @@ TEST_F (GodModeTests, ValidDropLoot)
   auto h = loot.GetByCoord (pos);
   EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 20);
   EXPECT_EQ (h->GetInventory ().GetFungibleCount ("bar"), MAX_ITEM_QUANTITY);
+  auto i = buildingInv.Get (100, "domob");
+  EXPECT_EQ (i->GetInventory ().GetFungibleCount ("foo"), 42);
 }
 
 TEST_F (GodModeTests, GiftCoins)

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -21,6 +21,7 @@
 
 #include "context.hpp"
 #include "moveprocessor.hpp"
+#include "services.hpp"
 
 #include "database/character.hpp"
 #include "database/database.hpp"
@@ -131,6 +132,9 @@ private:
     /** The combined coin transfer / burn for this account.  */
     std::unique_ptr<CoinTransferBurn> coinOps;
 
+    /** Requested service operations (already as JSON).  */
+    std::vector<Json::Value> serviceOps;
+
     /**
      * Returns the JSON representation of the pending state.
      */
@@ -231,6 +235,11 @@ public:
   void AddCoinTransferBurn (const Account& a, const CoinTransferBurn& op);
 
   /**
+   * Updates the state for a given account, adding a new service operation.
+   */
+  void AddServiceOperation (const ServiceOperation& op);
+
+  /**
    * Returns the JSON representation of the pending state.
    */
   Json::Value ToJson () const;
@@ -254,6 +263,7 @@ protected:
 
   void PerformCharacterCreation (const std::string& name, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& upd) override;
+  void PerformServiceOperation (ServiceOperation& op) override;
 
 public:
 

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -79,6 +79,7 @@ protected:
   }
 
   bool IsValid () const override;
+  Json::Value SpecificToPendingJson () const override;
   void ExecuteSpecific () override;
 
 public:
@@ -160,6 +161,27 @@ RefiningOperation::IsValid () const
   return true;
 }
 
+Json::Value
+RefiningOperation::SpecificToPendingJson () const
+{
+  Json::Value res(Json::objectValue);
+  res["type"] = "refining";
+
+  Json::Value inp(Json::objectValue);
+  inp[type] = IntToJson (amount);
+
+  CHECK (refData != nullptr);
+  const unsigned steps = GetSteps ();
+  Json::Value outp(Json::objectValue);
+  for (const auto& out : refData->outputs ())
+    outp[out.first] = IntToJson (steps * out.second);
+
+  res["input"] = inp;
+  res["output"] = outp;
+
+  return res;
+}
+
 void
 RefiningOperation::ExecuteSpecific ()
 {
@@ -203,6 +225,18 @@ RefiningOperation::Parse (Account& acc, const Building& b,
 /* ************************************************************************** */
 
 } // anonymous namespace
+
+Json::Value
+ServiceOperation::ToPendingJson () const
+{
+  Json::Value res = SpecificToPendingJson ();
+  CHECK (res.isObject ());
+
+  res["building"] = IntToJson (building.GetId ());
+  res["cost"] = IntToJson (GetBaseCost ());
+
+  return res;
+}
 
 void
 ServiceOperation::Execute ()

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -1,0 +1,287 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "services.hpp"
+
+#include "jsonutils.hpp"
+
+#include "proto/roconfig.hpp"
+
+#include <glog/logging.h>
+
+#include <string>
+
+namespace pxd
+{
+
+namespace
+{
+
+/* ************************************************************************** */
+
+/**
+ * A refining operation.
+ */
+class RefiningOperation : public ServiceOperation
+{
+
+private:
+
+  /** The type of resource being refined.  */
+  const std::string type;
+
+  /** The amount of raw resource being refined.  */
+  const Inventory::QuantityT amount;
+
+  /**
+   * The refining data for the resource type.  May be null if the item
+   * type is invalid or it can't be refined.
+   */
+  const proto::ItemData::RefiningData* refData;
+
+  /**
+   * Returns the number of refining steps this operation represents.  Assumes
+   * that the operation is otherwise valid (e.g. we have refData).
+   */
+  unsigned
+  GetSteps () const
+  {
+    return amount / refData->input_units ();
+  }
+
+protected:
+
+  bool
+  IsSupported (const Building& b) const override
+  {
+    return b.RoConfigData ().offered_services ().refining ();
+  }
+
+  Amount
+  GetBaseCost () const override
+  {
+    return GetSteps () * refData->cost ();
+  }
+
+  bool IsValid () const override;
+  void ExecuteSpecific () override;
+
+public:
+
+  explicit RefiningOperation (Account& a, const Building& b,
+                              const std::string& t,
+                              const Inventory::QuantityT am,
+                              BuildingInventoriesTable& i);
+
+  /**
+   * Tries to parse a refining operation from the corresponding JSON move.
+   * Returns a possibly invalid RefiningOperation instance or null if parsing
+   * fails.
+   */
+  static std::unique_ptr<RefiningOperation> Parse (Account& acc,
+                                                   const Building& b,
+                                                   const Json::Value& data,
+                                                   BuildingInventoriesTable& i);
+
+};
+
+RefiningOperation::RefiningOperation (Account& a, const Building& b,
+                                      const std::string& t,
+                                      const Inventory::QuantityT am,
+                                      BuildingInventoriesTable& i)
+  : ServiceOperation(a, b, i),
+    type(t), amount(am)
+{
+  const auto& itemData = RoConfigData ().fungible_items ();
+  const auto mit = itemData.find (type);
+  if (mit == itemData.end ())
+    {
+      LOG (WARNING) << "Can't refine invalid item type " << type;
+      refData = nullptr;
+      return;
+    }
+
+  if (!mit->second.has_refines ())
+    {
+      LOG (WARNING) << "Item type " << type << " can't be refined";
+      refData = nullptr;
+      return;
+    }
+
+  refData = &mit->second.refines ();
+}
+
+bool
+RefiningOperation::IsValid () const
+{
+  if (refData == nullptr)
+    return false;
+
+  if (amount <= 0)
+    return false;
+
+  if (amount % refData->input_units () != 0)
+    {
+      LOG (WARNING)
+          << "Invalid refinement input of " << amount << " " << type
+          << ", the input for one step is " << refData->input_units ();
+      return false;
+    }
+
+  const auto buildingId = GetBuilding ().GetId ();
+  const auto& name = GetAccount ().GetName ();
+
+  const auto inv = invTable.Get (buildingId, name);
+  const auto balance = inv->GetInventory ().GetFungibleCount (type);
+  if (amount > balance)
+    {
+      LOG (WARNING)
+          << "Can't refine " << amount << " " << type
+          << " as balance of " << name << " in building " << buildingId
+          << " is only " << balance;
+      return false;
+    }
+
+  return true;
+}
+
+void
+RefiningOperation::ExecuteSpecific ()
+{
+  const auto buildingId = GetBuilding ().GetId ();
+  const auto& name = GetAccount ().GetName ();
+
+  LOG (INFO)
+      << name << " in building " << buildingId
+      << " refines " << amount << " " << type;
+
+  auto invHandle = invTable.Get (buildingId, name);
+  auto& inv = invHandle->GetInventory ();
+  inv.AddFungibleCount (type, -amount);
+
+  const unsigned steps = GetSteps ();
+  for (const auto& out : refData->outputs ())
+    inv.AddFungibleCount (out.first, steps * out.second);
+}
+
+std::unique_ptr<RefiningOperation>
+RefiningOperation::Parse (Account& acc, const Building& b,
+                          const Json::Value& data,
+                          BuildingInventoriesTable& inv)
+{
+  CHECK (data.isObject ());
+  if (data.size () != 4)
+    return nullptr;
+
+  const auto& type = data["i"];
+  if (!type.isString ())
+    return nullptr;
+
+  const auto& amount = data["n"];
+  if (!amount.isUInt64 ())
+    return nullptr;
+
+  return std::make_unique<RefiningOperation> (acc, b, type.asString (),
+                                              amount.asUInt64 (), inv);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+
+void
+ServiceOperation::Execute ()
+{
+  acc.AddBalance (-GetBaseCost ());
+  ExecuteSpecific ();
+}
+
+std::unique_ptr<ServiceOperation>
+ServiceOperation::Parse (Account& acc, const Json::Value& data,
+                         BuildingsTable& buildings,
+                         BuildingInventoriesTable& inv)
+{
+  if (!data.isObject ())
+    {
+      LOG (WARNING) << "Invalid service operation: " << data;
+      return nullptr;
+    }
+
+  Database::IdT buildingId;
+  if (!IdFromJson (data["b"], buildingId))
+    {
+      LOG (WARNING) << "Invalid service operation: " << data;
+      return nullptr;
+    }
+
+  auto b = buildings.GetById (buildingId);
+  if (b == nullptr)
+    {
+      LOG (WARNING)
+          << "Service operation requested in non-existant building "
+          << buildingId;
+      return nullptr;
+    }
+
+  const auto& typeVal = data["t"];
+  if (!typeVal.isString ())
+    {
+      LOG (WARNING) << "Invalid service operation (no type): " << data;
+      return nullptr;
+    }
+  const std::string type = typeVal.asString ();
+
+  std::unique_ptr<ServiceOperation> op;
+  if (type == "ref")
+    op = RefiningOperation::Parse (acc, *b, data, inv);
+  else
+    {
+      LOG (WARNING) << "Unknown service operation: " << type;
+      return nullptr;
+    }
+
+  if (op == nullptr || !op->IsValid ())
+    {
+      LOG (WARNING) << "Invalid service operation: " << data;
+      return nullptr;
+    }
+
+  if (!op->IsSupported (*b))
+    {
+      LOG (WARNING)
+          << "Building " << b->GetId ()
+          << " does not support service operation: " << data;
+      return nullptr;
+    }
+
+  const Amount cost = op->GetBaseCost ();
+  if (cost > acc.GetBalance ())
+    {
+      LOG (WARNING)
+          << "Service operation would cost " << cost
+          << ", but " << acc.GetName () << " has only " << acc.GetBalance ()
+          << ": " << data;
+      return nullptr;
+    }
+
+  return op;
+}
+
+/* ************************************************************************** */
+
+} // namespace pxd

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -79,6 +79,13 @@ protected:
    */
   virtual void ExecuteSpecific () = 0;
 
+  /**
+   * Converts the subclass-specific data of this operation (not including
+   * e.g. building or cost) to JSON for the pending state.  Must return
+   * a JSON object.
+   */
+  virtual Json::Value SpecificToPendingJson () const = 0;
+
 public:
 
   virtual ~ServiceOperation () = default;
@@ -100,6 +107,11 @@ public:
   {
     return acc;
   }
+
+  /**
+   * Returns a JSON representation of this operation for pending moves.
+   */
+  Json::Value ToPendingJson () const;
 
   /**
    * Fully executes the update corresponding to this operation.

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -1,0 +1,121 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_SERVICES_HPP
+#define PXD_SERVICES_HPP
+
+#include "database/account.hpp"
+#include "database/amount.hpp"
+#include "database/building.hpp"
+#include "database/inventory.hpp"
+
+#include <json/json.h>
+
+#include <memory>
+
+namespace pxd
+{
+
+/**
+ * A particular service operation requested by a user in a move.  The individual
+ * services (plus their details, e.g. refining and how much of what item
+ * should be refined) are instances of subclasses.
+ */
+class ServiceOperation
+{
+
+private:
+
+  /** The account triggering the service operation.  */
+  Account& acc;
+
+  /** The building in which the operation is happening.  */
+  const Building& building;
+
+protected:
+
+  /** Database handle for upating building inventories (e.g. for refining).  */
+  BuildingInventoriesTable& invTable;
+
+  explicit ServiceOperation (Account& a, const Building& b,
+                             BuildingInventoriesTable& i)
+    : acc(a), building(b), invTable(i)
+  {}
+
+  /**
+   * Returns true if the service is supported by the given building.
+   */
+  virtual bool IsSupported (const Building& b) const = 0;
+
+  /**
+   * Returns true if the operation is actually valid according to game
+   * and move rules.
+   */
+  virtual bool IsValid () const = 0;
+
+  /**
+   * Returns the base cost (vCHI that are burnt) for this operation.
+   */
+  virtual Amount GetBaseCost () const = 0;
+
+  /**
+   * Executes the subclass-specific part of this operation, which is all updates
+   * except for the vCHI cost.
+   */
+  virtual void ExecuteSpecific () = 0;
+
+public:
+
+  virtual ~ServiceOperation () = default;
+
+  /**
+   * Returns the building the operation is happening in.
+   */
+  const Building&
+  GetBuilding () const
+  {
+    return building;
+  }
+
+  /**
+   * Returns the account requesting this operation.
+   */
+  const Account&
+  GetAccount () const
+  {
+    return acc;
+  }
+
+  /**
+   * Fully executes the update corresponding to this operation.
+   */
+  void Execute ();
+
+  /**
+   * Tries to parse a service operation from JSON move data.  Returns nullptr
+   * if the format is invalid or the operation would not be valid.
+   */
+  static std::unique_ptr<ServiceOperation> Parse (
+      Account& acc, const Json::Value& data,
+      BuildingsTable& buildings, BuildingInventoriesTable& inv);
+
+};
+
+} // namespace pxd
+
+#endif // PXD_SERVICES_HPP

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -1,0 +1,294 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "services.hpp"
+
+#include "testutils.hpp"
+
+#include "database/dbtest.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+/* ************************************************************************** */
+
+class ServicesTests : public DBTestWithSchema
+{
+
+protected:
+
+  /** ID of an ancient building with all services.  */
+  static constexpr Database::IdT ANCIENT_BUILDING = 100;
+
+  AccountsTable accounts;
+  BuildingsTable buildings;
+  BuildingInventoriesTable inv;
+
+  ServicesTests ()
+    : accounts(db), buildings(db), inv(db)
+  {
+    accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+
+    db.SetNextId (ANCIENT_BUILDING);
+    auto b = buildings.CreateNew ("ancient1", "", Faction::ANCIENT);
+    CHECK_EQ (b->GetId (), ANCIENT_BUILDING);
+    b->SetCentre (HexCoord (42, 10));
+
+    /* We use refining for most general tests, thus it makes sense to set up
+       basic resources for it already here.  */
+    inv.Get (ANCIENT_BUILDING, "domob")
+        ->GetInventory ().AddFungibleCount ("foo", 10);
+  }
+
+  /**
+   * Calls TryServiceOperation with the given account and data parsed from
+   * a JSON literal string.  Returns true if the operation was valid.
+   */
+  bool
+  Process (const std::string& name, const std::string& dataStr)
+  {
+    auto a = accounts.GetByName (name);
+    auto op = ServiceOperation::Parse (*a, ParseJson (dataStr), buildings, inv);
+
+    if (op == nullptr)
+      return false;
+
+    op->Execute ();
+    return true;
+  }
+
+};
+
+TEST_F (ServicesTests, BasicOperation)
+{
+  ASSERT_TRUE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": 3
+  })"));
+
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 90);
+  auto i = inv.Get (ANCIENT_BUILDING, "domob");
+  EXPECT_EQ (i->GetInventory ().GetFungibleCount ("foo"), 7);
+  EXPECT_EQ (i->GetInventory ().GetFungibleCount ("bar"), 2);
+  EXPECT_EQ (i->GetInventory ().GetFungibleCount ("zerospace"), 1);
+}
+
+TEST_F (ServicesTests, InvalidFormat)
+{
+  EXPECT_FALSE (Process ("domob", "[]"));
+  EXPECT_FALSE (Process ("domob", "null"));
+  EXPECT_FALSE (Process ("domob", "\"foo\""));
+  EXPECT_FALSE (Process ("domob", "{}"));
+
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "i": "foo",
+    "n": 6
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": "invalid",
+    "i": "foo",
+    "n": 6
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 42,
+    "i": "foo",
+    "n": 6
+  })"));
+
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 100,
+    "i": "foo",
+    "n": 6
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "",
+    "b": 100,
+    "i": "foo",
+    "n": 6
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "invalid type",
+    "b": 100,
+    "i": "foo",
+    "n": 6
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": 42,
+    "b": 100,
+    "i": "foo",
+    "n": 6
+  })"));
+}
+
+TEST_F (ServicesTests, InvalidOperation)
+{
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": 5
+  })"));
+}
+
+TEST_F (ServicesTests, UnsupportedBuilding)
+{
+  db.SetNextId (200);
+  buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  inv.Get (200, "domob")->GetInventory ().AddFungibleCount ("foo", 10);
+
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 200,
+    "i": "foo",
+    "n": 3
+  })"));
+}
+
+TEST_F (ServicesTests, InsufficientFunds)
+{
+  accounts.GetByName ("domob")->AddBalance (-91);
+
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": 3
+  })"));
+}
+
+/* ************************************************************************** */
+
+using RefiningTests = ServicesTests;
+
+TEST_F (RefiningTests, InvalidFormat)
+{
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": 3,
+    "x": false
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": 42,
+    "n": 3
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": -3
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": "x"
+  })"));
+}
+
+TEST_F (RefiningTests, InvalidItemType)
+{
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "invalid item",
+    "n": 3
+  })"));
+}
+
+TEST_F (RefiningTests, ItemNotRefinable)
+{
+  inv.Get (ANCIENT_BUILDING, "domob")
+      ->GetInventory ().AddFungibleCount ("bar", 10);
+
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "bar",
+    "n": 3
+  })"));
+}
+
+TEST_F (RefiningTests, InvalidAmount)
+{
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": -3
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": 0
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": 2
+  })"));
+}
+
+TEST_F (RefiningTests, TooMuch)
+{
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": 30
+  })"));
+}
+
+TEST_F (RefiningTests, MultipleSteps)
+{
+  ASSERT_TRUE (Process ("domob", R"({
+    "t": "ref",
+    "b": 100,
+    "i": "foo",
+    "n": 9
+  })"));
+
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 70);
+  auto i = inv.Get (ANCIENT_BUILDING, "domob");
+  EXPECT_EQ (i->GetInventory ().GetFungibleCount ("foo"), 1);
+  EXPECT_EQ (i->GetInventory ().GetFungibleCount ("bar"), 6);
+  EXPECT_EQ (i->GetInventory ().GetFungibleCount ("zerospace"), 3);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace pxd


### PR DESCRIPTION
This implements "refining" as a first building service, together with general logic for services in buildings.  Refining can be triggered on select items in the inventory of a building, and will then instantly turn those items (raw materials) into a set of different items (refined minerals) as outputs.  This costs a given vCHI amount.

Which items can be refined, what the outputs and costs are, and what buildings support it is up to be defined in the roconfig data.  For now the `ancient?` buildings support refining and 3N `foo` can be refined to 2N `bar` and N `zerospace` at a cost of 10N vCHI.  Testing this is only possible in regtest for now, as those buildings need to be placed in god-mode first.

The general move format for requesting one or more refining operations is this:

    {"s": [{"b": 123, "t": "ref", "i": "foo", "n": 3}]}

(Note that the operation is only valid if the input amount `n` is a whole multiple of the numbers in the roconfig, i.e. divisible by three in the case of `foo`.)

For testing this easily, there is now also a new god-mode command for dropping loot directly "into" a building rather than on the ground:

    {"god": {"drop": [{"building": {"id": 123, "a": "domob"}, "fungible": {"foo": 10}}]}}