### PR TITLE
Implement fees for services

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -28,6 +28,7 @@ REGTESTS = \
   prospecting_basic.py \
   prospecting_prizes.py \
   prospecting_resources.py \
+  services_fees.py \
   services_refining.py \
   services_repair.py \
   splitstaterpcs.py

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -47,6 +47,7 @@ class GodModeTest (PXTest):
       "faction": "a",
       "centre": {"x": 100, "y": 150},
       "rotationsteps": 2,
+      "servicefee": 0,
       "tiles":
         [
           {"x": 100, "y": 150},
@@ -72,6 +73,7 @@ class GodModeTest (PXTest):
       "owner": "domob",
       "centre": {"x": -100, "y": -150},
       "rotationsteps": 0,
+      "servicefee": 0,
       "tiles":
         [
           {"x": -100, "y": -150},

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -206,7 +206,7 @@ class PendingTest (PXTest):
                 {
                   "building": building,
                   "type": "refining",
-                  "cost": 30,
+                  "cost": {"base": 30, "fee": 0},
                   "input": {"foo": 9},
                   "output": {"bar": 6, "zerospace": 3},
                 }

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -117,7 +117,8 @@ class Building (object):
   Basic handle for a building in the game state.
   """
 
-  def __init__ (self, data):
+  def __init__ (self, test, data):
+    self.test = test
     self.data = data
 
   def getId (self):
@@ -142,6 +143,14 @@ class Building (object):
     if account not in inv:
       return collections.Counter ()
     return collections.Counter (inv[account]["fungible"])
+
+  def sendMove (self, mv):
+    """
+    Sends a move to update the given building with the given data.
+    """
+
+    idStr = "%s" % self.getId ()
+    return self.test.sendMove (self.data["owner"], {"b": {idStr: mv}})
 
 
 class Account (object):
@@ -370,7 +379,7 @@ class PXTest (XayaGameTest):
 
     res = {}
     for b in self.getRpc ("getbuildings"):
-      handle = Building (b)
+      handle = Building (self, b)
       curId = handle.getId ()
       assert curId not in res
       res[curId] = handle

--- a/gametest/services_fees.py
+++ b/gametest/services_fees.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests service fees for building owners.
+"""
+
+from pxtest import PXTest
+
+
+class ServicesFeesTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.mainLogger.info ("Setting up initial situation...")
+    self.initAccount ("domob", "r")
+    self.initAccount ("andy", "r")
+    self.generate (1)
+    self.build ("ancient1", None, {"x": 0, "y": 0}, 0)
+    self.build ("ancient1", "domob", {"x": 100, "y": 0}, 0)
+    ancient = 1001
+    domob = 1002
+    self.assertEqual (self.getBuildings ()[ancient].getOwner (), None)
+    self.assertEqual (self.getBuildings ()[domob].getOwner (), "domob")
+
+    self.dropIntoBuilding (ancient, "andy", {"foo": 3})
+    self.dropIntoBuilding (domob, "andy", {"foo": 3})
+    self.dropIntoBuilding (domob, "domob", {"foo": 3})
+
+    self.mainLogger.info ("Setting service fee...")
+    self.getBuildings ()[domob].sendMove ({"sf": 50})
+    self.generate (1)
+    self.assertEqual (self.getBuildings ()[domob].data["servicefee"], 50)
+
+    self.mainLogger.info ("Using 'free' services...")
+    self.giftCoins ({"domob": 10, "andy": 10})
+    self.sendMove ("andy", {"s": [
+      {"b": ancient, "t": "ref", "i": "foo", "n": 3},
+    ]})
+    self.sendMove ("domob", {"s": [
+      {"b": domob, "t": "ref", "i": "foo", "n": 3},
+    ]})
+    self.generate (1)
+    self.assertEqual (self.getAccounts ()["andy"].getBalance (), 0)
+    self.assertEqual (self.getAccounts ()["domob"].getBalance (), 0)
+    b = self.getBuildings ()
+    self.assertEqual (b[ancient].getFungibleInventory ("andy"), {
+      "bar": 2,
+      "zerospace": 1,
+    })
+    self.assertEqual (b[domob].getFungibleInventory ("domob"), {
+      "bar": 2,
+      "zerospace": 1,
+    })
+
+    self.mainLogger.info ("Using service with fee...")
+    self.giftCoins ({"andy": 20})
+    self.sendMove ("andy", {"s": [
+      {"b": domob, "t": "ref", "i": "foo", "n": 3},
+    ]})
+    self.generate (1)
+    self.assertEqual (self.getAccounts ()["andy"].getBalance (), 5)
+    self.assertEqual (self.getAccounts ()["domob"].getBalance (), 5)
+    b = self.getBuildings ()
+    self.assertEqual (b[domob].getFungibleInventory ("andy"), {
+      "bar": 2,
+      "zerospace": 1,
+    })
+
+
+if __name__ == "__main__":
+  ServicesFeesTest ().main ()

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -56,4 +56,11 @@ message Building
    */
   optional CombatData combat_data = 2;
 
+  /**
+   * The service fee that users need to pay to the building owner for using
+   * services in the building.  This is a percentage of the service's base
+   * fee (the burnt amount).
+   */
+  optional uint32 service_fee_percent = 3;
+
 }

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -345,6 +345,7 @@ template <>
 
   const auto& pb = b.GetProto ();
   res["rotationsteps"] = IntToJson (pb.shape_trafo ().rotation_steps ());
+  res["servicefee"] = IntToJson (pb.service_fee_percent ());
 
   Json::Value tiles(Json::arrayValue);
   for (const auto& c : GetBuildingShape (b))

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -685,6 +685,24 @@ TEST_F (BuildingJsonTests, Inventories)
   })");
 }
 
