### PR TITLE
Blueprints & research service

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -23,7 +23,7 @@ libdatabase_la_SOURCES = \
   faction.cpp \
   fighter.cpp \
   inventory.cpp \
-  prizes.cpp \
+  itemcounts.cpp \
   region.cpp \
   schema.cpp \
   target.cpp
@@ -39,8 +39,8 @@ noinst_HEADERS = \
   faction.hpp faction.tpp \
   fighter.hpp \
   inventory.hpp \
+  itemcounts.hpp \
   lazyproto.hpp lazyproto.tpp \
-  prizes.hpp \
   region.hpp \
   schema.hpp \
   target.hpp
@@ -84,8 +84,8 @@ tests_SOURCES = \
   faction_tests.cpp \
   fighter_tests.cpp \
   inventory_tests.cpp \
+  itemcounts_tests.cpp \
   lazyproto_tests.cpp \
-  prizes_tests.cpp \
   region_tests.cpp \
   schema_tests.cpp \
   target_tests.cpp

--- a/database/itemcounts.hpp
+++ b/database/itemcounts.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,8 +16,8 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DATABASE_PRIZES_HPP
-#define DATABASE_PRIZES_HPP
+#ifndef DATABASE_ITEMCOUNTS_HPP
+#define DATABASE_ITEMCOUNTS_HPP
 
 #include "database.hpp"
 
