### PR TITLE
Generalise ongoing operations

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -24,6 +24,7 @@ libdatabase_la_SOURCES = \
   fighter.cpp \
   inventory.cpp \
   itemcounts.cpp \
+  ongoing.cpp \
   region.cpp \
   schema.cpp \
   target.cpp
@@ -40,6 +41,7 @@ noinst_HEADERS = \
   fighter.hpp \
   inventory.hpp \
   itemcounts.hpp \
+  ongoing.hpp \
   lazyproto.hpp lazyproto.tpp \
   region.hpp \
   schema.hpp \
@@ -86,6 +88,7 @@ tests_SOURCES = \
   inventory_tests.cpp \
   itemcounts_tests.cpp \
   lazyproto_tests.cpp \
+  ongoing_tests.cpp \
   region_tests.cpp \
   schema_tests.cpp \
   target_tests.cpp

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -32,21 +32,6 @@ namespace
 
 using testing::ElementsAre;
 
-/**
- * Sets the busy field of a character to the given value.  Makes sure to
- * add a prospection operation (or remove it) as necessary to make the
- * state consistent.
- */
-void
-SetBusy (Character& c, const unsigned val)
-{
-  c.SetBusy (val);
-  if (val == 0)
-    c.MutableProto ().clear_prospection ();
-  else
-    c.MutableProto ().mutable_prospection ();
-}
-
 /* ************************************************************************** */
 
 class CharacterTests : public DBTestWithSchema
@@ -73,7 +58,6 @@ TEST_F (CharacterTests, Creation)
   c->SetEnterBuilding (10);
   c->MutableHP ().set_armour (10);
   c->MutableRegenData ().set_shield_regeneration_mhp (1234);
-  SetBusy (*c, 42);
   c.reset ();
 
   c = tbl.CreateNew ("domob", Faction::GREEN);
@@ -94,7 +78,6 @@ TEST_F (CharacterTests, Creation)
   EXPECT_EQ (c->GetEnterBuilding (), 10);
   EXPECT_EQ (c->GetHP ().armour (), 10);
   EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 1234);
-  EXPECT_EQ (c->GetBusy (), 42);
   EXPECT_FALSE (c->GetProto ().has_movement ());
 
   ASSERT_TRUE (res.Step ());
@@ -106,7 +89,6 @@ TEST_F (CharacterTests, Creation)
   EXPECT_EQ (c->GetBuildingId (), 100);
   EXPECT_EQ (c->GetEnterBuilding (), Database::EMPTY_ID);
   EXPECT_FALSE (c->GetRegenData ().has_shield_regeneration_mhp ());
-  EXPECT_EQ (c->GetBusy (), 0);
   EXPECT_TRUE (c->GetProto ().has_movement ());
 
   ASSERT_FALSE (res.Step ());
@@ -125,7 +107,7 @@ TEST_F (CharacterTests, ModificationWithProto)
   EXPECT_EQ (c->GetPosition (), HexCoord (0, 0));
   EXPECT_FALSE (c->GetVolatileMv ().has_partial_step ());
   EXPECT_FALSE (c->GetHP ().has_shield ());
-  EXPECT_EQ (c->GetBusy (), 0);
+  EXPECT_FALSE (c->IsBusy ());
   ASSERT_FALSE (res.Step ());
 
   c->SetOwner ("andy");
@@ -133,7 +115,7 @@ TEST_F (CharacterTests, ModificationWithProto)
   c->MutableVolatileMv ().set_partial_step (10);
   c->MutableHP ().set_shield (5);
   c->MutableRegenData ().set_shield_regeneration_mhp (1234);
-  SetBusy (*c, 42);
+  c->MutableProto ().set_ongoing (105);
   c.reset ();
 
   res = tbl.QueryAll ();
@@ -145,7 +127,7 @@ TEST_F (CharacterTests, ModificationWithProto)
   EXPECT_EQ (c->GetVolatileMv ().partial_step (), 10);
   EXPECT_EQ (c->GetHP ().shield (), 5);
   EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 1234);
-  EXPECT_EQ (c->GetBusy (), 42);
+  EXPECT_TRUE (c->IsBusy ());
   ASSERT_FALSE (res.Step ());
 }
 
@@ -153,14 +135,9 @@ TEST_F (CharacterTests, ModificationFieldsOnly)
 {
   const HexCoord pos(-2, 5);
 
-  /* When we set the busy value using SetBusy, the proto gets modified.
-     Only once we have the prospection proto set, we can modify the busy
-     value without touching the proto.  Thus set up a non-zero value here
-     and later modify just the value.  */
   auto c = tbl.CreateNew ("domob", Faction::RED);
   const auto id = c->GetId ();
   c->SetBuildingId (100);
-  SetBusy (*c, 100);
   c.reset ();
 
   c = tbl.GetById (id);
@@ -170,7 +147,6 @@ TEST_F (CharacterTests, ModificationFieldsOnly)
   c->SetEnterBuilding (42);
   c->MutableVolatileMv ().set_partial_step (24);
   c->MutableHP ().set_shield (5);
-  c->SetBusy (42);
   c.reset ();
 
   c = tbl.GetById (id);
@@ -182,7 +158,6 @@ TEST_F (CharacterTests, ModificationFieldsOnly)
   EXPECT_EQ (c->GetEnterBuilding (), 42);
   EXPECT_EQ (c->GetVolatileMv ().partial_step (), 24);
   EXPECT_EQ (c->GetHP ().shield (), 5);
-  EXPECT_EQ (c->GetBusy (), 42);
 
   c->SetBuildingId (101);
   c.reset ();
@@ -444,21 +419,6 @@ TEST_F (CharacterTableTests, QueryWithTarget)
   ASSERT_FALSE (res.Step ());
 }
 
-TEST_F (CharacterTableTests, QueryBusyDone)
-{
-  tbl.CreateNew ("leisurely", Faction::RED);
-  SetBusy (*tbl.CreateNew ("verybusy", Faction::RED), 2);
-  SetBusy (*tbl.CreateNew ("done 1", Faction::RED), 1);
-  SetBusy (*tbl.CreateNew ("done 2", Faction::RED), 1);
-
-  auto res = tbl.QueryBusyDone ();
-  ASSERT_TRUE (res.Step ());
-  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "done 1");
-  ASSERT_TRUE (res.Step ());
-  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "done 2");
-  ASSERT_FALSE (res.Step ());
-}
-
 TEST_F (CharacterTableTests, QueryForEnterBuilding)
 {
   tbl.CreateNew ("not entering", Faction::RED);
@@ -527,20 +487,6 @@ TEST_F (CharacterTableTests, DeleteById)
   tbl.DeleteById (id2);
   EXPECT_TRUE (tbl.GetById (id1) == nullptr);
   EXPECT_TRUE (tbl.GetById (id2) == nullptr);
-}
-
-TEST_F (CharacterTableTests, DecrementBusy)
-{
-  const auto id1 = tbl.CreateNew ("leisurely", Faction::RED)->GetId ();
-
-  auto c = tbl.CreateNew ("verybusy", Faction::RED);
-  const auto id2 = c->GetId ();
-  SetBusy (*c, 10);
-  c.reset ();
-
-  tbl.DecrementBusy ();
-  EXPECT_EQ (tbl.GetById (id1)->GetBusy (), 0);
-  EXPECT_EQ (tbl.GetById (id2)->GetBusy (), 9);
 }
 
 TEST_F (CharacterTableTests, CountForOwner)