+TEST_F (BuildingJsonTests, ServiceFees)
+{
+  auto b = tbl.CreateNew ("checkmark", "daniel", Faction::RED);
+  ASSERT_EQ (b->GetId (), 1);
+  b->MutableProto ().set_service_fee_percent (42);
+  b.reset ();
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "servicefee": 42
+        }
+      ]
+  })");
+}
+
 TEST_F (BuildingJsonTests, CombatData)
 {
   ASSERT_EQ (tbl.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId (), 1);

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -223,6 +223,7 @@ BaseMoveProcessor::TryServiceOperations (const std::string& name,
   for (const auto& op : cmds)
     {
       auto parsed = ServiceOperation::Parse (*a, op, ctx,
+                                             accounts,
                                              buildings, buildingInv,
                                              characters);
       if (parsed != nullptr)

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -35,6 +35,13 @@
 namespace pxd
 {
 
+/**
+ * The maximum allowed service fee in a building.  The value is consensus
+ * relevant, as it affects move validation.  It is chosen to disallow
+ * "completely scam" buildings.
+ */
+static constexpr unsigned MAX_SERVICE_FEE_PERCENT = 1'000;
+
 /* ************************************************************************** */
 
 BaseMoveProcessor::BaseMoveProcessor (Database& d, const Context& c)
@@ -206,6 +213,74 @@ BaseMoveProcessor::TryCharacterUpdates (const std::string& name,
         }
 
       PerformCharacterUpdate (*c, entry.second);
+    }
+}
+
+void
+BaseMoveProcessor::TryBuildingUpdates (const std::string& name,
+                                       const Json::Value& mv)
+{
+  const auto& cmd = mv["b"];
+  if (!cmd.isObject ())
+    return;
+
+  /* The order in which building updates are processed may be relevant for
+     consensus, and we perform the update in order of increasing *numerical*
+     value of the ID (unlike the alphabetical value of the string keys).
+     This matches how character updates are processed.
+
+     Unlike characters, however, updates with ID lists are not necessary.  */
+
+  std::map<Database::IdT, Json::Value> updates;
+  for (auto i = cmd.begin (); i != cmd.end (); ++i)
+    {
+      Database::IdT id;
+      if (!IdFromString (i.name (), id))
+        {
+          LOG (WARNING)
+              << "Ignoring invalid building ID for update: " << i.name ();
+          continue;
+        }
+
+      const auto& upd = *i;
+      if (!upd.isObject ())
+        {
+          LOG (WARNING)
+              << "Building update is not an object: " << upd;
+          continue;
+        }
+
+      CHECK (updates.emplace (id, upd).second);
+    }
+
+  for (const auto& entry : updates)
+    {
+      auto b = buildings.GetById (entry.first);
+      if (b == nullptr)
+        {
+          LOG (WARNING)
+              << "Building ID does not exist: " << entry.first;
+          continue;
+        }
+
+      if (b->GetFaction () == Faction::ANCIENT)
+        {
+          LOG (WARNING)
+              << "User " << name
+              << " is not allowed to update ancient buildings";
+          continue;
+        }
+
+      if (b->GetOwner () != name)
+        {
+          LOG (WARNING)
+              << "User " << name
+              << " is not allowed to update building owned by "
+              << b->GetOwner ();
+          continue;
+        }
+
+      PerformBuildingUpdate (*b, entry.second);
     }
 }
 
@@ -731,6 +806,7 @@ MoveProcessor::ProcessOne (const Json::Value& moveObj)
   TryCharacterUpdates (name, mv);
   TryCharacterCreation (name, mv, paidToDev);
 
+  TryBuildingUpdates (name, mv);
   TryServiceOperations (name, mv);
 }
 
@@ -1084,6 +1160,41 @@ MoveProcessor::PerformCharacterUpdate (Character& c, const Json::Value& upd)
      than allowing to exit & enter again in the same move.  */
   MaybeEnterBuilding (c, upd);
   MaybeExitBuilding (c, upd);
+}
+
+namespace
+{
+
+/**
+ * Tries to perform a service-fee update in a building.
+ */
+void
+MaybeUpdateServiceFee (Building& b, const Json::Value& upd)
+{
+  if (!upd.isUInt64 ())
+    return;
+
+  const uint64_t val = upd.asUInt64 ();
+  if (val > MAX_SERVICE_FEE_PERCENT)
+    {
+      LOG (WARNING)
+          << "Service fee " << val << "% is too much for building "
+          << b.GetId () << " of " << b.GetOwner ();
+      return;
+    }
+
+  LOG (INFO)
+      << "Setting service fee for building " << b.GetId ()
+      << " to " << val << "%";
+  b.MutableProto ().set_service_fee_percent (val);
+}
+
+} // anonymous namespace
+
+void
+MoveProcessor::PerformBuildingUpdate (Building& b, const Json::Value& upd)
+{
+  MaybeUpdateServiceFee (b, upd["sf"]);
 }
 
 void

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -200,6 +200,14 @@ protected:
   void TryCharacterUpdates (const std::string& name, const Json::Value& mv);
 
   /**
+   * Parses and verifies potential building updates as part of a move
+   * by the building's owner.  This does some general verification and
+   * parsing, and calls through to PerformBuildingUpdates with the
+   * data per building that is valid.
+   */
+  void TryBuildingUpdates (const std::string& name, const Json::Value& mv);
+
+  /**
    * Parses and handles a potential move with requested service operations.
    * Each valid operation will be passed to PerformServiceOperation for
    * either execution or recording in the pending state.
@@ -220,6 +228,14 @@ protected:
    */
   virtual void
   PerformCharacterUpdate (Character& c, const Json::Value& upd)