@@ -27,9 +27,9 @@ namespace pxd
 {
 
 /**
- * Wrapper class around the table of prospecting prizes in the database.
+ * Wrapper class around the table of item counts in the database.
  */
-class Prizes
+class ItemCounts
 {
 
 private:
@@ -39,21 +39,21 @@ private:
 
 public:
 
-  explicit Prizes (Database& d)
+  explicit ItemCounts (Database& d)
     : db(d)
   {}
 
-  Prizes () = delete;
-  Prizes (const Prizes&) = delete;
-  void operator= (const Prizes&) = delete;
+  ItemCounts () = delete;
+  ItemCounts (const ItemCounts&) = delete;
+  void operator= (const ItemCounts&) = delete;
 
   /**
-   * Query how many of a given prize have been found already.
+   * Query how many of a given item have been found already.
    */
   unsigned GetFound (const std::string& name);
 
   /**
-   * Increment the found counter of the given prize.
+   * Increment the found counter of the given item.
    */
   void IncrementFound (const std::string& name);
 
@@ -61,4 +61,4 @@ public:
 
 } // namespace pxd
 
-#endif // DATABASE_PRIZES_HPP
+#endif // DATABASE_ITEMCOUNTS_HPP

--- a/database/itemcounts_tests.cpp
+++ b/database/itemcounts_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "prizes.hpp"
+#include "itemcounts.hpp"
 
 #include "dbtest.hpp"
 
@@ -27,48 +27,50 @@ namespace pxd
 namespace
 {
 
-class PrizesTests : public DBTestWithSchema
+class ItemCountsTests : public DBTestWithSchema
 {
 
 protected:
 
-  /** Prizes instance for tests.  */
-  Prizes p;
+  ItemCounts cnt;
 
-  PrizesTests ()
-    : p(db)
+  ItemCountsTests ()
+    : cnt(db)
   {
     auto stmt = db.Prepare (R"(
-      INSERT INTO `prizes` (`name`, `found`) VALUES (?1, ?2)
+      INSERT INTO `item_counts`
+        (`name`, `found`)
+        VALUES (?1, ?2)
     )");
 
-    stmt.Bind<std::string> (1, "gold");
+    stmt.Bind<std::string> (1, "gold prize");
     stmt.Bind (2, 10);
     stmt.Execute ();
 
     stmt.Reset ();
-    stmt.Bind<std::string> (1, "silver");
-    stmt.Bind (2, 0);
+    stmt.Bind<std::string> (1, "bow bpo");
+    stmt.Bind (2, 3);
     stmt.Execute ();
   }
 
 };
 
-TEST_F (PrizesTests, GetFound)
+TEST_F (ItemCountsTests, GetFound)
 {
-  EXPECT_EQ (p.GetFound ("gold"), 10);
-  EXPECT_EQ (p.GetFound ("silver"), 0);
+  EXPECT_EQ (cnt.GetFound ("gold prize"), 10);
+  EXPECT_EQ (cnt.GetFound ("silver prize"), 0);
+  EXPECT_EQ (cnt.GetFound ("bow bpo"), 3);
 }
 
-TEST_F (PrizesTests, IncrementFound)
+TEST_F (ItemCountsTests, IncrementFound)
 {
-  p.IncrementFound ("gold");
-  EXPECT_EQ (p.GetFound ("gold"), 11);
-  EXPECT_EQ (p.GetFound ("silver"), 0);
+  cnt.IncrementFound ("gold prize");
+  EXPECT_EQ (cnt.GetFound ("gold prize"), 11);
+  EXPECT_EQ (cnt.GetFound ("silver prize"), 0);
 
-  p.IncrementFound ("silver");
-  EXPECT_EQ (p.GetFound ("gold"), 11);
-  EXPECT_EQ (p.GetFound ("silver"), 1);
+  cnt.IncrementFound ("silver prize");
+  EXPECT_EQ (cnt.GetFound ("gold prize"), 11);
+  EXPECT_EQ (cnt.GetFound ("silver prize"), 1);
 }
 
 } // anonymous namespace

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -296,14 +296,14 @@ CREATE INDEX IF NOT EXISTS `building_inventories_by_account`
 
 -- =============================================================================
 
--- Data about the still available prospecting prizes (so that we can
--- ensure only a certain number can be found).
-CREATE TABLE IF NOT EXISTS `prizes` (
+-- Data about counts of items found for a particular type already (for
+-- things where it matters, like prizes and blueprints).
+CREATE TABLE IF NOT EXISTS `item_counts` (
 
-  -- Name of the prize (as defined in the game params).
+  -- Name of the item type.
   `name` TEXT PRIMARY KEY,
 
-  -- Number of prizes found from this type already.
+  -- Number of items of this type found already.
   `found` INTEGER NOT NULL
 
 );

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -31,6 +31,7 @@ REGTESTS = \
   services_fees.py \
   services_refining.py \
   services_repair.py \
+  services_reveng.py \
   splitstaterpcs.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)

--- a/gametest/services_reveng.py
+++ b/gametest/services_reveng.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests basic reverse-engineering service operations.
+"""
+
+from pxtest import PXTest
+
+
+class ServicesRevEngTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.mainLogger.info ("Setting up initial situation...")
+    self.build ("ancient1", None, {"x": 0, "y": 0}, 0)
+    building = 1001
+    self.assertEqual (self.getBuildings ()[building].getType (), "ancient1")
+
+    self.initAccount ("domob", "r")
+    self.generate (1)
+    self.giftCoins ({"domob": 100})
+    self.dropIntoBuilding (building, "domob", {"test artefact": 10})
+
+    self.mainLogger.info ("Re-rolls of first reveng...")
+    trials = 10
+    # On regtest, the first reveng operation is guaranteed to succeed.
+    # If we keep undoing and redoing (fresh) blocks, we will always be in
+    # that situation; this ensures (among other things) that undoing the
+    # item counter works.
+    found = {}
+    self.sendMove ("domob", {"s": [{
+      "t": "rve",
+      "b": building,
+      "i": "test artefact",
+      "n": 1,
+    }]})
+    for _ in range (trials):
+      self.assertEqual (len (self.rpc.xaya.name_pending ("p/domob")), 1)
+      self.generate (1)
+      inv = self.getBuildings ()[building].getFungibleInventory ("domob")
+      for t, n in inv.iteritems ():
+        if t == "test artefact":
+          continue
+        self.assertEqual (n, 1)
+        if t not in found:
+          found[t] = 0
+        found[t] += 1
+      self.rpc.xaya.invalidateblock (self.rpc.xaya.getbestblockhash ())
+    self.assertEqual (set (found.keys ()), set (["bow bpo", "sword bpo"]))
+    self.assertEqual (found["bow bpo"] + found["sword bpo"], trials)
+    assert found["bow bpo"] > 0
+    assert found["sword bpo"] > 0
+
+    self.mainLogger.info ("Batched reverse engineering...")
+    # Note that we still have one operation already done from before.
+    self.sendMove ("domob", {"s": [
+      {"t": "rve", "b": building, "i": "test artefact", "n": 4},
+      {"t": "rve", "b": building, "i": "test artefact", "n": 5},
+    ]})
+    self.generate (1)
+    self.assertEqual (self.getAccounts ()["domob"].getBalance (), 0)
+    inv = self.getBuildings ()[building].getFungibleInventory ("domob")
+    self.assertEqual (set (inv.keys ()), set (["bow bpo", "sword bpo"]))
+    assert inv["bow bpo"] > 0
+    assert inv["sword bpo"] > 0
+    assert inv["bow bpo"] + inv["sword bpo"] < trials
+
+
+if __name__ == "__main__":
+  ServicesRevEngTest ().main ()

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -150,6 +150,7 @@ message BuildingData
   {
     optional bool refining = 1;
     optional bool armour_repair = 2;
+    optional bool reverse_engineering = 3;
   }
 
   /** Services this building type offers.  */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -23,6 +23,8 @@ import "geometry.proto";
 
 package pxd.proto;
 
+/* ************************************************************************** */
+
 /**
  * Hardcoded data defining a type of fungible item.
  */
@@ -56,7 +58,35 @@ message ItemData
   /** If this type of item can be refined, then the stats for doing so.  */
   optional RefiningData refines = 2;
 
+  /** Whether or not this item has an associated blueprint.  */
+  optional bool with_blueprint = 3;
+
+  /**
+   * Specific data for blueprint items defining the modalities for
+   * constructing stuff from it.
+   */
+  message BlueprintData
+  {
+
+    /** The item type constructed from the blueprint.  */
+    optional string for_item = 1;
+
+    /**
+     * Whether or not this is an original.  Originals can be copied and
+     * can be used an unlimited amount of time, whereas copies (if not
+     * originals) cannot be copied themselves and can only be used once
+     * to build an item.
+     */
+    optional bool original = 2;
+
+  }
+
+  /** If this is a blueprint, the associated data.  */
+  optional BlueprintData is_blueprint = 4;
+
 }
+
+/* ************************************************************************** */
 
 /**
  * Hardcoded data defining a type of building.
@@ -104,6 +134,8 @@ message BuildingData
 
 }
 
+/* ************************************************************************** */
+
 /**
  * Data for the resource distribution on the map (when prospecting).
  * This is based on multiple "areas" where one or two resources occur.
@@ -146,6 +178,8 @@ message ResourceDistribution
   repeated Area areas = 2;
 
 }
+
+/* ************************************************************************** */
 
 /**
  * The hardcoded "configuration data" for Taurion.  This includes all data

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -84,6 +84,29 @@ message ItemData
   /** If this is a blueprint, the associated data.  */
   optional BlueprintData is_blueprint = 4;
 
+  /**
+   * Data about the ability to reverse-engineer an item to obtain blueprints.
+   */
+  message RevEngData
+  {
+
+    /** Cost (in vCHI) for a reveng attempt.  */
+    optional uint32 cost = 1;
+
+    /**
+     * Types of items (most likely blueprint originals) that can be obtained
+     * from this through reverse engineering.
+     */
+    repeated string possible_outputs = 2;
+
+  }
+
+  /**
+   * If this can be reverse engineered (i.e. is an artefact), the configuration
+   * data specifying the corresponding stats.
+   */
+  optional RevEngData reveng = 5;
+
 }
 
 /* ************************************************************************** */

--- a/proto/roconfig/buildings/ancient1.pb.text
+++ b/proto/roconfig/buildings/ancient1.pb.text
@@ -8,6 +8,7 @@ building_types:
           {
             refining: true
             armour_repair: true
+            reverse_engineering: true
           }
         shape_tiles: { x: -13 y: -6 }
         shape_tiles: { x: -14 y: -5 }

--- a/proto/roconfig/buildings/ancient2.pb.text
+++ b/proto/roconfig/buildings/ancient2.pb.text
@@ -8,6 +8,7 @@ building_types:
           {
             refining: true
             armour_repair: true
+            reverse_engineering: true
           }
         shape_tiles: { x: -15 y: -14 }
         shape_tiles: { x: -29 y: 14 }

--- a/proto/roconfig/buildings/ancient3.pb.text
+++ b/proto/roconfig/buildings/ancient3.pb.text
@@ -8,6 +8,7 @@ building_types:
           {
             refining: true
             armour_repair: true
+            reverse_engineering: true
           }
         shape_tiles: { x: -19 y: -1 }
         shape_tiles: { x: -21 y: 0 }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -53,7 +53,7 @@ fungible_items:
 
 fungible_items:
   {
-    key: "test aretefact"
+    key: "test artefact"
     value:
       {
         space: 0,

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -1,22 +1,7 @@
-#   GSP for the Taurion blockchain game
-#   Copyright (C) 2019  Autonomous Worlds Ltd
-#
-#   This program is free software: you can redistribute it and/or modify
-#   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation, either version 3 of the License, or
-#   (at your option) any later version.
-#
-#   This program is distributed in the hope that it will be useful,
-#   but WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#   GNU General Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License
-#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 # The following items are used only for tests.  They are defined also
 # in the real game, but since they are never generated (except through
 # god-mode or direct intervention in tests), that has no effect.
+
 fungible_items:
   {
     key: "foo"
@@ -32,13 +17,27 @@ fungible_items:
           }
       }
   }
+
 fungible_items:
   {
     key: "bar"
     value: { space: 20 }
   }
+
 fungible_items:
   {
     key: "zerospace"
     value: { space: 0 }
+  }
+
+# This one is a dummy "weapon" that can be equipped and constructed
+# from a dummy blueprint for testing purposes.
+fungible_items:
+  {
+    key: "bow"
+    value:
+      {
+        space: 1,
+        with_blueprint: true
+      }
   }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -30,8 +30,8 @@ fungible_items:
     value: { space: 0 }
   }
 
-# This one is a dummy "weapon" that can be equipped and constructed
-# from a dummy blueprint for testing purposes.
+# These ones are dummy "weapons" that can be equipped and constructed
+# from dummy blueprints for testing purposes.
 fungible_items:
   {
     key: "bow"
@@ -39,5 +39,29 @@ fungible_items:
       {
         space: 1,
         with_blueprint: true
+      }
+  }
+fungible_items:
+  {
+    key: "sword"
+    value:
+      {
+        space: 1,
+        with_blueprint: true
+      }
+  }
+
+fungible_items:
+  {
+    key: "test aretefact"
+    value:
+      {
+        space: 0,
+        reveng:
+          {
+            cost: 10
+            possible_outputs: "bow bpo"
+            possible_outputs: "sword bpo"
+          }
       }
   }

--- a/proto/roitems.cpp
+++ b/proto/roitems.cpp
@@ -16,21 +16,118 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "roitems.hpp"
+
 #include "roconfig.hpp"
 
 #include <glog/logging.h>
 
+#include <map>
+#include <memory>
+
 namespace pxd
 {
+
+namespace
+{
+
+/** Suffix for original blueprints.  */
+constexpr const char* SUFFIX_BP_ORIGINAL = " bpo";
+/** Suffix for blueprint copies.  */
+constexpr const char* SUFFIX_BP_COPY = " bpc";
+
+/**
+ * Global cache for constructed item data, where we have already done so.
+ * Entries are always added to this map and never removed / destructed
+ * during the entire runtime.  We store pointers rather than instances
+ * so that references remain valid no matter what happens to the map.
+ */
+std::unordered_map<std::string, const proto::ItemData*> constructedItems;
+
+/**
+ * Tries to strip the given suffix of an item name, and then look up the base
+ * item data.  Returns that data if it exists and the suffix is there, and
+ * returns null if either the string does not have that suffix of the base item
+ * does not exist.
+ *
+ * If the base item exists and the suffix is there, also the name of the base
+ * item (i.e. string without suffix) is returned in baseName for further use.
+ */
+const proto::ItemData*
+LookupBase (const std::string& str, const std::string& suffix,
+            std::string& baseName)
+{
+  if (str.size () < suffix.size ())
+    return nullptr;
+
+  const size_t baseLen = str.size () - suffix.size ();
+  if (str.substr (baseLen) != suffix)
+    return nullptr;
+
+  baseName = str.substr (0, baseLen);
+  return RoItemDataOrNull (baseName);
+}
+
+/**
+ * Tries to construct the item data for the given type.  This returns null
+ * if the item type string does not correspond to a valid constructed item,
+ * and otherwise a fresh instance of the item data.
+ */
+std::unique_ptr<const proto::ItemData>
+ConstructItemData (const std::string& item)
+{
+  std::string baseName;
+  const proto::ItemData* base;
+
+  base = LookupBase (item, SUFFIX_BP_ORIGINAL, baseName);
+  if (base != nullptr && base->with_blueprint ())
+    {
+      auto res = std::make_unique<proto::ItemData> ();
+      res->set_space (0);
+      auto* bp = res->mutable_is_blueprint ();
+      bp->set_for_item (baseName);
+      bp->set_original (true);
+      return res;
+    }
+
+  base = LookupBase (item, SUFFIX_BP_COPY, baseName);
+  if (base != nullptr && base->with_blueprint ())
+    {
+      auto res = std::make_unique<proto::ItemData> ();
+      res->set_space (0);
+      auto* bp = res->mutable_is_blueprint ();
+      bp->set_for_item (baseName);
+      bp->set_original (false);
+      return res;
+    }
+
+  return nullptr;
+}
+
+} // anonymous namespace
 
 const proto::ItemData*
 RoItemDataOrNull (const std::string& item)
 {
-  const auto& data = RoConfigData ().fungible_items ();
-  const auto mit = data.find (item);
-  if (mit != data.end ())
-    return &mit->second;
-  return nullptr;
+  {
+    const auto mit = constructedItems.find (item);
+    if (mit != constructedItems.end ())
+      return mit->second;
+  }
+
+  {
+    const auto& baseData = RoConfigData ().fungible_items ();
+    const auto mit = baseData.find (item);
+    if (mit != baseData.end ())
+      return &mit->second;
+  }
+
+  auto newData = ConstructItemData (item);
+  if (newData == nullptr)
+    return nullptr;
+
+  CHECK (constructedItems.emplace (item, newData.get ()).second);
+  return newData.release ();
 }
 
 const proto::ItemData&

--- a/proto/roitems_tests.cpp
+++ b/proto/roitems_tests.cpp
@@ -33,5 +33,27 @@ TEST (RoItemsTests, BasicItem)
   EXPECT_EQ (RoItemDataOrNull ("invalid item"), nullptr);
 }
 
+TEST (RoItemsTests, Blueprints)
+{
+  EXPECT_EQ (RoItemDataOrNull ("bpo"), nullptr);
+  EXPECT_EQ (RoItemDataOrNull ("bowbpo"), nullptr);
+  EXPECT_EQ (RoItemDataOrNull ("bow bpo "), nullptr);
+
+  EXPECT_EQ (RoItemDataOrNull ("foo bpo"), nullptr);
+  EXPECT_EQ (RoItemDataOrNull ("foo bpc"), nullptr);
+
+  const auto& orig = RoItemData ("bow bpo");
+  ASSERT_TRUE (orig.has_is_blueprint ());
+  EXPECT_EQ (orig.space (), 0);
+  EXPECT_EQ (orig.is_blueprint ().for_item (), "bow");
+  EXPECT_TRUE (orig.is_blueprint ().original ());
+
+  const auto& copy = RoItemData ("bow bpc");
+  ASSERT_TRUE (copy.has_is_blueprint ());
+  EXPECT_EQ (copy.space (), 0);
+  EXPECT_EQ (copy.is_blueprint ().for_item (), "bow");
+  EXPECT_FALSE (copy.is_blueprint ().original ());
+}
+
 } // anonymous namespace
 } // namespace pxd

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -26,7 +26,7 @@
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/faction.hpp"
-#include "database/prizes.hpp"
+#include "database/itemcounts.hpp"
 #include "database/region.hpp"
 #include "hexagonal/pathfinder.hpp"
 #include "proto/character.pb.h"
@@ -428,7 +428,7 @@ template <typename T, typename R>
 Json::Value
 GameStateJson::PrizeStats ()
 {
-  Prizes prizeTable(db);
+  ItemCounts cnt(db);
 
   Json::Value res(Json::objectValue);
   for (const auto& p : params.ProspectingPrizes ())
@@ -437,7 +437,7 @@ GameStateJson::PrizeStats ()
       cur["number"] = p.number;
       cur["probability"] = p.probability;
 
-      const unsigned found = prizeTable.GetFound (p.name);
+      const unsigned found = cnt.GetFound (p.name + " prize");
       CHECK_LE (found, p.number);
 
       cur["found"] = found;

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -18,7 +18,6 @@
 
 #include "gamestatejson.hpp"
 
-#include "prospecting.hpp"
 #include "protoutils.hpp"
 #include "testutils.hpp"
 
@@ -27,7 +26,7 @@
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
 #include "database/inventory.hpp"
-#include "database/prizes.hpp"
+#include "database/itemcounts.hpp"
 #include "database/region.hpp"
 #include "proto/character.pb.h"
 #include "proto/region.pb.h"
@@ -63,9 +62,7 @@ protected:
 
   GameStateJsonTests ()
     : params(xaya::Chain::MAIN), converter(db, params, map)
-  {
-    InitialisePrizes (db, params);
-  }
+  {}
 
   /**
    * Expects that the current state matches the given one, after parsing
@@ -910,19 +907,19 @@ class PrizesJsonTests : public GameStateJsonTests
 
 protected:
 
-  Prizes tbl;
+  ItemCounts cnt;
 
   PrizesJsonTests ()
-    : tbl(db)
+    : cnt(db)
   {}
 
 };
 
 TEST_F (PrizesJsonTests, Works)
 {
-  tbl.IncrementFound ("gold");
+  cnt.IncrementFound ("gold prize");
   for (unsigned i = 0; i < 10; ++i)
-    tbl.IncrementFound ("bronze");
+    cnt.IncrementFound ("bronze prize");
 
   ExpectStateJson (R"({
     "prizes":

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -183,7 +183,6 @@ PXLogic::InitialiseState (xaya::SQLiteDatabase& db)
   SQLiteGameDatabase dbObj(db, *this);
   const Params params(GetChain ());
 
-  InitialisePrizes (dbObj, params);
   InitialiseBuildings (dbObj);
 
   /* The initialisation uses up some auto IDs, namely for placed buildings.

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -20,7 +20,6 @@
 
 #include "fame_tests.hpp"
 #include "params.hpp"
-#include "prospecting.hpp"
 #include "protoutils.hpp"
 #include "testutils.hpp"
 
@@ -80,9 +79,7 @@ protected:
   PXLogicTests ()
     : accounts(db), buildings(db), characters(db),
       inv(db), groundLoot(db), regions(db, HEIGHT)
-  {
-    InitialisePrizes (db, ctx.Params ());
-  }
+  {}
 
   /**
    * Builds a blockData JSON value from the given moves (JSON serialised

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -48,7 +48,8 @@ static constexpr unsigned MAX_SERVICE_FEE_PERCENT = 1'000;
 BaseMoveProcessor::BaseMoveProcessor (Database& d, const Context& c)
   : ctx(c), db(d),
     accounts(db), buildings(db), characters(db),
-    groundLoot(db), buildingInv(db), regions(db, ctx.Height ())
+    groundLoot(db), buildingInv(db), itemCounts(db),
+    regions(db, ctx.Height ())
 {}
 
 bool
@@ -301,7 +302,7 @@ BaseMoveProcessor::TryServiceOperations (const std::string& name,
       auto parsed = ServiceOperation::Parse (*a, op, ctx,
                                              accounts,
                                              buildings, buildingInv,
-                                             characters);
+                                             characters, itemCounts);
       if (parsed != nullptr)
         PerformServiceOperation (*parsed);
     }
@@ -1196,7 +1197,7 @@ MoveProcessor::PerformBuildingUpdate (Building& b, const Json::Value& upd)
 void
 MoveProcessor::PerformServiceOperation (ServiceOperation& op)
 {
-  op.Execute ();
+  op.Execute (rnd);
 }
 
 namespace

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -29,6 +29,7 @@
 #include "database/character.hpp"
 #include "database/database.hpp"
 #include "database/inventory.hpp"
+#include "database/itemcounts.hpp"
 #include "database/region.hpp"
 #include "mapdata/basemap.hpp"
 
@@ -114,6 +115,9 @@ protected:
 
   /** Access handle for building inventories.  */
   BuildingInventoriesTable buildingInv;
+
+  /** Item counts table.  */
+  ItemCounts itemCounts;
 
   /** Access to the regions table.  */
   RegionsTable regions;

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -145,6 +145,12 @@ public:
   Amount ArmourRepairCostMillis () const;
 
   /**
+   * Returns the chance for reverse-engineering success (as N in 1/N) based
+   * on the already existing number of blueprints.
+   */
+  unsigned RevEngSuccessChance (unsigned existingBp) const;
+
+  /**
    * Returns the spawn centre and radius for the given faction.
    */
   HexCoord SpawnArea (Faction f, HexCoord::IntT& radius) const;

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -25,6 +25,7 @@
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
+#include "database/itemcounts.hpp"
 #include "database/region.hpp"
 
 #include <gtest/gtest.h>
@@ -49,12 +50,14 @@ protected:
   BuildingsTable buildings;
   BuildingInventoriesTable buildingInv;
   CharacterTable characters;
+  ItemCounts itemCounts;
   RegionsTable regions;
 
   PendingStateTests ()
     : accounts(db),
       buildings(db), buildingInv(db),
       characters(db),
+      itemCounts(db),
       regions(db, 1'042)
   {}
 
@@ -513,7 +516,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 3
-      })"), ctx, accounts, buildings, buildingInv, characters));
+      })"), ctx, accounts, buildings, buildingInv, characters, itemCounts));
   state.AddServiceOperation (*ServiceOperation::Parse (
       *accounts.GetByName ("andy"),
       ParseJson (R"({
@@ -521,7 +524,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 6
-      })"), ctx, accounts, buildings, buildingInv, characters));
+      })"), ctx, accounts, buildings, buildingInv, characters, itemCounts));
   state.AddServiceOperation (*ServiceOperation::Parse (
       *accounts.GetByName ("domob"),
       ParseJson (R"({
@@ -529,7 +532,7 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 9
-      })"), ctx, accounts, buildings, buildingInv, characters));
+      })"), ctx, accounts, buildings, buildingInv, characters, itemCounts));
 
   ExpectStateJson (R"(
     {

--- a/src/prospecting.hpp
+++ b/src/prospecting.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -31,12 +31,6 @@
 
 namespace pxd
 {
-
-/**
- * Fills in the initial data for the prizes table from the prizes defined
- * in the game parameters.
- */
-void InitialisePrizes (Database& db, const Params& params);
 
 /**
  * Checks if the given region can be prospected by the given character

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -21,7 +21,7 @@
 #include "testutils.hpp"
 
 #include "database/dbtest.hpp"
-#include "database/prizes.hpp"
+#include "database/itemcounts.hpp"
 #include "hexagonal/coord.hpp"
 #include "proto/roitems.hpp"
 
@@ -128,7 +128,6 @@ protected:
     : characters(db), regions(db, 1'042)
   {
     ctx.SetChain (xaya::Chain::REGTEST);
-    InitialisePrizes (db, ctx.Params ());
 
     const auto h = characters.CreateNew ("domob", Faction::RED);
     CHECK_EQ (h->GetId (), 1);
@@ -251,11 +250,11 @@ TEST_F (FinishProspectingTests, Prizes)
     }
   c.reset ();
 
-  Prizes prizeTable(db);
+  ItemCounts cnt(db);
   for (const auto& p : ctx.Params ().ProspectingPrizes ())
     {
       LOG (INFO) << "Found for prize " << p.name << ": " << foundMap[p.name];
-      EXPECT_EQ (prizeTable.GetFound (p.name), foundMap[p.name]);
+      EXPECT_EQ (cnt.GetFound (p.name + " prize"), foundMap[p.name]);
     }
 
   /* We should have found all gold prizes (since there are only a few),
@@ -280,8 +279,8 @@ TEST_F (FinishProspectingTests, FewerPrizesInCentre)
   for (unsigned i = 0; i < trials; ++i)
     ProspectAndClear (characters.GetById (id), POS_LOW_PRIZES);
 
-  Prizes prizeTable(db);
-  const auto silver = prizeTable.GetFound ("silver");
+  ItemCounts cnt(db);
+  const auto silver = cnt.GetFound ("silver prize");
   LOG (INFO) << "Found silver prizes in low-chance area: " << silver;
   /* Expected value is 550.  */
   EXPECT_GE (silver, 500);

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -39,14 +39,15 @@ private:
   const Context& ctx;
   AccountsTable& accounts;
   BuildingInventoriesTable& invTable;
+  ItemCounts& cnt;
 
   friend class ServiceOperation;
 
 public:
 
   explicit ContextRefs (const Context& c, AccountsTable& a,
-                        BuildingInventoriesTable& i)
-    : ctx(c), accounts(a), invTable(i)
+                        BuildingInventoriesTable& i, ItemCounts& ic)
+    : ctx(c), accounts(a), invTable(i), cnt(ic)
   {}
 
   ContextRefs () = delete;
@@ -106,7 +107,7 @@ protected:
 
   bool IsValid () const override;
   Json::Value SpecificToPendingJson () const override;
-  void ExecuteSpecific () override;
+  void ExecuteSpecific (xaya::Random& rnd) override;
 
 public:
 
@@ -208,7 +209,7 @@ RefiningOperation::SpecificToPendingJson () const
 }
 
 void
-RefiningOperation::ExecuteSpecific ()
+RefiningOperation::ExecuteSpecific (xaya::Random& rnd)
 {
   const auto buildingId = GetBuilding ().GetId ();
   const auto& name = GetAccount ().GetName ();
@@ -284,7 +285,7 @@ protected:
   bool IsValid () const override;
   Amount GetBaseCost () const override;
   Json::Value SpecificToPendingJson () const override;
-  void ExecuteSpecific () override;
+  void ExecuteSpecific (xaya::Random& rnd) override;
 
 public:
 
@@ -379,7 +380,7 @@ RepairOperation::SpecificToPendingJson () const
 }
 
 void
-RepairOperation::ExecuteSpecific ()
+RepairOperation::ExecuteSpecific (xaya::Random& rnd)
 {
   LOG (INFO) << "Character " << ch->GetId () << " is repairing their armour";
 
@@ -412,12 +413,196 @@ RepairOperation::Parse (Account& acc, BuildingsTable::Handle b,
 
 /* ************************************************************************** */
 
+/**
+ * A reverse engineering operation (artefacts to blueprints).
+ */
+class RevEngOperation : public ServiceOperation
+{
+
+private:
+
+  /** The type of artefact being reverse engineered.  */
+  const std::string type;
+
+  /** The number of artefacts to reverse engineer in this operation.  */
+  const Inventory::QuantityT num;
+
+  /**
+   * The reveng data for the artefact type.  May be null if the item
+   * type is invalid or it can't be refined.
+   */
+  const proto::ItemData::RevEngData* revEngData;
+
+protected:
+
+  bool
+  IsSupported (const Building& b) const override
+  {
+    return b.RoConfigData ().offered_services ().reverse_engineering ();
+  }
+
+  Amount
+  GetBaseCost () const override
+  {
+    return Inventory::Product (num, revEngData->cost ());
+  }
+
+  bool IsValid () const override;
+  Json::Value SpecificToPendingJson () const override;
+  void ExecuteSpecific (xaya::Random& rnd) override;
+
+public:
+
+  explicit RevEngOperation (Account& a, BuildingsTable::Handle b,
+                            const std::string& t,
+                            const Inventory::QuantityT n,
+                            const ContextRefs& refs);
+
+  /**
+   * Tries to parse a reveng operation from the corresponding JSON move.
+   * Returns a possibly invalid RevEngOperation instance or null if parsing
+   * fails.
+   */
+  static std::unique_ptr<RevEngOperation> Parse (Account& acc,
+                                                 BuildingsTable::Handle b,
+                                                 const Json::Value& data,
+                                                 const ContextRefs& refs);
+
+};
+
+RevEngOperation::RevEngOperation (Account& a, BuildingsTable::Handle b,
+                                  const std::string& t,
+                                  const Inventory::QuantityT n,
+                                  const ContextRefs& refs)
+  : ServiceOperation(a, std::move (b), refs),
+    type(t), num(n)
+{
+  const auto* itemData = RoItemDataOrNull (type);
+  if (itemData == nullptr)
+    {
+      LOG (WARNING) << "Can't reveng invalid item type " << type;
+      revEngData = nullptr;
+      return;
+    }
+
+  if (!itemData->has_reveng ())
+    {
+      LOG (WARNING) << "Item type " << type << " can't be reveng'ed";
+      revEngData = nullptr;
+      return;
+    }
+
+  revEngData = &itemData->reveng ();
+}
+
+bool
+RevEngOperation::IsValid () const
+{
+  if (revEngData == nullptr)
+    return false;
+
+  if (num <= 0)
+    return false;
+
+  const auto buildingId = GetBuilding ().GetId ();
+  const auto& name = GetAccount ().GetName ();
+
+  const auto inv = invTable.Get (buildingId, name);
+  const auto balance = inv->GetInventory ().GetFungibleCount (type);
+  if (num > balance)
+    {
+      LOG (WARNING)
+          << "Can't reveng " << num << " " << type
+          << " as balance of " << name << " in building " << buildingId
+          << " is only " << balance;
+      return false;
+    }
+
+  return true;
+}
+
+Json::Value
+RevEngOperation::SpecificToPendingJson () const
+{
+  Json::Value res(Json::objectValue);
+  res["type"] = "reveng";
+
+  Json::Value inp(Json::objectValue);
+  inp[type] = IntToJson (num);
+  res["input"] = inp;
+
+  return res;
+}
+
+void
+RevEngOperation::ExecuteSpecific (xaya::Random& rnd)
+{
+  const auto buildingId = GetBuilding ().GetId ();
+  const auto& name = GetAccount ().GetName ();
+
+  LOG (INFO)
+      << name << " in building " << buildingId
+      << " reverse engineers " << num << " " << type;
+
+  auto invHandle = invTable.Get (buildingId, name);
+  auto& inv = invHandle->GetInventory ();
+  inv.AddFungibleCount (type, -num);
+
+  const size_t numOptions = revEngData->possible_outputs_size ();
+  CHECK_GT (numOptions, 0);
+
+  for (unsigned trial = 0; trial < num; ++trial)
+    {
+      const size_t chosenOption = rnd.NextInt (numOptions);
+      const std::string outType = revEngData->possible_outputs (chosenOption);
+
+      const unsigned existingCount = itemCounts.GetFound (outType);
+      const unsigned chance = ctx.Params ().RevEngSuccessChance (existingCount);
+      const bool success = rnd.ProbabilityRoll (1, chance);
+      LOG (INFO)
+          << "Chosen output type " << outType
+          << " has chance 1 / " << chance
+          << "; success = " << success;
+
+      if (success)
+        {
+          inv.AddFungibleCount (outType, 1);
+          itemCounts.IncrementFound (outType);
+        }
+    }
+}
+
+std::unique_ptr<RevEngOperation>
+RevEngOperation::Parse (Account& acc, BuildingsTable::Handle b,
+                        const Json::Value& data,
+                        const ContextRefs& refs)
+{
+  CHECK (data.isObject ());
+  if (data.size () != 4)
+    return nullptr;
+
+  const auto& type = data["i"];
+  if (!type.isString ())
+    return nullptr;
+
+  const auto& num = data["n"];
+  if (!num.isUInt64 ())
+    return nullptr;
+
+  return std::make_unique<RevEngOperation> (acc, std::move (b),
+                                            type.asString (),
+                                            num.asUInt64 (),
+                                            refs);
+}
+
+/* ************************************************************************** */
+
 } // anonymous namespace
 
 ServiceOperation::ServiceOperation (Account& a, BuildingsTable::Handle b,
                                     const ContextRefs& refs)
   : accounts(refs.accounts), acc(a), building(std::move (b)),
-    ctx(refs.ctx), invTable(refs.invTable)
+    ctx(refs.ctx), invTable(refs.invTable), itemCounts(refs.cnt)
 {}
 
 void
@@ -463,7 +648,7 @@ ServiceOperation::ToPendingJson () const
 }
 
 void
-ServiceOperation::Execute ()
+ServiceOperation::Execute (xaya::Random& rnd)
 {
   Amount base, fee;
   GetCosts (base, fee);
@@ -478,7 +663,7 @@ ServiceOperation::Execute ()
       owner->AddBalance (fee);
     }
 
-  ExecuteSpecific ();
+  ExecuteSpecific (rnd);
 }
 
 std::unique_ptr<ServiceOperation>
@@ -487,7 +672,8 @@ ServiceOperation::Parse (Account& acc, const Json::Value& data,
                          AccountsTable& accounts,
                          BuildingsTable& buildings,
                          BuildingInventoriesTable& inv,
-                         CharacterTable& characters)
+                         CharacterTable& characters,
+                         ItemCounts& cnt)
 {
   if (!data.isObject ())
     {
@@ -519,12 +705,14 @@ ServiceOperation::Parse (Account& acc, const Json::Value& data,
     }
   const std::string type = typeVal.asString ();
 
-  const ContextRefs refs(ctx, accounts, inv);
+  const ContextRefs refs(ctx, accounts, inv, cnt);
   std::unique_ptr<ServiceOperation> op;
   if (type == "ref")
     op = RefiningOperation::Parse (acc, std::move (b), data, refs);
   else if (type == "fix")
     op = RepairOperation::Parse (acc, std::move (b), data, refs, characters);
+  else if (type == "rve")
+    op = RevEngOperation::Parse (acc, std::move (b), data, refs);
   else
     {
       LOG (WARNING) << "Unknown service operation: " << type;

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -65,6 +65,13 @@ private:
 
 protected:
 
+  /**
+   * Utility class that wraps all database table and context references
+   * needed to construct a ServiceOperation instance, so we can easily pass
+   * them around without ever-growing argument lists.
+   */
+  class ContextRefs;
+
   /** Context for parameters and such.  */
   const Context& ctx;
 
@@ -72,11 +79,7 @@ protected:
   BuildingInventoriesTable& invTable;
 
   explicit ServiceOperation (Account& a, BuildingsTable::Handle b,
-                             const Context& cx,
-                             AccountsTable& at,
-                             BuildingInventoriesTable& i)
-    : accounts(at), acc(a), building(std::move (b)), ctx(cx), invTable(i)
-  {}
+                             const ContextRefs& refs);
 
   /**
    * Returns true if the service is supported by the given building.

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -26,6 +26,9 @@
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/inventory.hpp"
+#include "database/itemcounts.hpp"
+
+#include <xayautil/random.hpp>
 
 #include <json/json.h>
 
@@ -78,6 +81,9 @@ protected:
   /** Database handle for upating building inventories (e.g. for refining).  */
   BuildingInventoriesTable& invTable;
 
+  /** Database handle for item-count tables.  */
+  ItemCounts& itemCounts;
+
   explicit ServiceOperation (Account& a, BuildingsTable::Handle b,
                              const ContextRefs& refs);
 
@@ -101,7 +107,7 @@ protected:
    * Executes the subclass-specific part of this operation, which is all updates
    * except for the vCHI cost.
    */
-  virtual void ExecuteSpecific () = 0;
+  virtual void ExecuteSpecific (xaya::Random& rnd) = 0;
 
   /**
    * Converts the subclass-specific data of this operation (not including
@@ -140,7 +146,7 @@ public:
   /**
    * Fully executes the update corresponding to this operation.
    */
-  void Execute ();
+  void Execute (xaya::Random& rnd);
 
   /**
    * Tries to parse a service operation from JSON move data.  Returns nullptr
@@ -151,7 +157,8 @@ public:
       const Context& ctx,
       AccountsTable& accounts,
       BuildingsTable& buildings, BuildingInventoriesTable& inv,
-      CharacterTable& characters);
+      CharacterTable& characters,
+      ItemCounts& cnt);
 
 };
 


### PR DESCRIPTION
This adds "blueprints" and "artefacts" as a concept (with just some fake test items defined, no real ones or stats yet).  Also a new service allows reverse-engineering artefacts.  Doing so has a small chance of turning them into a blueprint (randomly chosen from a set of eligible ones).  The chance decreases with a factor of 75% for each blueprint of a given type found already in the game.

To request the new service, the move data is similar to refining:

    {"s": [{"t": "rve", "b": 123, "i": "artefact", "n": 2}]}