--- a/database/ongoing.cpp
+++ b/database/ongoing.cpp
@@ -1,0 +1,173 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "ongoing.hpp"
+
+namespace pxd
+{
+
+OngoingOperation::OngoingOperation (Database& d)
+  : db(d), id(db.GetNextId ()), height(0),
+    characterId(Database::EMPTY_ID), buildingId(Database::EMPTY_ID),
+    dirtyFields(true)
+{
+  VLOG (1) << "Created new ongoing operation with ID " << id;
+  data.SetToDefault ();
+}
+
+OngoingOperation::OngoingOperation (Database& d,
+                                    const Database::Result<OngoingResult>& res)
+  : db(d), dirtyFields(false)
+{
+  id = res.Get<OngoingResult::id> ();
+  height = res.Get<OngoingResult::height> ();
+  characterId = res.Get<OngoingResult::character> ();
+  buildingId = res.Get<OngoingResult::building> ();
+  data = res.GetProto<OngoingResult::proto> ();
+
+  VLOG (1) << "Created ongoing instance for ID " << id << " from database";
+}
+
+OngoingOperation::~OngoingOperation ()
+{
+  if (!dirtyFields && !data.IsDirty ())
+    {
+      VLOG (1) << "Ongoing " << id << " is not dirty";
+      return;
+    }
+
+  VLOG (1) << "Updating dirty ongoing " << id << " in the database";
+
+  auto stmt = db.Prepare (R"(
+    INSERT OR REPLACE INTO `ongoing_operations`
+      (`id`, `height`, `character`, `building`, `proto`)
+      VALUES (?1, ?2, ?3, ?4, ?5)
+  )");
+
+  stmt.Bind (1, id);
+  stmt.Bind (2, height);
+
+  if (characterId == Database::EMPTY_ID)
+    stmt.BindNull (3);
+  else
+    stmt.Bind (3, characterId);
+
+  if (buildingId == Database::EMPTY_ID)
+    stmt.BindNull (4);
+  else
+    stmt.Bind (4, buildingId);
+
+  stmt.BindProto (5, data);
+
+  stmt.Execute ();
+}
+
+OngoingsTable::Handle
+OngoingsTable::CreateNew ()
+{
+  return Handle (new OngoingOperation (db));
+}
+
+OngoingsTable::Handle
+OngoingsTable::GetFromResult (const Database::Result<OngoingResult>& res)
+{
+  return Handle (new OngoingOperation (db, res));
+}
+
+OngoingsTable::Handle
+OngoingsTable::GetById (const Database::IdT id)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `ongoing_operations`
+      WHERE `id` = ?1
+  )");
+  stmt.Bind (1, id);
+  auto res = stmt.Query<OngoingResult> ();
+  if (!res.Step ())
+    return nullptr;
+
+  auto op = GetFromResult (res);
+  CHECK (!res.Step ());
+  return op;
+}
+
+Database::Result<OngoingResult>
+OngoingsTable::QueryAll ()
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `ongoing_operations`
+      ORDER BY `id`
+  )");
+  return stmt.Query<OngoingResult> ();
+}
+
+Database::Result<OngoingResult>
+OngoingsTable::QueryForHeight (const unsigned h)
+{
+  /* There should never be any entries *less* than the current block height
+     in the database.  We query for less-of-equal anyway, so that we can then
+     assert this while processing them.  */
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `ongoing_operations`
+      WHERE `height` <= ?1
+      ORDER BY `id`
+  )");
+  stmt.Bind (1, h);
+  return stmt.Query<OngoingResult> ();
+}
+
+void
+OngoingsTable::DeleteForCharacter (const Database::IdT id)
+{
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `ongoing_operations`
+      WHERE `character` = ?1
+  )");
+  stmt.Bind (1, id);
+  stmt.Execute ();
+}
+
+void
+OngoingsTable::DeleteForBuilding (const Database::IdT id)
+{
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `ongoing_operations`
+      WHERE `building` = ?1
+  )");
+  stmt.Bind (1, id);
+  stmt.Execute ();
+}
+
+void
+OngoingsTable::DeleteForHeight (const unsigned h)
+{
+  /* We only remove by exact height (not less-or-equal) so that any rows
+     with an invalid height (should not happen) will not be silently removed.
+     They should instead come up when processing next and assert-fail.  */
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `ongoing_operations`
+      WHERE `height` = ?1
+  )");
+  stmt.Bind (1, h);
+  stmt.Execute ();
+}
+
+} // namespace pxd

