### PR TITLE
Blueprint copying service

### DIFF
--- a/database/ongoing.cpp
+++ b/database/ongoing.cpp
@@ -119,6 +119,19 @@ OngoingsTable::QueryAll ()
 }
 
 Database::Result<OngoingResult>
+OngoingsTable::QueryForBuilding (const Database::IdT id)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `ongoing_operations`
+      WHERE `building` = ?1
+      ORDER BY `id`
+  )");
+  stmt.Bind (1, id);
+  return stmt.Query<OngoingResult> ();
+}
+
+Database::Result<OngoingResult>
 OngoingsTable::QueryForHeight (const unsigned h)
 {
   /* There should never be any entries *less* than the current block height

--- a/database/ongoing.hpp
+++ b/database/ongoing.hpp
@@ -205,6 +205,13 @@ public:
   Database::Result<OngoingResult> QueryAll ();
 
   /**
+   * Queries the database for all operations associated to a given building.
+   * This is used to process some of them (e.g. blueprint copy) when the
+   * building is destroyed, in addition to deleting them afterwards.
+   */
+  Database::Result<OngoingResult> QueryForBuilding (Database::IdT id);
+
+  /**
    * Queries the database for all operations that need processing at the
    * given (current) block height.
    */

--- a/database/ongoing_tests.cpp
+++ b/database/ongoing_tests.cpp
@@ -137,6 +137,31 @@ TEST_F (OngoingsTableTests, QueryForHeight)
   ASSERT_FALSE (res.Step ());
 }
 
