### PR TITLE
Armour repair service

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -29,6 +29,7 @@ REGTESTS = \
   prospecting_prizes.py \
   prospecting_resources.py \
   services_refining.py \
+  services_repair.py \
   splitstaterpcs.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/gametest/services_repair.py
+++ b/gametest/services_repair.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests basic "armour repair" service operations.
+"""
+
+from pxtest import PXTest
+
+
+class ServicesRepairTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.mainLogger.info ("Setting up initial situation...")
+    self.build ("ancient1", None, {"x": 0, "y": 0}, 0)
+    building = 1001
+    self.assertEqual (self.getBuildings ()[building].getType (), "ancient1")
+
+    self.initAccount ("domob", "r")
+    self.generate (1)
+    self.giftCoins ({"domob": 100})
+    self.createCharacters ("domob")
+    self.generate (1)
+    cId = self.getCharacters ()["domob"].getId ()
+    self.setCharactersHP ({"domob": {"ma": 500, "a": 20}})
+    self.moveCharactersTo ({"domob": {"x": 30, "y": 0}})
+    self.getCharacters ()["domob"].sendMove ({"eb": building})
+    self.generate (1)
+
+    self.generate (1)
+    reorgBlk = self.rpc.xaya.getbestblockhash ()
+
+    self.mainLogger.info ("Starting repair...")
+    self.sendMove ("domob", {"s": [
+      {"b": building, "t": "fix", "c": cId},
+    ]})
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["domob"].getBusy (), {
+      "operation": "armourrepair",
+      "blocks": 5,
+    })
+
+    self.mainLogger.info ("Repairing character is busy...")
+    self.getCharacters ()["domob"].sendMove ({"xb": {}})
+    self.generate (4)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isInBuilding (), True)
+    self.assertEqual (c.data["combat"]["hp"]["current"]["armour"], 20)
+    self.assertEqual (c.getBusy (), {
+      "operation": "armourrepair",
+      "blocks": 1,
+    })
+
+    self.mainLogger.info ("Finishing the repair...")
+    c.sendMove ({"xb": {}})
+    self.generate (1)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isInBuilding (), False)
+    self.assertEqual (c.data["combat"]["hp"]["current"]["armour"], 500)
+    self.assertEqual (c.getBusy (), None)
+
+    self.generate (20)
+    self.testReorg (reorgBlk, building, cId)
+
+  def testReorg (self, blk, building, cId):
+    self.mainLogger.info ("Testing reorg...")
+
+    originalState = self.getGameState ()
+    self.rpc.xaya.invalidateblock (blk)
+
+    # We leave the building now instead of requesting a repair to create
+    # an alternative reality.
+    self.getCharacters ()["domob"].sendMove ({"xb": {}})
+    self.generate (10)
+
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.isInBuilding (), False)
+    self.assertEqual (c.data["combat"]["hp"]["current"]["armour"], 20)
+    self.assertEqual (c.getBusy (), None)
+
+    self.rpc.xaya.reconsiderblock (blk)
+    self.expectGameState (originalState)
+
+
+if __name__ == "__main__":
+  ServicesRepairTest ().main ()

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -39,6 +39,17 @@ message OngoingProspection
 }
 
 /**
+ * Data representing an "armour repair" operation in progress.
+ */
+message ArmourRepair
+{
+
+  /* As with OngoingProspection, this is just a signal message for the
+     busy oneof, at least for the time being.  */
+
+}
+
+/**
  * Data about the mining state of a character.
  */
 message MiningData
@@ -93,16 +104,17 @@ message Character
   oneof busy
   {
     OngoingProspection prospection = 3;
+    ArmourRepair armour_repair = 4;
   }
 
   /** The character's mining data, if it can mine.  */
-  optional MiningData mining = 4;
+  optional MiningData mining = 5;
 
   /** Movement speed of the character.  */
-  optional uint32 speed = 5;
+  optional uint32 speed = 6;
 
   /** Total cargo space the character has.  */
-  optional uint64 cargo_space = 6;
+  optional uint64 cargo_space = 7;
 
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -96,6 +96,7 @@ message BuildingData
   message Services
   {
     optional bool refining = 1;
+    optional bool armour_repair = 2;
   }
 
   /** Services this building type offers.  */

--- a/proto/roconfig/buildings/ancient1.pb.text
+++ b/proto/roconfig/buildings/ancient1.pb.text
@@ -7,6 +7,7 @@ building_types:
         offered_services:
           {
             refining: true
+            armour_repair: true
           }
         shape_tiles: { x: -13 y: -6 }
         shape_tiles: { x: -14 y: -5 }

--- a/proto/roconfig/buildings/ancient2.pb.text
+++ b/proto/roconfig/buildings/ancient2.pb.text
@@ -7,6 +7,7 @@ building_types:
         offered_services:
           {
             refining: true
+            armour_repair: true
           }
         shape_tiles: { x: -15 y: -14 }
         shape_tiles: { x: -29 y: 14 }

--- a/proto/roconfig/buildings/ancient3.pb.text
+++ b/proto/roconfig/buildings/ancient3.pb.text
@@ -7,6 +7,7 @@ building_types:
         offered_services:
           {
             refining: true
+            armour_repair: true
           }
         shape_tiles: { x: -19 y: -1 }
         shape_tiles: { x: -21 y: 0 }

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -212,6 +212,10 @@ GetBusyJsonObject (const BaseMap& map, const Character& c)
       res["region"] = IntToJson (map.Regions ().GetRegionId (c.GetPosition ()));
       break;
 
+    case proto::Character::kArmourRepair:
+      res["operation"] = "armourrepair";
+      break;
+
     default:
       LOG (FATAL) << "Unexpected busy state for character: " << pb.busy_case ();
     }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -522,6 +522,29 @@ TEST_F (CharacterJsonTests, Prospecting)
   })");
 }
 
+TEST_F (CharacterJsonTests, ArmourRepair)
+{
+  auto c = tbl.CreateNew ("domob", Faction::RED);
+  c->SetBuildingId (20);
+  c->SetBusy (42);
+  c->MutableProto ().mutable_armour_repair ();
+  c.reset ();
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "owner": "domob",
+          "busy":
+            {
+              "blocks": 42,
+              "operation": "armourrepair"
+            }
+        }
+      ]
+  })");
+}
+
 /* ************************************************************************** */
 
 class AccountJsonTests : public GameStateJsonTests

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -71,6 +71,13 @@ ProcessBusy (Database& db, xaya::Random& rnd, const Context& ctx)
           FinishProspecting (*c, db, regions, rnd, ctx);
           break;
 
+        case proto::Character::kArmourRepair:
+          LOG (INFO) << "Finished armour repair of character " << c->GetId ();
+          c->MutableHP ().set_armour (c->GetRegenData ().max_hp ().armour ());
+          c->MutableProto ().clear_armour_repair ();
+          c->SetBusy (0);
+          break;
+
         default:
           LOG (FATAL)
               << "Unexpected busy case: " << c->GetProto ().busy_case ();

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -876,6 +876,28 @@ TEST_F (PXLogicTests, EnterAndExitBuildingWhenOutside)
   EXPECT_EQ (c->GetBuildingId (), 1);
 }
 
+TEST_F (PXLogicTests, FinishingArmourRepair)
+{
+  auto c = CreateCharacter ("domob", Faction::RED);
+  ASSERT_EQ (c->GetId (), 1);
+  c->SetBuildingId (20);
+  c->MutableRegenData ().mutable_max_hp ()->set_armour (100);
+  c->MutableHP ().set_armour (5);
+  c->MutableProto ().mutable_armour_repair ();
+  c->SetBusy (2);
+  c.reset ();
+
+  UpdateState ("[]");
+  c = characters.GetById (1);
+  EXPECT_EQ (c->GetBusy (), 1);
+  EXPECT_EQ (c->GetHP ().armour (), 5);
+
+  UpdateState ("[]");
+  c = characters.GetById (1);
+  EXPECT_EQ (c->GetBusy (), 0);
+  EXPECT_EQ (c->GetHP ().armour (), 100);
+}
+
 /* ************************************************************************** */
 
 using ValidateStateTests = PXLogicTests;

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -443,6 +443,13 @@ BaseMoveProcessor::ParseExitBuilding (const Character& c,
       return false;
     }
 
+  if (c.GetBusy () > 0)
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId () << " is busy, can't exit building";
+      return false;
+    }
+
   if (!c.IsInBuilding ())
     {
       LOG (WARNING)

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -222,7 +222,9 @@ BaseMoveProcessor::TryServiceOperations (const std::string& name,
 
   for (const auto& op : cmds)
     {
-      auto parsed = ServiceOperation::Parse (*a, op, buildings, buildingInv);
+      auto parsed = ServiceOperation::Parse (*a, op, ctx,
+                                             buildings, buildingInv,
+                                             characters);
       if (parsed != nullptr)
         PerformServiceOperation (*parsed);
     }

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1159,6 +1159,25 @@ TEST_F (ExitBuildingMoveTests, Invalid)
   EXPECT_EQ (GetTest ()->GetBuildingId (), 20);
 }
 
+TEST_F (ExitBuildingMoveTests, WhenBusy)
+{
+  const auto buildingId
+      = buildings.CreateNew ("checkmark", "domob", Faction::RED)->GetId ();
+
+  GetTest ()->SetBuildingId (buildingId);
+  GetTest ()->SetBusy (1);
+
+  Process (R"([
+    {
+      "name": "domob",
+      "move": {"c": {"1": {"xb": {}}}}
+    }
+  ])");
+
+  ASSERT_TRUE (GetTest ()->IsInBuilding ());
+  EXPECT_EQ (GetTest ()->GetBuildingId (), buildingId);
+}
+
 TEST_F (ExitBuildingMoveTests, NotInBuilding)
 {
   const HexCoord pos(10, 20);

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -186,6 +186,19 @@ Params::IsLowPrizeZone (const HexCoord& pos) const
   return HexCoord::DistanceL1 (pos, noPrizeCentre) <= noPrizeRadius;
 }
 
+unsigned
+Params::ArmourRepairHpPerBlock () const
+{
+  return 100;
+}
+
+Amount
+Params::ArmourRepairCostMillis () const
+{
+  /* The cost is 1 vCHI for 10 HP repair.  */
+  return 100;
+}
+
 HexCoord
 Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
 {

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -135,6 +135,16 @@ public:
   bool IsLowPrizeZone (const HexCoord& pos) const;
 
   /**
+   * Returns the maximum armour HP that can be repaired per block.
+   */
+  unsigned ArmourRepairHpPerBlock () const;
+
+  /**
+   * Returns the cost (in 1/1000 vCHI) for repairing one HP of armour.
+   */
+  Amount ArmourRepairCostMillis () const;
+
+  /**
    * Returns the spawn centre and radius for the given faction.
    */
   HexCoord SpawnArea (Faction f, HexCoord::IntT& radius) const;

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -43,6 +43,8 @@ protected:
 
   PendingState state;
 
+  ContextForTesting ctx;
+
   AccountsTable accounts;
   BuildingsTable buildings;
   BuildingInventoriesTable buildingInv;
@@ -511,7 +513,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 3
-      })"), buildings, buildingInv));
+      })"), ctx, buildings, buildingInv, characters));
   state.AddServiceOperation (*ServiceOperation::Parse (
       *accounts.GetByName ("andy"),
       ParseJson (R"({
@@ -519,7 +521,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 6
-      })"), buildings, buildingInv));
+      })"), ctx, buildings, buildingInv, characters));
   state.AddServiceOperation (*ServiceOperation::Parse (
       *accounts.GetByName ("domob"),
       ParseJson (R"({
@@ -527,7 +529,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 9
-      })"), buildings, buildingInv));
+      })"), ctx, buildings, buildingInv, characters));
 
   ExpectStateJson (R"(
     {

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -19,9 +19,12 @@
 #ifndef PXD_SERVICES_HPP
 #define PXD_SERVICES_HPP
 
+#include "context.hpp"
+
 #include "database/account.hpp"
 #include "database/amount.hpp"
 #include "database/building.hpp"
+#include "database/character.hpp"
 #include "database/inventory.hpp"
 
 #include <json/json.h>
@@ -49,12 +52,16 @@ private:
 
 protected:
 
+  /** Context for parameters and such.  */
+  const Context& ctx;
+
   /** Database handle for upating building inventories (e.g. for refining).  */
   BuildingInventoriesTable& invTable;
 
   explicit ServiceOperation (Account& a, const Building& b,
+                             const Context& cx,
                              BuildingInventoriesTable& i)
-    : acc(a), building(b), invTable(i)
+    : acc(a), building(b), ctx(cx), invTable(i)
   {}
 
   /**
@@ -124,7 +131,9 @@ public:
    */
   static std::unique_ptr<ServiceOperation> Parse (
       Account& acc, const Json::Value& data,
-      BuildingsTable& buildings, BuildingInventoriesTable& inv);
+      const Context& ctx,
+      BuildingsTable& buildings, BuildingInventoriesTable& inv,
+      CharacterTable& characters);
 
 };
 


### PR DESCRIPTION
This implements a new building service, repairing the armour of a vehicle.  The vehicle must be inside the building where the service is requested, and it must be owned by the requesting account (plus have less than maximum HP).

Armour repair costs 1 vCHI for 10 HP, and takes one block per 100 HP repaired (so it does not work immediate like refining, instead it uses the character "busy" functionality).

To request armour repair, a move like this can be used:

    {"s": [{"t": "fix", "b": 123, "c": 42}]}