--- a/database/ongoing.hpp
+++ b/database/ongoing.hpp
@@ -1,0 +1,235 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_ONGOING_HPP
+#define DATABASE_ONGOING_HPP
+
+#include "database.hpp"
+#include "lazyproto.hpp"
+
+#include "proto/ongoing.pb.h"
+
+#include <memory>
+#include <string>
+
+namespace pxd
+{
+
+/**
+ * Database result type for rows from the ongoing-operations table.
+ */
+struct OngoingResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, id, 1);
+  RESULT_COLUMN (int64_t, height, 2);
+  RESULT_COLUMN (int64_t, character, 3);
+  RESULT_COLUMN (int64_t, building, 4);
+  RESULT_COLUMN (pxd::proto::OngoingOperation, proto, 5);
+};
+
+/**
+ * Wrapper class around an ongoing operation in the database.  Instances
+ * should be obtained through OngoingTable.
+ */
+class OngoingOperation
+{
+
+private:
+
+  /** Database reference this belongs to.  */
+  Database& db;
+
+  /** The underlying ID in the database.  */
+  Database::IdT id;
+
+  /** The block height at which it needs to be processed.  */
+  unsigned height;
+
+  /** The associated character ID (or EMPTY_ID if none).  */
+  Database::IdT characterId;
+
+  /** The associated building ID (or EMPTY_ID if none).  */
+  Database::IdT buildingId;
+
+  /** General proto data.  */
+  LazyProto<proto::OngoingOperation> data;
+
+  /** Whether or not the fields are dirty.  */
+  bool dirtyFields;
+
+  /**
+   * Constructs a new instance with auto-generated ID meant to be inserted
+   * into the database.
+   */
+  explicit OngoingOperation (Database& d);
+
+  /**
+   * Constructs an instance based on the given DB result set.  The result
+   * set should be constructed by an OngoingsTable.
+   */
+  explicit OngoingOperation (Database& d,
+                             const Database::Result<OngoingResult>& res);
+
+  friend class OngoingsTable;
+
+public:
+
+  /**
+   * In the destructor, the underlying database is updated if there are any
+   * modifications to send.
+   */
+  ~OngoingOperation ();
+
+  OngoingOperation () = delete;
+  OngoingOperation (const OngoingOperation&) = delete;
+  void operator= (const OngoingOperation&) = delete;
+
+  Database::IdT
+  GetId () const
+  {
+    return id;
+  }
+
+  unsigned
+  GetHeight () const
+  {
+    return height;
+  }
+
+  void
+  SetHeight (const unsigned h)
+  {
+    height = h;
+    dirtyFields = true;
+  }
+
+  Database::IdT
+  GetCharacterId () const
+  {
+    return characterId;
+  }
+
+  void
+  SetCharacterId (const Database::IdT id)
+  {
+    characterId = id;
+    dirtyFields = true;
+  }
+
+  Database::IdT
+  GetBuildingId () const
+  {
+    return buildingId;
+  }
+
+  void
+  SetBuildingId (const Database::IdT id)
+  {
+    buildingId = id;
+    dirtyFields = true;
+  }
+
+  const proto::OngoingOperation&
+  GetProto () const
+  {
+    return data.Get ();
+  }
+
+  proto::OngoingOperation&
+  MutableProto ()
+  {
+    return data.Mutable ();
+  }
+
+};
+
+/**
+ * Utility class that handles querying the ongoings table in the database and
+ * should be used to obtain OngoingOperation instances.
+ */
+class OngoingsTable
+{
+
+private:
+
+  /** The Database reference for creating queries.  */
+  Database& db;
+
+public:
+
+  /** Movable handle to an instance.  */
+  using Handle = std::unique_ptr<OngoingOperation>;
+
+  explicit OngoingsTable (Database& d)
+    : db(d)
+  {}
+
+  OngoingsTable () = delete;
+  OngoingsTable (const OngoingsTable&) = delete;
+  void operator= (const OngoingsTable&) = delete;
+
+  /**
+   * Creates a new entry in the database and returns the handle so it
+   * can be initialised.
+   */
+  Handle CreateNew ();
+
+  /**
+   * Returns a handle for the instance based on a Database::Result.
+   */
+  Handle GetFromResult (const Database::Result<OngoingResult>& res);
+
+  /**
+   * Returns a handle for the given ID (or null if it doesn't exist).
+   */
+  Handle GetById (Database::IdT id);
+
+  /**
+   * Queries the database for all ongoing operations.
+   */
+  Database::Result<OngoingResult> QueryAll ();
+
+  /**
+   * Queries the database for all operations that need processing at the
+   * given (current) block height.
+   */
+  Database::Result<OngoingResult> QueryForHeight (unsigned h);
+
+  /**
+   * Deletes all operations for a given character ID.  This is used when
+   * the character dies.
+   */
+  void DeleteForCharacter (Database::IdT id);
+
+  /**
+   * Deletes all operations for a given building ID.  This is used when
+   * the building is destroyed.
+   */
+  void DeleteForBuilding (Database::IdT id);
+
+  /**
+   * Deletes all operations with the given height.  This is used to clean
+   * up finished operations after processing them.
+   */
+  void DeleteForHeight (unsigned h);
+
+};
+
+} // namespace pxd
+
+#endif // DATABASE_ONGOING_HPP