+TEST_F (OngoingsTableTests, QueryForBuilding)
+{
+  auto op = tbl.CreateNew ();
+  op->SetHeight (1);
+  op->SetBuildingId (42);
+  op.reset ();
+
+  op = tbl.CreateNew ();
+  op->SetHeight (2);
+  op->SetBuildingId (5);
+  op.reset ();
+
+  op = tbl.CreateNew ();
+  op->SetHeight (3);
+  op->SetCharacterId (42);
+  op.reset ();
+
+  auto res = tbl.QueryForBuilding (42);
+
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetHeight (), 1);
+
+  ASSERT_FALSE (res.Step ());
+}
+
 TEST_F (OngoingsTableTests, DeleteForCharacter)
 {
   db.SetNextId (101);

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -28,6 +28,7 @@ REGTESTS = \
   prospecting_basic.py \
   prospecting_prizes.py \
   prospecting_resources.py \
+  services_bpcopy.py \
   services_fees.py \
   services_refining.py \
   services_repair.py \

--- a/gametest/services_bpcopy.py
+++ b/gametest/services_bpcopy.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests the "blueprint copy" building service.
+"""
+
+from pxtest import PXTest
+
+
+class ServicesBlueprintCopyTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.mainLogger.info ("Setting up initial situation...")
+    self.build ("ancient1", None, {"x": 0, "y": 0}, 0)
+    building = 1001
+    self.assertEqual (self.getBuildings ()[building].getType (), "ancient1")
+
+    self.initAccount ("domob", "r")
+    self.generate (1)
+    self.giftCoins ({"domob": 1000})
+    self.dropIntoBuilding (building, "domob", {"sword bpo": 2})
+    self.generate (1)
+
+    # Start three operations.  The third will be invalid as the blueprints
+    # are "blocked" by then.
+    self.mainLogger.info ("Starting the copying operation...")
+    self.sendMove ("domob", {"s": [
+      {"b": building, "t": "cp", "i": "sword bpo", "n": 3},
+      {"b": building, "t": "cp", "i": "sword bpo", "n": 2},
+      {"b": building, "t": "cp", "i": "sword bpo", "n": 1},
+    ]})
+
+    self.generate (1)
+    self.assertEqual (self.getAccounts ()["domob"].getBalance (), 500)
+    b = self.getBuildings ()[building]
+    self.assertEqual (b.getFungibleInventory ("domob"), {})
+    self.assertEqual (self.getRpc ("getongoings"), [
+      {
+        "id": 1002,
+        "operation": "bpcopy",
+        "buildingid": building,
+        "account": "domob",
+        "height": self.rpc.xaya.getblockcount () + 30,
+        "original": "sword bpo",
+        "output": {"sword bpc": 3},
+      },
+      {
+        "id": 1003,
+        "operation": "bpcopy",
+        "buildingid": building,
+        "account": "domob",
+        "height": self.rpc.xaya.getblockcount () + 20,
+        "original": "sword bpo",
+        "output": {"sword bpc": 2},
+      },
+    ])
+
+    self.generate (1)
+    reorgBlk = self.rpc.xaya.getbestblockhash ()
+
+    self.mainLogger.info ("Finishing the copying...")
+    self.generate (50)
+    self.assertEqual (self.getAccounts ()["domob"].getBalance (), 500)
+    b = self.getBuildings ()[building]
+    self.assertEqual (b.getFungibleInventory ("domob"), {
+      "sword bpo": 2,
+      "sword bpc": 5,
+    })
+    self.assertEqual (self.getRpc ("getongoings"), [])
+
+
+if __name__ == "__main__":
+  ServicesBlueprintCopyTest ().main ()

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -34,6 +34,9 @@ message ItemData
   /** The cargo space it uses per unit.  */
   optional uint32 space = 1;
 
+  /** For items that have one, the complexity level.  */
+  optional uint32 complexity = 2;
+
   /**
    * Data about the ability to refine items of this type to other item types
    * (i.e. raw materials into refined resources).
@@ -56,10 +59,10 @@ message ItemData
   }
 
   /** If this type of item can be refined, then the stats for doing so.  */
-  optional RefiningData refines = 2;
+  optional RefiningData refines = 3;
 
   /** Whether or not this item has an associated blueprint.  */
-  optional bool with_blueprint = 3;
+  optional bool with_blueprint = 4;
 
   /**
    * Specific data for blueprint items defining the modalities for
@@ -82,7 +85,7 @@ message ItemData
   }
 
   /** If this is a blueprint, the associated data.  */
-  optional BlueprintData is_blueprint = 4;
+  optional BlueprintData is_blueprint = 5;
 
   /**
    * Data about the ability to reverse-engineer an item to obtain blueprints.
@@ -105,7 +108,7 @@ message ItemData
    * If this can be reverse engineered (i.e. is an artefact), the configuration
    * data specifying the corresponding stats.
    */
-  optional RevEngData reveng = 5;
+  optional RevEngData reveng = 6;
 
 }
 
@@ -151,6 +154,7 @@ message BuildingData
     optional bool refining = 1;
     optional bool armour_repair = 2;
     optional bool reverse_engineering = 3;
+    optional bool blueprint_copy = 4;
   }
 
   /** Services this building type offers.  */

--- a/proto/ongoing.proto
+++ b/proto/ongoing.proto
@@ -47,6 +47,28 @@ message ArmourRepair
 }
 
 /**
+ * Data about an ongoing blueprint copy operation.  While a blueprint is being
+ * copied, it is "removed" from the main inventory, and only given back together
+ * with the copy when the operation is done.
+ */
+message BlueprintCopy
+{
+
+  /** The account doing the copying.  Also the owner of the blueprints.  */
+  optional string account = 1;
+
+  /** The blueprint item type being copied (the original).  */
+  optional string original_type = 2;
+
+  /** The item type of the copy that will be produced.  */
+  optional string copy_type = 3;
+
+  /** The number of copies being made.  */
+  optional uint32 num_copies = 4;
+
+}
+
+/**
  * Data about an ongoing operation.
  */
 message OngoingOperation
@@ -57,6 +79,7 @@ message OngoingOperation
   {
     OngoingProspection prospection = 1;
     ArmourRepair armour_repair = 2;
+    BlueprintCopy blueprint_copy = 3;
   }
 
   /* The database stores extra data directly in columns:

--- a/proto/roconfig/buildings/ancient1.pb.text
+++ b/proto/roconfig/buildings/ancient1.pb.text
@@ -9,6 +9,7 @@ building_types:
             refining: true
             armour_repair: true
             reverse_engineering: true
+            blueprint_copy: true
           }
         shape_tiles: { x: -13 y: -6 }
         shape_tiles: { x: -14 y: -5 }

--- a/proto/roconfig/buildings/ancient2.pb.text
+++ b/proto/roconfig/buildings/ancient2.pb.text
@@ -9,6 +9,7 @@ building_types:
             refining: true
             armour_repair: true
             reverse_engineering: true
+            blueprint_copy: true
           }
         shape_tiles: { x: -15 y: -14 }
         shape_tiles: { x: -29 y: 14 }

--- a/proto/roconfig/buildings/ancient3.pb.text
+++ b/proto/roconfig/buildings/ancient3.pb.text
@@ -9,6 +9,7 @@ building_types:
             refining: true
             armour_repair: true
             reverse_engineering: true
+            blueprint_copy: true
           }
         shape_tiles: { x: -19 y: -1 }
         shape_tiles: { x: -21 y: 0 }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -38,6 +38,7 @@ fungible_items:
     value:
       {
         space: 1,
+        complexity: 100,
         with_blueprint: true
       }
   }
@@ -47,6 +48,7 @@ fungible_items:
     value:
       {
         space: 1,
+        complexity: 1,
         with_blueprint: true
       }
   }

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -371,6 +371,19 @@ KillProcessor::ProcessBuilding (const Database::IdT id)
       }
   }
 
+  {
+    auto res = ongoings.QueryForBuilding (id);
+    while (res.Step ())
+      {
+        auto op = ongoings.GetFromResult (res);
+        if (!op->GetProto ().has_blueprint_copy ())
+          continue;
+
+        const auto& type = op->GetProto ().blueprint_copy ().original_type ();
+        totalInv.AddFungibleCount (type, 1);
+      }
+  }
+
   /* The underlying proto map does not have a well-defined order.  Since the
      random rolls depend on the other, make sure to explicitly sort the
      the list of inventory positions.  */

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -369,6 +369,21 @@ template <>
       res["operation"] = "armourrepair";
       break;
 
+    case proto::OngoingOperation::kBlueprintCopy:
+      {
+        const auto& cp = pb.blueprint_copy ();
+
+        res["operation"] = "bpcopy";
+        res["account"] = cp.account ();
+        res["original"] = cp.original_type ();
+
+        Json::Value output(Json::objectValue);
+        output[cp.copy_type ()] = IntToJson (cp.num_copies ());
+        res["output"] = output;
+
+        break;
+      }
+
     default:
       LOG (FATAL) << "Unexpected ongoing operation case: " << pb.op_case ();
     }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -874,6 +874,30 @@ TEST_F (OngoingsJsonTests, ArmourRepair)
   })");
 }
 
+TEST_F (OngoingsJsonTests, BlueprintCopy)
+{
+  auto op = tbl.CreateNew ();
+  ASSERT_EQ (op->GetId (), 1);
+  auto& cp = *op->MutableProto ().mutable_blueprint_copy ();
+  cp.set_account ("domob");
+  cp.set_original_type ("bow bpo");
+  cp.set_copy_type ("bow bpc");
+  cp.set_num_copies (42);
+  op.reset ();
+
+  ExpectStateJson (R"({
+    "ongoings":
+      [
+        {
+          "id": 1,
+          "operation": "bpcopy",
+          "original": "bow bpo",
+          "output": {"bow bpc": 42}
+        }
+      ]
+  })");
+}
+
 /* ************************************************************************** */
 
 class RegionJsonTests : public GameStateJsonTests

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -239,6 +239,18 @@ Params::RevEngSuccessChance (const unsigned existingBp) const
   return base;
 }
 
+Amount
+Params::BlueprintCopyCost (const unsigned complexity) const
+{
+  return 100 * complexity;
+}
+
+unsigned
+Params::BlueprintCopyBlocks (const unsigned complexity) const
+{
+  return 10 * complexity;
+}
+
 HexCoord
 Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
 {

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -151,6 +151,17 @@ public:
   unsigned RevEngSuccessChance (unsigned existingBp) const;
 
   /**
+   * Returns the cost for copying a blueprint of the given complexity.
+   */
+  Amount BlueprintCopyCost (unsigned complexity) const;
+
+  /**
+   * Returns the number of blocks for copying a blueprint of the given
+   * complexity.
+   */
+  unsigned BlueprintCopyBlocks (unsigned complexity) const;
+
+  /**
    * Returns the spawn centre and radius for the given faction.
    */
   HexCoord SpawnArea (Faction f, HexCoord::IntT& radius) const;


### PR DESCRIPTION
This defines a new service, which allows copying original blueprints into copies.  This costs some vCHI and takes some amount of time based on the base item's complexity.  The original blueprint is "locked" during the operation, so it can't be used for anything else in the mean time.

To request the building service, the move looks like this:

    {"s": [{"b": 42, "t": "cp", "i": "item bpo", "n": 3}]}

The requested number of copies (three in this case) makes the operation more costly and take longer, but still works with a single original (i.e. these copies are produced "in series").