+  {}
+
+  /**
+   * This function is called when TryBuildingUpdates found a valid update
+   * that should be performed.
+   */
+  virtual void
+  PerformBuildingUpdate (Building& b, const Json::Value& upd)
   {}
 
   /**
@@ -334,6 +350,7 @@ protected:
 
   void PerformCharacterCreation (const std::string& name, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& mv) override;
+  void PerformBuildingUpdate (Building& b, const Json::Value& mv) override;
   void PerformServiceOperation (ServiceOperation& op) override;
 
 public:

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -513,7 +513,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 3
-      })"), ctx, buildings, buildingInv, characters));
+      })"), ctx, accounts, buildings, buildingInv, characters));
   state.AddServiceOperation (*ServiceOperation::Parse (
       *accounts.GetByName ("andy"),
       ParseJson (R"({
@@ -521,7 +521,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 6
-      })"), ctx, buildings, buildingInv, characters));
+      })"), ctx, accounts, buildings, buildingInv, characters));
   state.AddServiceOperation (*ServiceOperation::Parse (
       *accounts.GetByName ("domob"),
       ParseJson (R"({
@@ -529,7 +529,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 9
-      })"), ctx, buildings, buildingInv, characters));
+      })"), ctx, accounts, buildings, buildingInv, characters));
 
   ExpectStateJson (R"(
     {

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -44,11 +44,24 @@ class ServiceOperation
 
 private:
 
+  /**
+   * Account table, which is needed to look up and modify the building owner
+   * account when fees are paid.
+   */
+  AccountsTable& accounts;
+
   /** The account triggering the service operation.  */
   Account& acc;
 
   /** The building in which the operation is happening.  */
   BuildingsTable::Handle building;
+
+  /**
+   * Computes the base and service cost.  The base cost is burnt (and defined
+   * by the service operation subclasses), while the service fee is sent
+   * to the building's owner and controlled by them.
+   */
+  void GetCosts (Amount& base, Amount& fee) const;
 
 protected:
 
@@ -60,8 +73,9 @@ protected:
 
   explicit ServiceOperation (Account& a, BuildingsTable::Handle b,
                              const Context& cx,
+                             AccountsTable& at,
                              BuildingInventoriesTable& i)
-    : acc(a), building(std::move (b)), ctx(cx), invTable(i)
+    : accounts(at), acc(a), building(std::move (b)), ctx(cx), invTable(i)
   {}
 
   /**
@@ -132,6 +146,7 @@ public:
   static std::unique_ptr<ServiceOperation> Parse (
       Account& acc, const Json::Value& data,
       const Context& ctx,
+      AccountsTable& accounts,
       BuildingsTable& buildings, BuildingInventoriesTable& inv,
       CharacterTable& characters);
 


### PR DESCRIPTION
This adds a fee for services, which is paid to the building owner in addition to the burnt amount of vCHI.  (Ancient buildings have no fee, nor do your own buildings.)

The owner of a building can configure the fee they want, as a percentage of the burnt "base cost".  Values can be chosen between 0% and 1'000% (10x the base cost) with a move like this:

    {"b": {"123": {"sf": 42}}}

This would set the service fee for building 123 to 42%.