--- a/database/ongoing_tests.cpp
+++ b/database/ongoing_tests.cpp
@@ -1,0 +1,206 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "ongoing.hpp"
+
+#include "dbtest.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+class OngoingOperationTests : public DBTestWithSchema
+{
+
+protected:
+
+  OngoingsTable tbl;
+
+  OngoingOperationTests ()
+    : tbl(db)
+  {}
+
+};
+
+TEST_F (OngoingOperationTests, DefaultData)
+{
+  auto op = tbl.CreateNew ();
+  EXPECT_EQ (op->GetHeight (), 0);
+  EXPECT_EQ (op->GetCharacterId (), Database::EMPTY_ID);
+  EXPECT_EQ (op->GetBuildingId (), Database::EMPTY_ID);
+  EXPECT_EQ (op->GetProto ().op_case (), proto::OngoingOperation::OP_NOT_SET);
+}
+
+TEST_F (OngoingOperationTests, Update)
+{
+  auto op = tbl.CreateNew ();
+  const auto id1 = op->GetId ();
+  op->SetHeight (5);
+  op->SetCharacterId (10);
+  op->MutableProto ().mutable_prospection ();
+  op.reset ();
+
+  op = tbl.CreateNew ();
+  const auto id2 = op->GetId ();
+  op->SetBuildingId (20);
+  op->MutableProto ().mutable_armour_repair ();
+  op.reset ();
+
+  op = tbl.GetById (id1);
+  EXPECT_EQ (op->GetHeight (), 5);
+  EXPECT_EQ (op->GetCharacterId (), 10);
+  EXPECT_EQ (op->GetBuildingId (), Database::EMPTY_ID);
+  EXPECT_TRUE (op->GetProto ().has_prospection ());
+  op->MutableProto ().clear_prospection ();
+  op.reset ();
+
+  op = tbl.GetById (id2);
+  EXPECT_EQ (op->GetCharacterId (), Database::EMPTY_ID);
+  EXPECT_EQ (op->GetBuildingId (), 20);
+  EXPECT_TRUE (op->GetProto ().has_armour_repair ());
+  op->SetCharacterId (30);
+  op->SetBuildingId (Database::EMPTY_ID);
+  op->MutableProto ().clear_prospection ();
+  op.reset ();
+
+  op = tbl.GetById (id1);
+  EXPECT_EQ (op->GetProto ().op_case (), proto::OngoingOperation::OP_NOT_SET);
+  op.reset ();
+
+  op = tbl.GetById (id2);
+  EXPECT_EQ (op->GetCharacterId (), 30);
+  EXPECT_EQ (op->GetBuildingId (), Database::EMPTY_ID);
+  op.reset ();
+}
+
+using OngoingsTableTests = OngoingOperationTests;
+
+TEST_F (OngoingsTableTests, QueryAll)
+{
+  tbl.CreateNew ()->SetHeight (10);
+  tbl.CreateNew ()->SetHeight (5);
+
+  auto res = tbl.QueryAll ();
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetHeight (), 10);
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetHeight (), 5);
+
+  ASSERT_FALSE (res.Step ());
+}
+
+TEST_F (OngoingsTableTests, QueryForHeight)
+{
+  auto op = tbl.CreateNew ();
+  op->SetHeight (5);
+  op->SetCharacterId (2);
+  op.reset ();
+
+  op = tbl.CreateNew ();
+  op->SetHeight (6);
+  op->SetCharacterId (5);
+  op.reset ();
+
+  op = tbl.CreateNew ();
+  op->SetHeight (5);
+  op->SetCharacterId (1);
+  op.reset ();
+
+  auto res = tbl.QueryForHeight (5);
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetCharacterId (), 2);
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetCharacterId (), 1);
+
+  ASSERT_FALSE (res.Step ());
+}
+
+TEST_F (OngoingsTableTests, DeleteForCharacter)
+{
+  db.SetNextId (101);
+
+  tbl.CreateNew ()->SetCharacterId (42);
+  tbl.CreateNew ()->SetBuildingId (42);
+  tbl.CreateNew ()->SetCharacterId (50);
+
+  tbl.DeleteForCharacter (42);
+  tbl.DeleteForCharacter (12345);
+
+  auto res = tbl.QueryAll ();
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 102);
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 103);
+
+  ASSERT_FALSE (res.Step ());
+}
+
+TEST_F (OngoingsTableTests, DeleteForBuilding)
+{
+  db.SetNextId (101);
+
+  tbl.CreateNew ()->SetBuildingId (42);
+  tbl.CreateNew ()->SetCharacterId (42);
+  tbl.CreateNew ()->SetBuildingId (50);
+
+  tbl.DeleteForBuilding (42);
+  tbl.DeleteForBuilding (12345);
+
+  auto res = tbl.QueryAll ();
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 102);
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 103);
+
+  ASSERT_FALSE (res.Step ());
+}
+
+TEST_F (OngoingsTableTests, DeleteForHeight)
+{
+  db.SetNextId (101);
+
+  tbl.CreateNew ()->SetHeight (50);
+  tbl.CreateNew ()->SetHeight (42);
+  tbl.CreateNew ()->SetHeight (10);
+
+  tbl.DeleteForHeight (42);
+
+  auto res = tbl.QueryAll ();
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 101);
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetId (), 103);
+
+  ASSERT_FALSE (res.Step ());
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/database/region.hpp
+++ b/database/region.hpp
@@ -151,6 +151,19 @@ private:
    */
   unsigned height;
 
+  /**
+   * Sets the height to a different value.  We need this for some tests so
+   * that we can reuse an existing RegionsTable instance for processing
+   * multiple blocks.
+   */
+  void
+  SetHeightForTesting (const unsigned h)
+  {
+    height = h;
+  }
+
+  friend class PXLogicTests;
+
 public:
 
   /**

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -69,10 +69,6 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- as we later on only process attacks of characters with a selected target.
   `target` BLOB NULL,
 
-  -- If non-zero, then the number represents for how many more blocks the
-  -- character is "locked" at being busy (e.g. prospecting).
-  `busy` INTEGER NOT NULL,
-
   -- Flag indicating if the character is currently moving.  This is set
   -- based on the encoded protocol buffer when updating the table, and is
   -- used so that we can efficiently retrieve only those characters that are
@@ -109,7 +105,6 @@ CREATE INDEX IF NOT EXISTS `characters_pos` ON `characters` (`x`, `y`);
 CREATE INDEX IF NOT EXISTS `characters_building` ON `characters` (`inbuilding`);
 CREATE INDEX IF NOT EXISTS `characters_enterbuilding`
   ON `characters` (`enterbuilding`);
-CREATE INDEX IF NOT EXISTS `characters_busy` ON `characters` (`busy`);
 CREATE INDEX IF NOT EXISTS `characters_ismoving` ON `characters` (`ismoving`);
 CREATE INDEX IF NOT EXISTS `characters_ismining` ON `characters` (`ismining`);
 CREATE INDEX IF NOT EXISTS `characters_attackrange`

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -307,3 +307,35 @@ CREATE TABLE IF NOT EXISTS `item_counts` (
   `found` INTEGER NOT NULL
 
 );
+
+-- =============================================================================
+
+-- Ongoing operations that take a couple of blocks and need processing
+-- at a later time (when they are done / need updates).
+CREATE TABLE IF NOT EXISTS `ongoing_operations` (
+
+  -- Unique ID for the operation.
+  `id` INTEGER PRIMARY KEY,
+
+  -- The block height at which the next processing / update is required.
+  `height` INTEGER NOT NULL,
+
+  -- Character ID that is associated to this operation (might be NULL if there
+  -- is no associated character).  If the character dies, then the operation
+  -- is removed.
+  `character` INTEGER NULL,
+
+  -- Building ID that is associated to this operation (if any).
+  `building` INTEGER NULL,
+
+  -- Main data for the operation encoded as serialised OngoingOperation proto.
+  `proto` BLOB NOT NULL
+
+);
+
+CREATE INDEX IF NOT EXISTS `ongoing_operations_by_height`
+  ON `ongoing_operations` (`height`);
+CREATE INDEX IF NOT EXISTS `ongoing_operations_by_character`
+  ON `ongoing_operations` (`character`);
+CREATE INDEX IF NOT EXISTS `ongoing_operations_by_building`
+  ON `ongoing_operations` (`building`);

--- a/gametest/prospecting_basic.py
+++ b/gametest/prospecting_basic.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -81,7 +81,6 @@ class BasicProspectingTest (PXTest):
     self.assertEqual (c.getBusy (), {
       "blocks": 10,
       "operation": "prospecting",
-      "region": region.getId (),
     })
     self.assertEqual (region.data["prospection"], {"inprogress": c.getId ()})
 
@@ -127,7 +126,6 @@ class BasicProspectingTest (PXTest):
     self.assertEqual (c.getBusy (), {
       "blocks": 10,
       "operation": "prospecting",
-      "region": region.getId (),
     })
 
     self.setCharactersHP ({
@@ -153,7 +151,6 @@ class BasicProspectingTest (PXTest):
     self.assertEqual (chars[self.prospectors[0]].getBusy (), {
       "blocks": 9,
       "operation": "prospecting",
-      "region": region.getId (),
     })
     self.assertEqual (chars[self.prospectors[1]].getBusy (), None)
     self.assertEqual (region.data["prospection"], {
@@ -259,7 +256,6 @@ class BasicProspectingTest (PXTest):
     self.assertEqual (c.getBusy (), {
       "blocks": 10,
       "operation": "prospecting",
-      "region": region.getId (),
     })
     self.assertEqual (region.data["prospection"], {"inprogress": c.getId ()})
 

--- a/gametest/splitstaterpcs.py
+++ b/gametest/splitstaterpcs.py
@@ -30,7 +30,7 @@ class SplitStateRpcsTest (PXTest):
     self.collectPremine ()
 
     # Set up a non-trivial situation, where we have characters, prospected
-    # regions, kills/fame, buildings and ground loot.
+    # regions, kills/fame, buildings, ground loot and ongoing operations.
     self.initAccount ("prospector", "r")
     self.initAccount ("killed", "g")
     self.dropLoot ({"x": 1, "y": 2}, {"foo": 5, "bar": 10})
@@ -48,6 +48,11 @@ class SplitStateRpcsTest (PXTest):
     })
     self.getCharacters ()["prospector"].sendMove ({"prospect": {}})
     self.generate (20)
+    self.moveCharactersTo ({
+      "prospector": {"x": 100, "y": -100},
+    })
+    self.getCharacters ()["prospector"].sendMove ({"prospect": {}})
+    self.generate (3)
 
     # Test that the full game state corresponds to the split RPCs.
     state = self.getGameState ()
@@ -55,18 +60,21 @@ class SplitStateRpcsTest (PXTest):
     buildings = self.getRpc ("getbuildings")
     characters = self.getRpc ("getcharacters")
     loot = self.getRpc ("getgroundloot")
+    ongoings = self.getRpc ("getongoings")
     regions = self.getRpc ("getregions", fromheight=0)
     prizes = self.getRpc ("getprizestats")
     assert len (accounts) > 0
     assert len (buildings) > 0
     assert len (characters) > 0
     assert len (loot) > 0
+    assert len (ongoings) > 0
     assert len (regions) > 0
     assert len (prizes) > 0
     self.assertEqual (accounts, state["accounts"])
     self.assertEqual (buildings, state["buildings"])
     self.assertEqual (characters, state["characters"])
     self.assertEqual (loot, state["groundloot"])
+    self.assertEqual (ongoings, state["ongoings"])
     self.assertEqual (regions, state["regions"])
     self.assertEqual (prizes, state["prizes"])
 

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -26,6 +26,7 @@ PROTOS = \
   geometry.proto \
   inventory.proto \
   movement.proto \
+  ongoing.proto \
   region.proto
 EXTRA_DIST = \
   $(PROTOS) $(ROCONFIG_TEXT_PROTOS) \

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -20,7 +20,6 @@ syntax = "proto2";
 
 import "combat.proto";
 import "movement.proto";
-import "ongoing.proto";
 
 package pxd.proto;
 
@@ -73,23 +72,19 @@ message Character
   optional CombatData combat_data = 2;
 
   /**
-   * If the character is currently busy, then this holds data about the
-   * currently ongoing operation.
+   * If the character is currently busy, then this is the ID of the
+   * corresponding ongoing operation.
    */
-  oneof busy
-  {
-    OngoingProspection prospection = 3;
-    ArmourRepair armour_repair = 4;
-  }
+  optional uint64 ongoing = 3;
 
   /** The character's mining data, if it can mine.  */
-  optional MiningData mining = 5;
+  optional MiningData mining = 4;
 
   /** Movement speed of the character.  */
-  optional uint32 speed = 6;
+  optional uint32 speed = 5;
 
   /** Total cargo space the character has.  */
-  optional uint64 cargo_space = 7;
+  optional uint64 cargo_space = 6;
 
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:
@@ -104,7 +99,6 @@ message Character
      - current HP proto
      - HP regeneration data proto
      - selected target as TargetId proto (if any)
-     - number of blocks the character is still "busy"
      - inventory proto
   */
 

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -20,34 +20,9 @@ syntax = "proto2";
 
 import "combat.proto";
 import "movement.proto";
+import "ongoing.proto";
 
 package pxd.proto;
-
-/**
- * Data representing an on-going prospection by a character.
- */
-message OngoingProspection
-{
-
-  /* There are no fields required.  The only piece of data is which region
-     is being prospected, but that is implicit from the character's
-     position on the map.
-
-     This message is simply used as a flag to indicate that a prospecting
-     operation is ongoing in the character's "busy" oneof.  */
-
-}
-
-/**
- * Data representing an "armour repair" operation in progress.
- */
-message ArmourRepair
-{
-
-  /* As with OngoingProspection, this is just a signal message for the
-     busy oneof, at least for the time being.  */
-
-}
 
 /**
  * Data about the mining state of a character.

--- a/proto/ongoing.proto
+++ b/proto/ongoing.proto
@@ -1,0 +1,68 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+syntax = "proto2";
+
+package pxd.proto;
+
+/**
+ * Data representing an on-going prospection by a character.
+ */
+message OngoingProspection
+{
+
+  /* There are no fields required.  The only piece of data is which region
+     is being prospected, but that is implicit from the character's
+     position on the map.
+
+     This message is simply used as a flag to indicate that an ongoing
+     operation is prospecting.  */
+
+}
+
+/**
+ * Data representing an "armour repair" operation in progress.
+ */
+message ArmourRepair
+{
+
+  /* As with OngoingProspection, this is just a signal message for the
+     op oneof, at least for the time being.  */
+
+}
+
+/**
+ * Data about an ongoing operation.
+ */
+message OngoingOperation
+{
+
+  /** The ongoing operation itself, which can be one of several types.  */
+  oneof op
+  {
+    OngoingProspection prospection = 1;
+    ArmourRepair armour_repair = 2;
+  }
+
+  /* The database stores extra data directly in columns:
+      - block height when the operation is finished
+      - associated character ID (if any)
+      - associated building ID (if any)
+  */
+
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,6 +31,7 @@ libtaurion_la_SOURCES = \
   mining.cpp \
   movement.cpp \
   moveprocessor.cpp \
+  ongoings.cpp \
   params.cpp \
   pending.cpp \
   prospecting.cpp \
@@ -50,6 +51,7 @@ libtaurionheaders = \
   mining.hpp \
   movement.hpp \
   moveprocessor.hpp \
+  ongoings.hpp \
   params.hpp \
   pending.hpp \
   prospecting.hpp \
@@ -122,6 +124,7 @@ tests_SOURCES = \
   mining_tests.cpp \
   movement_tests.cpp \
   moveprocessor_tests.cpp \
+  ongoings_tests.cpp \
   pending_tests.cpp \
   prospecting_tests.cpp \
   protoutils_tests.cpp \

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -98,7 +98,7 @@ ProcessEnterBuildings (Database& db)
       ++processed;
       auto c = characters.GetFromResult (res);
 
-      if (c->GetBusy () > 0)
+      if (c->IsBusy ())
         {
           LOG (WARNING)
               << "Busy character " << c->GetId () << " can't enter building";

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -118,7 +118,7 @@ TEST_F (ProcessEnterBuildingsTests, BusyCharacter)
   auto c = GetCharacter (10);
   c->SetPosition (HexCoord (5, 0));
   c->SetEnterBuilding (1);
-  c->SetBusy (2);
+  c->MutableProto ().set_ongoing (12345);
   c.reset ();
 
   ProcessEnterBuildings (db);

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -73,6 +73,7 @@ const std::map<std::string, PXRpcMethod> CHARON_METHODS = {
   {"getbuildings", &PXRpcServer::getbuildingsI},
   {"getcharacters", &PXRpcServer::getcharactersI},
   {"getgroundloot", &PXRpcServer::getgroundlootI},
+  {"getongoings", &PXRpcServer::getongoingsI},
   {"getregions", &PXRpcServer::getregionsI},
   {"getprizestats", &PXRpcServer::getprizestatsI},
 };

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -192,39 +192,6 @@ GetCombatJsonObject (const Character& c, const DamageLists& dl)
 }
 
 /**
- * Constructs the JSON state object for a character's busy state.  Returns
- * JSON null if the character is not busy.
- */
-Json::Value
-GetBusyJsonObject (const BaseMap& map, const Character& c)
-{
-  const auto busyBlocks = c.GetBusy ();
-  if (busyBlocks == 0)
-    return Json::Value ();
-
-  Json::Value res(Json::objectValue);
-  res["blocks"] = IntToJson (busyBlocks);
-
-  const auto& pb = c.GetProto ();
-  switch (pb.busy_case ())
-    {
-    case proto::Character::kProspection:
-      res["operation"] = "prospecting";
-      res["region"] = IntToJson (map.Regions ().GetRegionId (c.GetPosition ()));
-      break;
-
-    case proto::Character::kArmourRepair:
-      res["operation"] = "armourrepair";
-      break;
-
-    default:
-      LOG (FATAL) << "Unexpected busy state for character: " << pb.busy_case ();
-    }
-
-  return res;
-}
-
-/**
  * Constructs the JSON representation of a character's cargo space.
  */
 Json::Value
@@ -305,9 +272,8 @@ template <>
   if (!mv.empty ())
     res["movement"] = mv;
 
-  const Json::Value busy = GetBusyJsonObject (map, c);
-  if (!busy.isNull ())
-    res["busy"] = busy;
+  if (c.IsBusy ())
+    res["busy"] = IntToJson (c.GetProto ().ongoing ());
 
   const Json::Value mining = GetMiningJsonObject (map, c);
   if (!mining.isNull ())

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -103,6 +103,11 @@ public:
   Json::Value GroundLoot ();
 
   /**
+   * Returns the JSON data about all ongoing operations.
+   */
+  Json::Value OngoingOperations ();
+
+  /**
    * Returns the JSON data representing all regions in the game state which
    * where modified after the given block height.
    */

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -487,15 +487,11 @@ TEST_F (CharacterJsonTests, DamageLists)
   })");
 }
 
-TEST_F (CharacterJsonTests, Prospecting)
+TEST_F (CharacterJsonTests, Busy)
 {
-  const HexCoord pos(10, -5);
-  ASSERT_EQ (map.Regions ().GetRegionId (pos), 350146);
-
   auto c = tbl.CreateNew ("domob", Faction::RED);
-  c->SetPosition (HexCoord (10, -5));
-  c->SetBusy (42);
-  c->MutableProto ().mutable_prospection ();
+  ASSERT_EQ (c->GetId (), 1);
+  c->MutableProto ().set_ongoing (42);
   c.reset ();
 
   tbl.CreateNew ("notbusy", Faction::RED);
@@ -505,39 +501,11 @@ TEST_F (CharacterJsonTests, Prospecting)
       [
         {
           "owner": "domob",
-          "busy":
-            {
-              "blocks": 42,
-              "operation": "prospecting",
-              "region": 350146
-            }
+          "busy": 42
         },
         {
           "owner": "notbusy",
           "busy": null
-        }
-      ]
-  })");
-}
-
-TEST_F (CharacterJsonTests, ArmourRepair)
-{
-  auto c = tbl.CreateNew ("domob", Faction::RED);
-  c->SetBuildingId (20);
-  c->SetBusy (42);
-  c->MutableProto ().mutable_armour_repair ();
-  c.reset ();
-
-  ExpectStateJson (R"({
-    "characters":
-      [
-        {
-          "owner": "domob",
-          "busy":
-            {
-              "blocks": 42,
-              "operation": "armourrepair"
-            }
         }
       ]
   })");

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -24,7 +24,7 @@
 #include "mining.hpp"
 #include "movement.hpp"
 #include "moveprocessor.hpp"
-#include "prospecting.hpp"
+#include "ongoings.hpp"
 
 #include "database/account.hpp"
 #include "database/building.hpp"
@@ -46,50 +46,6 @@ SQLiteGameDatabase::GetNextId ()
 {
   return game.Ids ("pxd").GetNext ();
 }
-
-namespace
-{
-
-/**
- * Decrements busy blocks for all characters and processes those that have
- * their operation finished.
- */
-void
-ProcessBusy (Database& db, xaya::Random& rnd, const Context& ctx)
-{
-  CharacterTable characters(db);
-  RegionsTable regions(db, ctx.Height ());
-
-  auto res = characters.QueryBusyDone ();
-  while (res.Step ())
-    {
-      auto c = characters.GetFromResult (res);
-      CHECK_EQ (c->GetBusy (), 1);
-      switch (c->GetProto ().busy_case ())
-        {
-        case proto::Character::kProspection:
-          FinishProspecting (*c, db, regions, rnd, ctx);
-          break;
-
-        case proto::Character::kArmourRepair:
-          LOG (INFO) << "Finished armour repair of character " << c->GetId ();
-          c->MutableHP ().set_armour (c->GetRegenData ().max_hp ().armour ());
-          c->MutableProto ().clear_armour_repair ();
-          c->SetBusy (0);
-          break;
-
-        default:
-          LOG (FATAL)
-              << "Unexpected busy case: " << c->GetProto ().busy_case ();
-        }
-
-      CHECK_EQ (c->GetBusy (), 0);
-    }
-
-  characters.DecrementBusy ();
-}
-
-} // anonymous namespace
 
 void
 PXLogic::UpdateState (Database& db, xaya::Random& rnd,
@@ -118,7 +74,7 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
   fame.GetDamageLists ().RemoveOld (ctx.Params ().DamageListBlocks ());
 
   AllHpUpdates (db, fame, rnd, ctx);
-  ProcessBusy (db, rnd, ctx);
+  ProcessAllOngoings (db, rnd, ctx);
 
   DynObstacles dyn(db);
   MoveProcessor mvProc(db, dyn, rnd, ctx);

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -30,6 +30,7 @@
 #include "database/database.hpp"
 #include "database/inventory.hpp"
 #include "database/itemcounts.hpp"
+#include "database/ongoing.hpp"
 #include "database/region.hpp"
 #include "mapdata/basemap.hpp"
 
@@ -118,6 +119,9 @@ protected:
 
   /** Item counts table.  */
   ItemCounts itemCounts;
+
+  /** Ongoing operations table.  */
+  OngoingsTable ongoings;
 
   /** Access to the regions table.  */
   RegionsTable regions;

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -1,0 +1,82 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "ongoings.hpp"
+
+#include "prospecting.hpp"
+
+#include "database/character.hpp"
+#include "database/ongoing.hpp"
+#include "database/region.hpp"
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+void
+ProcessAllOngoings (Database& db, xaya::Random& rnd, const Context& ctx)
+{
+  LOG (INFO) << "Processing ongoing operations for height " << ctx.Height ();
+
+  CharacterTable characters(db);
+  OngoingsTable ongoings(db);
+  RegionsTable regions(db, ctx.Height ());
+
+  auto res = ongoings.QueryForHeight (ctx.Height ());
+  while (res.Step ())
+    {
+      auto op = ongoings.GetFromResult (res);
+
+      /* The query returns all entries with height less-or-equal to the
+         current one, but there shouldn't be any with less (as they should have
+         been processed already last block).  Enforce this.  */
+      CHECK_EQ (op->GetHeight (), ctx.Height ());
+
+      CharacterTable::Handle c;
+      if (op->GetCharacterId () != Database::EMPTY_ID)
+        c = characters.GetById (op->GetCharacterId ());
+
+      switch (op->GetProto ().op_case ())
+        {
+        case proto::OngoingOperation::kProspection:
+          CHECK (c != nullptr);
+          FinishProspecting (*c, db, regions, rnd, ctx);
+          c->MutableProto ().clear_ongoing ();
+          break;
+
+        case proto::OngoingOperation::kArmourRepair:
+          CHECK (c != nullptr);
+          LOG (INFO) << "Finished armour repair of character " << c->GetId ();
+          c->MutableHP ().set_armour (c->GetRegenData ().max_hp ().armour ());
+          c->MutableProto ().clear_ongoing ();
+          break;
+
+        default:
+          LOG (FATAL)
+              << "Unexpected operation case: " << op->GetProto ().op_case ();
+        }
+
+      if (c != nullptr)
+        CHECK (!c->IsBusy ());
+    }
+
+  ongoings.DeleteForHeight (ctx.Height ());
+}
+
+} // namespace pxd

--- a/src/ongoings.hpp
+++ b/src/ongoings.hpp
@@ -1,0 +1,39 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_ONGOINGS_HPP
+#define PXD_ONGOINGS_HPP
+
+#include "context.hpp"
+
+#include "database/database.hpp"
+
+#include <xayautil/random.hpp>
+
+namespace pxd
+{
+
+/**
+ * Processes ongoing operations (i.e. check which have reached the block height,
+ * handle them, and then delete the ones that are done).
+ */
+void ProcessAllOngoings (Database& db, xaya::Random& rnd, const Context& ctx);
+
+} // namespace pxd
+
+#endif // PXD_ONGOINGS_HPP

--- a/src/ongoings_tests.cpp
+++ b/src/ongoings_tests.cpp
@@ -1,0 +1,135 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "ongoings.hpp"
+
+#include "testutils.hpp"
+
+#include "database/character.hpp"
+#include "database/dbtest.hpp"
+#include "database/ongoing.hpp"
+#include "database/region.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace pxd
+{
+namespace
+{
+
+class OngoingsTests : public DBTestWithSchema
+{
+
+protected:
+
+  CharacterTable characters;
+  OngoingsTable ongoings;
+
+  TestRandom rnd;
+  ContextForTesting ctx;
+
+  OngoingsTests ()
+    : characters(db), ongoings(db)
+  {}
+
+  /**
+   * Inserts an ongoing operation into the table, associated to the
+   * given character.  Returns the handle for further changes.
+   */
+  OngoingsTable::Handle
+  AddOp (Character& c)
+  {
+    auto op = ongoings.CreateNew ();
+    op->SetCharacterId (c.GetId ());
+    c.MutableProto ().set_ongoing (op->GetId ());
+    return op;
+  }
+
+};
+
+/* FIXME: Once we have copying blueprints (which are easier as the existing
+   character-based services), add a separate test just for the height
+   filtering and perhaps remove the partial height testing from ArmourRepair
+   afterwards.  */
+
+TEST_F (OngoingsTests, ArmourRepair)
+{
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  const auto cId = c->GetId ();
+  c->MutableRegenData ().mutable_max_hp ()->set_armour (1'000);
+  c->MutableHP ().set_armour (850);
+
+  auto op = AddOp (*c);
+  const auto opId = op->GetId ();
+  op->SetHeight (10);
+  op->MutableProto ().mutable_armour_repair ();
+
+  op.reset ();
+  c.reset ();
+
+  ctx.SetHeight (9);
+  ProcessAllOngoings (db, rnd, ctx);
+
+  c = characters.GetById (cId);
+  EXPECT_TRUE (c->IsBusy ());
+  EXPECT_EQ (c->GetHP ().armour (), 850);
+  EXPECT_NE (ongoings.GetById (opId), nullptr);
+  c.reset ();
+
+  ctx.SetHeight (10);
+  ProcessAllOngoings (db, rnd, ctx);
+
+  c = characters.GetById (cId);
+  EXPECT_FALSE (c->IsBusy ());
+  EXPECT_EQ (c->GetHP ().armour (), 1'000);
+  EXPECT_EQ (ongoings.GetById (opId), nullptr);
+}
+
+TEST_F (OngoingsTests, Prospection)
+{
+  const HexCoord pos(5, 5);
+  const auto region = ctx.Map ().Regions ().GetRegionId (pos);
+
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  const auto cId = c->GetId ();
+  c->SetPosition (pos);
+
+  auto op = AddOp (*c);
+  op->SetHeight (10);
+  op->MutableProto ().mutable_prospection ();
+
+  op.reset ();
+  c.reset ();
+
+  RegionsTable regions(db, 5);
+  regions.GetById (region)->MutableProto ().set_prospecting_character (cId);
+
+  ctx.SetHeight (10);
+  ProcessAllOngoings (db, rnd, ctx);
+
+  c = characters.GetById (cId);
+  EXPECT_FALSE (c->IsBusy ());
+  auto r = regions.GetById (region);
+  EXPECT_FALSE (r->GetProto ().has_prospecting_character ());
+  EXPECT_EQ (r->GetProto ().prospection ().name (), "domob");
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -51,6 +51,7 @@ protected:
   BuildingInventoriesTable buildingInv;
   CharacterTable characters;
   ItemCounts itemCounts;
+  OngoingsTable ongoings;
   RegionsTable regions;
 
   PendingStateTests ()
@@ -58,6 +59,7 @@ protected:
       buildings(db), buildingInv(db),
       characters(db),
       itemCounts(db),
+      ongoings(db),
       regions(db, 1'042)
   {}
 
@@ -516,7 +518,8 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 3
-      })"), ctx, accounts, buildings, buildingInv, characters, itemCounts));
+      })"), ctx, accounts, buildings, buildingInv, characters,
+            itemCounts, ongoings));
   state.AddServiceOperation (*ServiceOperation::Parse (
       *accounts.GetByName ("andy"),
       ParseJson (R"({
@@ -524,7 +527,8 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 6
-      })"), ctx, accounts, buildings, buildingInv, characters, itemCounts));
+      })"), ctx, accounts, buildings, buildingInv, characters,
+            itemCounts, ongoings));
   state.AddServiceOperation (*ServiceOperation::Parse (
       *accounts.GetByName ("domob"),
       ParseJson (R"({
@@ -532,7 +536,8 @@ TEST_F (PendingStateTests, ServiceOperations)
         "t": "ref",
         "i": "foo",
         "n": 9
-      })"), ctx, accounts, buildings, buildingInv, characters, itemCounts));
+      })"), ctx, accounts, buildings, buildingInv, characters,
+            itemCounts, ongoings));
 
   ExpectStateJson (R"(
     {
@@ -897,8 +902,7 @@ TEST_F (PendingStateUpdaterTests, Prospecting)
 
   h = characters.CreateNew ("domob", Faction::GREEN);
   ASSERT_EQ (h->GetId (), 2);
-  h->SetBusy (10);
-  h->MutableProto ().mutable_prospection ();
+  h->MutableProto ().set_ongoing (42);
   h.reset ();
 
   Process ("domob", R"({

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -79,13 +79,6 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
       << "Character " << c.GetId ()
       << " finished prospecting region " << regionId;
 
-  CHECK_EQ (c.GetBusy (), 1);
-  c.SetBusy (0);
-
-  auto& cpb = c.MutableProto ();
-  CHECK (cpb.has_prospection ());
-  cpb.clear_prospection ();
-
   auto r = regions.GetById (regionId);
   auto& mpb = r->MutableProto ();
   CHECK_EQ (mpb.prospecting_character (), c.GetId ());

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -144,8 +144,7 @@ protected:
 
   /**
    * Prospects with the given character on the given location.  This sets up
-   * the character on that position, marks it as prospecting, and calls
-   * FinishProspecting.
+   * the character on that position and calls FinishProspecting.
    *
    * Returns the region ID prospected.
    */
@@ -154,8 +153,6 @@ protected:
   {
     const auto id = c->GetId ();
     c->SetPosition (pos);
-    c->SetBusy (1);
-    c->MutableProto ().mutable_prospection ();
     c.reset ();
 
     const auto region = ctx.Map ().Regions ().GetRegionId (pos);
@@ -186,10 +183,6 @@ TEST_F (FinishProspectingTests, Basic)
 {
   ctx.SetHeight (10);
   const auto region = Prospect (GetTest (), HexCoord (10, -20));
-
-  auto c = GetTest ();
-  EXPECT_EQ (c->GetBusy (), 0);
-  EXPECT_FALSE (c->GetProto ().has_prospection ());
 
   auto r = regions.GetById (region);
   EXPECT_FALSE (r->GetProto ().has_prospecting_character ());

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -270,6 +270,17 @@ PXRpcServer::getgroundloot ()
 }
 
 Json::Value
+PXRpcServer::getongoings ()
+{
+  LOG (INFO) << "RPC method called: getongoings";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.OngoingOperations ();
+      });
+}
+
+Json::Value
 PXRpcServer::getregions (const int fromHeight)
 {
   LOG (INFO) << "RPC method called: getregions " << fromHeight;

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -128,6 +128,7 @@ public:
   Json::Value getbuildings () override;
   Json::Value getcharacters () override;
   Json::Value getgroundloot () override;
+  Json::Value getongoings () override;
   Json::Value getregions (int fromHeight) override;
   Json::Value getprizestats () override;
 

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -50,6 +50,11 @@
     "returns": {}
   },
   {
+    "name": "getongoings",
+    "params": {},
+    "returns": {}
+  },
+  {
     "name": "getregions",
     "params": {
       "fromheight": 42

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -27,6 +27,7 @@
 #include "database/character.hpp"
 #include "database/inventory.hpp"
 #include "database/itemcounts.hpp"
+#include "database/ongoing.hpp"
 
 #include <xayautil/random.hpp>
 
@@ -83,6 +84,9 @@ protected:
 
   /** Database handle for item-count tables.  */
   ItemCounts& itemCounts;
+
+  /** Database table for ongoing operations.  */
+  OngoingsTable& ongoings;
 
   explicit ServiceOperation (Account& a, BuildingsTable::Handle b,
                              const ContextRefs& refs);
@@ -158,7 +162,8 @@ public:
       AccountsTable& accounts,
       BuildingsTable& buildings, BuildingInventoriesTable& inv,
       CharacterTable& characters,
-      ItemCounts& cnt);
+      ItemCounts& cnt,
+      OngoingsTable& ong);
 
 };
 


### PR DESCRIPTION
This refactors the way that "busy" characters are handled.  Instead of tying this concept to characters, we introduce a new concept of "ongoing operations".  These represent anything that takes more than a block to process, and needs to be handled again at a later point in time.

These operations can be tied to characters, which replaces the existing "busy" concept.  But they will also be able to be unrelated to characters in the future, for instance for construction or blue-print copying services.

With this change, the `busy` field of the character JSON no longer returns detailed information, but just the ID of an ongoing operation.  The detail data needs to be queried with a new RPC `getongoings` (and then linked through the ID to the character).