### PR TITLE
Vehicle fitments

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -6,6 +6,7 @@ ROCONFIG_TEXT_PROTOS = \
   \
   roconfig/items/materials.pb.text \
   roconfig/items/prizes.pb.text \
+  roconfig/items/vehicles.pb.text \
   roconfig/items/test.pb.text \
   \
   roconfig/buildings/ancient1.pb.text \

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -4,6 +4,7 @@ noinst_LTLIBRARIES = libpxproto.la
 ROCONFIG_TEXT_PROTOS = \
   roconfig/resourcedist.pb.text \
   \
+  roconfig/items/fitments.pb.text \
   roconfig/items/materials.pb.text \
   roconfig/items/prizes.pb.text \
   roconfig/items/vehicles.pb.text \

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -63,8 +63,11 @@ message Character
   /** The vehicle (as item type) this character is using.  */
   optional string vehicle = 1;
 
+  /** Fitments placed on the vehicle.  */
+  repeated string fitments = 2;
+
   /** Active movement of the character, if any.  */
-  optional Movement movement = 2;
+  optional Movement movement = 3;
 
   /**
    * Static combat data for thie character.  That data is derived from other
@@ -72,22 +75,22 @@ message Character
    * here for easy computation of combat.  The data here changes only
    * through explicit actions done by the owner.
    */
-  optional CombatData combat_data = 3;
+  optional CombatData combat_data = 4;
 
   /**
    * If the character is currently busy, then this is the ID of the
    * corresponding ongoing operation.
    */
-  optional uint64 ongoing = 4;
+  optional uint64 ongoing = 5;
 
   /** The character's mining data, if it can mine.  */
-  optional MiningData mining = 5;
+  optional MiningData mining = 6;
 
   /** Movement speed of the character.  */
-  optional uint32 speed = 6;
+  optional uint32 speed = 7;
 
   /** Total cargo space the character has.  */
-  optional uint64 cargo_space = 7;
+  optional uint64 cargo_space = 8;
 
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -60,8 +60,11 @@ message MiningData
 message Character
 {
 
+  /** The vehicle (as item type) this character is using.  */
+  optional string vehicle = 1;
+
   /** Active movement of the character, if any.  */
-  optional Movement movement = 1;
+  optional Movement movement = 2;
 
   /**
    * Static combat data for thie character.  That data is derived from other
@@ -69,22 +72,22 @@ message Character
    * here for easy computation of combat.  The data here changes only
    * through explicit actions done by the owner.
    */
-  optional CombatData combat_data = 2;
+  optional CombatData combat_data = 3;
 
   /**
    * If the character is currently busy, then this is the ID of the
    * corresponding ongoing operation.
    */
-  optional uint64 ongoing = 3;
+  optional uint64 ongoing = 4;
 
   /** The character's mining data, if it can mine.  */
-  optional MiningData mining = 4;
+  optional MiningData mining = 5;
 
   /** Movement speed of the character.  */
-  optional uint32 speed = 5;
+  optional uint32 speed = 6;
 
   /** Total cargo space the character has.  */
-  optional uint64 cargo_space = 6;
+  optional uint64 cargo_space = 7;
 
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -18,6 +18,7 @@
 
 syntax = "proto2";
 
+import "character.proto";
 import "combat.proto";
 import "geometry.proto";
 
@@ -121,8 +122,22 @@ message ItemData
    */
   message VehicleData
   {
-    /* TODO: When we implement changing vehicles, we should fill in the
-       data here as required.  */
+
+    /** Base cargo space of this vehicle.  */
+    optional uint32 cargo_space = 1;
+
+    /** Base movement speed (in milli-tiles per block).  */
+    optional uint32 speed = 2;
+
+    /** Basic regeneration data and max HP.  */
+    optional RegenData regen_data = 3;
+
+    /** Basic combat data (including attacks mostly).  */
+    optional CombatData combat_data = 4;
+
+    /** Base mining speed for the vehicle.  */
+    optional MiningData.Speed mining_rate = 5;
+
   }
 
   /** If this is a vehicle item, the specific stats for that.  */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -24,6 +24,21 @@ import "geometry.proto";
 
 package pxd.proto;
 
+/**
+ * General modification something can give to an existing numerical value,
+ * e.g. an increase to a vehicle speed or combat damage.
+ */
+message StatModifier
+{
+
+  /**
+   * Relative change to the base value, in percent.  This is added (or
+   * subtracted if negative), so not a multiplicative factor.
+   */
+  optional sint32 percent = 1;
+
+}
+
 /* ************************************************************************** */
 
 /**
@@ -142,6 +157,41 @@ message ItemData
 
   /** If this is a vehicle item, the specific stats for that.  */
   optional VehicleData vehicle = 8;
+
+  /**
+   * Data specific about items that are fitments.
+   */
+  message FitmentData
+  {
+
+    /** An attack this does.  */
+    optional Attack attack = 1;
+
+    /** Modification to the cargo space.  */
+    optional StatModifier cargo_space = 2;
+
+    /** Modification to the movement speed.  */
+    optional StatModifier speed = 3;
+
+    /** Modification to max armour HP.  */
+    optional StatModifier max_armour = 4;
+
+    /** Modification to max shield HP.  */
+    optional StatModifier max_shield = 5;
+
+    /** Modification to shield regeneration rate.  */
+    optional StatModifier shield_regen = 6;
+
+    /** Modification of all attack ranges.  */
+    optional StatModifier range = 7;
+
+    /** Modification of all attack damages (min and max).  */
+    optional StatModifier damage = 8;
+
+  }
+
+  /** If this is a fitment, the specific stats for that.  */
+  optional FitmentData fitment = 9;
 
 }
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -153,6 +153,14 @@ message ItemData
     /** Base mining speed for the vehicle.  */
     optional MiningData.Speed mining_rate = 5;
 
+    /**
+     * Number of equipment slots of each type.  The slot types are just strings
+     * which have to be matched between here and the fitment configs.  The valid
+     * values are "high", "mid" and "low".  Unfortunately we cannot use enum
+     * values as they can't be keys in protocol buffer maps.
+     */
+    map<string, uint32> equipment_slots = 6;
+
   }
 
   /** If this is a vehicle item, the specific stats for that.  */
@@ -164,29 +172,35 @@ message ItemData
   message FitmentData
   {
 
+    /** The type of slot this requires.  */
+    optional string slot = 1;
+
     /** An attack this does.  */
-    optional Attack attack = 1;
+    optional Attack attack = 2;
 
     /** Modification to the cargo space.  */
-    optional StatModifier cargo_space = 2;
+    optional StatModifier cargo_space = 3;
 
     /** Modification to the movement speed.  */
-    optional StatModifier speed = 3;
+    optional StatModifier speed = 4;
 
     /** Modification to max armour HP.  */
-    optional StatModifier max_armour = 4;
+    optional StatModifier max_armour = 5;
 
     /** Modification to max shield HP.  */
-    optional StatModifier max_shield = 5;
+    optional StatModifier max_shield = 6;
 
     /** Modification to shield regeneration rate.  */
-    optional StatModifier shield_regen = 6;
+    optional StatModifier shield_regen = 7;
 
     /** Modification of all attack ranges.  */
-    optional StatModifier range = 7;
+    optional StatModifier range = 8;
 
     /** Modification of all attack damages (min and max).  */
-    optional StatModifier damage = 8;
+    optional StatModifier damage = 9;
+
+    /** Modification to the vehicle's allowed fitment complexity.  */
+    optional StatModifier complexity = 10;
 
   }
 

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1,0 +1,104 @@
+fungible_items:
+  {
+    key: "bomb"
+    value:
+      {
+        space: 5
+        complexity: 4
+        with_blueprint: true
+        fitment:
+          {
+            attack:
+              {
+                range: 2
+                area: true
+                min_damage: 2
+                max_damage: 5
+              }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "expander"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment: { cargo_space: { percent: 10 } }
+      }
+  }
+
+fungible_items:
+  {
+    key: "turbo"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment: { speed: { percent: 10 } }
+      }
+  }
+
+fungible_items:
+  {
+    key: "plating"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment: { max_armour: { percent: 10 } }
+      }
+  }
+
+fungible_items:
+  {
+    key: "shield"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment: { max_shield: { percent: 10 } }
+      }
+  }
+
+fungible_items:
+  {
+    key: "replenisher"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment: { shield_regen: { percent: 10 } }
+      }
+  }
+
+fungible_items:
+  {
+    key: "rangeext"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment: { range: { percent: 10 } }
+      }
+  }
+
+fungible_items:
+  {
+    key: "dmgext"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment: { damage: { percent: 10 } }
+      }
+  }

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -8,6 +8,7 @@ fungible_items:
         with_blueprint: true
         fitment:
           {
+            slot: "high"
             attack:
               {
                 range: 2
@@ -27,7 +28,11 @@ fungible_items:
         space: 1
         complexity: 4
         with_blueprint: true
-        fitment: { cargo_space: { percent: 10 } }
+        fitment:
+          {
+            slot: "low"
+            cargo_space: { percent: 10 }
+          }
       }
   }
 
@@ -39,7 +44,11 @@ fungible_items:
         space: 1
         complexity: 4
         with_blueprint: true
-        fitment: { speed: { percent: 10 } }
+        fitment:
+          {
+            slot: "mid"
+            speed: { percent: 10 }
+          }
       }
   }
 
@@ -51,7 +60,11 @@ fungible_items:
         space: 1
         complexity: 4
         with_blueprint: true
-        fitment: { max_armour: { percent: 10 } }
+        fitment:
+          {
+            slot: "low"
+            max_armour: { percent: 10 }
+          }
       }
   }
 
@@ -63,7 +76,11 @@ fungible_items:
         space: 1
         complexity: 4
         with_blueprint: true
-        fitment: { max_shield: { percent: 10 } }
+        fitment:
+          {
+            slot: "mid"
+            max_shield: { percent: 10 }
+          }
       }
   }
 
@@ -75,7 +92,11 @@ fungible_items:
         space: 1
         complexity: 4
         with_blueprint: true
-        fitment: { shield_regen: { percent: 10 } }
+        fitment:
+          {
+            slot: "mid"
+            shield_regen: { percent: 10 }
+          }
       }
   }
 
@@ -87,7 +108,11 @@ fungible_items:
         space: 1
         complexity: 4
         with_blueprint: true
-        fitment: { range: { percent: 10 } }
+        fitment:
+          {
+            slot: "mid"
+            range: { percent: 10 }
+          }
       }
   }
 
@@ -99,6 +124,26 @@ fungible_items:
         space: 1
         complexity: 4
         with_blueprint: true
-        fitment: { damage: { percent: 10 } }
+        fitment:
+          {
+            slot: "low"
+            damage: { percent: 10 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "multiplier"
+    value:
+      {
+        space: 1
+        complexity: 1
+        with_blueprint: true
+        fitment:
+          {
+            slot: "low"
+            complexity: { percent: 10 }
+          }
       }
   }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -42,6 +42,7 @@ fungible_items:
         with_blueprint: true
         construction_resources: { key: "foo" value: 2 }
         construction_resources: { key: "bar" value: 1 }
+        fitment: { slot: "high" }
       }
   }
 fungible_items:
@@ -53,6 +54,7 @@ fungible_items:
         complexity: 1,
         with_blueprint: true
         construction_resources: { key: "zerospace" value: 10 }
+        fitment: { slot: "high" }
       }
   }
 
@@ -107,6 +109,9 @@ fungible_items:
                   }
               }
             mining_rate: { min: 10 max: 100 }
+            equipment_slots: { key: "high" value: 3 }
+            equipment_slots: { key: "mid" value: 2 }
+            equipment_slots: { key: "low" value: 1 }
           }
       }
   }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -71,14 +71,42 @@ fungible_items:
       }
   }
 
+# A test vehicle with some well-defined stats that can be used
+# also e.g. in tests for fitments.
 fungible_items:
   {
     key: "chariot"
     value:
       {
-        space: 50,
-        complexity: 100,
-        with_blueprint: true,
-        vehicle: {}
+        space: 50
+        complexity: 100
+        with_blueprint: true
+        vehicle:
+          {
+            cargo_space: 1000
+            speed: 1000
+            regen_data:
+              {
+                max_hp: { armour: 1000 shield: 100 }
+                shield_regeneration_mhp: 10
+              }
+            combat_data:
+              {
+                attacks:
+                  {
+                    range: 100
+                    min_damage: 10
+                    max_damage: 100
+                  }
+                attacks:
+                  {
+                    range: 10
+                    area: true
+                    min_damage: 1
+                    max_damage: 10
+                  }
+              }
+            mining_rate: { min: 10 max: 100 }
+          }
       }
   }

--- a/proto/roconfig/items/vehicles.pb.text
+++ b/proto/roconfig/items/vehicles.pb.text
@@ -1,0 +1,93 @@
+################################################################################
+# Starter vehicles.
+
+fungible_items:
+  {
+    key: "rv st"
+    value:
+      {
+        space: 100
+        complexity: 1
+        vehicle:
+          {
+            cargo_space: 20
+            speed: 2100
+            regen_data:
+              {
+                max_hp: { armour: 75 shield: 30 }
+                shield_regeneration_mhp: 500
+              }
+            combat_data:
+              {
+                attacks:
+                  {
+                    range: 7
+                    area: true
+                    min_damage: 1
+                    max_damage: 20
+                  }
+              }
+            mining_rate: { min: 0 max: 5 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "gv st"
+    value:
+      {
+        space: 100
+        complexity: 1
+        vehicle:
+          {
+            cargo_space: 30
+            speed: 2000
+            regen_data:
+              {
+                max_hp: { armour: 150 shield: 30 }
+                shield_regeneration_mhp: 200
+              }
+            combat_data:
+              {
+                attacks:
+                  {
+                    range: 10
+                    min_damage: 1
+                    max_damage: 20
+                  }
+              }
+            mining_rate: { min: 0 max: 5 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "bv st"
+    value:
+      {
+        space: 100
+        complexity: 1
+        vehicle:
+          {
+            cargo_space: 20
+            speed: 2200
+            regen_data:
+              {
+                max_hp: { armour: 50 shield: 30 }
+                shield_regeneration_mhp: 1000
+              }
+            combat_data:
+              {
+                attacks:
+                  {
+                    range: 10
+                    min_damage: 1
+                    max_damage: 12
+                  }
+              }
+            mining_rate: { min: 0 max: 5 }
+          }
+      }
+  }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@ libtaurion_la_SOURCES = \
   context.cpp \
   dynobstacles.cpp \
   fame.cpp \
+  fitments.cpp \
   gamestatejson.cpp \
   jsonutils.cpp \
   logic.cpp \
@@ -45,6 +46,7 @@ libtaurionheaders = \
   context.hpp \
   dynobstacles.hpp dynobstacles.tpp \
   fame.hpp \
+  fitments.hpp \
   gamestatejson.hpp \
   jsonutils.hpp \
   logic.hpp \
@@ -118,6 +120,7 @@ tests_SOURCES = \
   combat_tests.cpp \
   dynobstacles_tests.cpp \
   fame_tests.cpp \
+  fitments_tests.cpp \
   gamestatejson_tests.cpp \
   jsonutils_tests.cpp \
   logic_tests.cpp \

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -1,0 +1,62 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "fitments.hpp"
+
+#include "proto/config.pb.h"
+#include "proto/roitems.hpp"
+
+namespace pxd
+{
+
+namespace
+{
+
+/**
+ * Initialises the character stats from the base values with the
+ * given vehicle.
+ */
+void
+InitCharacterStats (Character& c, const proto::ItemData::VehicleData& data)
+{
+  auto& pb = c.MutableProto ();
+  pb.set_cargo_space (data.cargo_space ());
+  pb.set_speed (data.speed ());
+  *pb.mutable_combat_data () = data.combat_data ();
+  c.MutableRegenData () = data.regen_data ();
+  *pb.mutable_mining ()->mutable_rate () = data.mining_rate ();
+}
+
+} // anonymous namespace
+
+void
+DeriveCharacterStats (Character& c)
+{
+  const auto& vehicleItemData = RoItemData (c.GetProto ().vehicle ());
+  CHECK (vehicleItemData.has_vehicle ())
+      << "Character " << c.GetId ()
+      << " is in non-vehicle: " << c.GetProto ().vehicle ();
+  InitCharacterStats (c, vehicleItemData.vehicle ());
+
+  /* Reset the current HP back to maximum, which might have changed.  This is
+     fine as we only allow fitment changes for fully repaired vehicles
+     anyway (as well as for spawned characters).  */
+  c.MutableHP () = c.GetRegenData ().max_hp ();
+}
+
+} // namespace pxd

--- a/src/fitments.hpp
+++ b/src/fitments.hpp
@@ -23,6 +23,9 @@
 
 #include "proto/config.pb.h"
 
+#include <string>
+#include <vector>
+
 namespace pxd
 {
 
@@ -71,6 +74,12 @@ public:
   }
 
 };
+
+/**
+ * Checks if the given list of fitments can be put onto a given vehicle.
+ */
+bool CheckVehicleFitments (const std::string& vehicle,
+                           const std::vector<std::string>& fitments);
 
 /**
  * Updates the "derived" stats of the character based on the vehicle and

--- a/src/fitments.hpp
+++ b/src/fitments.hpp
@@ -1,0 +1,35 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_FITMENTS_HPP
+#define PXD_FITMENTS_HPP
+
+#include "database/character.hpp"
+
+namespace pxd
+{
+
+/**
+ * Updates the "derived" stats of the character based on the vehicle and
+ * fitments it is equipped with.
+ */
+void DeriveCharacterStats (Character& c);
+
+} // namespace pxd
+
+#endif // PXD_FITMENTS_HPP

--- a/src/fitments.hpp
+++ b/src/fitments.hpp
@@ -21,8 +21,56 @@
 
 #include "database/character.hpp"
 
+#include "proto/config.pb.h"
+
 namespace pxd
 {
+
+/**
+ * Simple wrapper around a stat modifier.  It allows adding up different
+ * modifiers to stack them, and computing their effect on a given number.
+ */
+class StatModifier
+{
+
+private:
+
+  /** Increase (or decrease if negative) of the base number as percent.  */
+  int64_t percent = 0;
+
+public:
+
+  StatModifier () = default;
+  StatModifier (const StatModifier&) = default;
+  StatModifier& operator= (const StatModifier&) = default;
+
+  /**
+   * Converts from the roconfig proto form to the instance.
+   */
+  StatModifier (const proto::StatModifier& pb)
+    : percent(pb.percent ())
+  {}
+
+  /**
+   * Adds another modifier "on top of" the current one.
+   */
+  StatModifier&
+  operator+= (const StatModifier& m)
+  {
+    percent += m.percent;
+    return *this;
+  }
+
+  /**
+   * Applies this modifier to a given base value.
+   */
+  int64_t
+  operator() (int64_t base) const
+  {
+    return base + (base * percent) / 100;
+  }
+
+};
 
 /**
  * Updates the "derived" stats of the character based on the vehicle and

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -22,6 +22,8 @@
 
 #include "database/dbtest.hpp"
 
+#include <google/protobuf/text_format.h>
+
 #include <gtest/gtest.h>
 
 namespace pxd
@@ -29,61 +31,173 @@ namespace pxd
 namespace
 {
 
-class FitmentsTests : public DBTestWithSchema
+using google::protobuf::TextFormat;
+
+/* ************************************************************************** */
+
+class StatModifierTests : public testing::Test
 {
 
 protected:
 
+  /**
+   * Constructs a stat modifier from a text proto.
+   */
+  static StatModifier
+  Modifier (const std::string& text)
+  {
+    proto::StatModifier m;
+    CHECK (TextFormat::ParseFromString (text, &m));
+    return m;
+  }
+
+};
+
+TEST_F (StatModifierTests, Default)
+{
+  StatModifier m;
+  m += proto::StatModifier ();
+
+  EXPECT_EQ (m (0), 0);
+  EXPECT_EQ (m (-5), -5);
+  EXPECT_EQ (m (1'000), 1'000);
+}
+
+TEST_F (StatModifierTests, Application)
+{
+  StatModifier m = Modifier ("percent: 50");
+  EXPECT_EQ (m (0), 0);
+  EXPECT_EQ (m (-100), -150);
+  EXPECT_EQ (m (1'000), 1'500);
+  EXPECT_EQ (m (1), 1);
+  EXPECT_EQ (m (3), 4);
+
+  m = Modifier ("percent: -10");
+  EXPECT_EQ (m (0), 0);
+  EXPECT_EQ (m (-100), -90);
+  EXPECT_EQ (m (10), 9);
+}
+
+TEST_F (StatModifierTests, Stacking)
+{
+  StatModifier m;
+  m += Modifier ("percent: 100");
+  m += Modifier ("percent: 100");
+  m += Modifier ("percent: -100");
+  m += Modifier ("percent: 100");
+
+  EXPECT_EQ (m (100), 300);
+}
+
+/* ************************************************************************** */
+
+class DeriveCharacterStatsTests : public DBTestWithSchema
+{
+
+private:
+
   CharacterTable characters;
 
-  FitmentsTests ()
+protected:
+
+  DeriveCharacterStatsTests ()
     : characters(db)
   {}
 
   /**
-   * Returns a test character (with ID 1).
+   * Constructs a character with the given vehicle and the given list
+   * of fitments on it.
    */
   CharacterTable::Handle
-  GetTest ()
+  Derive (const std::string& vehicle,
+          const std::vector<std::string>& fitments)
   {
-    auto c = characters.GetById (1);
-    if (c != nullptr)
-      return c;
+    auto c = characters.CreateNew ("domob", Faction::RED);
+    c->MutableProto ().set_vehicle (vehicle);
+    for (const auto& f : fitments)
+      c->MutableProto ().add_fitments (f);
 
-    c = characters.CreateNew ("domob", Faction::RED);
-    CHECK_EQ (c->GetId (), 1);
+    DeriveCharacterStats (*c);
     return c;
   }
 
 };
 
-using DeriveCharacterStatsTests = FitmentsTests;
-
 TEST_F (DeriveCharacterStatsTests, BaseVehicleStats)
 {
-  GetTest ()->MutableProto ().set_vehicle ("gv st");
-  DeriveCharacterStats (*GetTest ());
-
-  auto c = GetTest ();
+  auto c = Derive ("chariot", {});
   const auto& pb = c->GetProto ();
-  EXPECT_EQ (pb.cargo_space (), 30);
-  EXPECT_EQ (pb.speed (), 2'000);
-  EXPECT_EQ (pb.combat_data ().attacks_size (), 1);
-  EXPECT_EQ (pb.mining ().rate ().max (), 5);
-  EXPECT_EQ (c->GetRegenData ().max_hp ().armour (), 150);
-  EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 30);
-  EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 200);
+  EXPECT_EQ (pb.cargo_space (), 1'000);
+  EXPECT_EQ (pb.speed (), 1'000);
+  EXPECT_EQ (pb.combat_data ().attacks_size (), 2);
+  EXPECT_EQ (pb.mining ().rate ().max (), 100);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().armour (), 1'000);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 1'00);
+  EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 10);
 }
 
 TEST_F (DeriveCharacterStatsTests, HpAreReset)
 {
-  GetTest ()->MutableProto ().set_vehicle ("gv st");
-  GetTest ()->MutableHP ().set_armour (42);
-  DeriveCharacterStats (*GetTest ());
+  auto c = Derive ("chariot", {});
+  c->MutableHP ().set_armour (42);
+  DeriveCharacterStats (*c);
 
-  EXPECT_EQ (GetTest ()->GetHP ().armour (), 150);
-  EXPECT_EQ (GetTest ()->GetHP ().shield (), 30);
+  EXPECT_EQ (c->GetHP ().armour (), 1'000);
+  EXPECT_EQ (c->GetHP ().shield (), 100);
 }
+
+TEST_F (DeriveCharacterStatsTests, FitmentAttacks)
+{
+  auto c = Derive ("chariot", {"bomb"});
+  const auto& attacks = c->GetProto ().combat_data ().attacks ();
+  ASSERT_EQ (attacks.size (), 3);
+  EXPECT_EQ (attacks[0].range (), 100);
+  EXPECT_EQ (attacks[1].range (), 10);
+  EXPECT_EQ (attacks[2].range (), 2);
+}
+
+TEST_F (DeriveCharacterStatsTests, CargoSpeed)
+{
+  auto c = Derive ("chariot", {"turbo"});
+  EXPECT_EQ (c->GetProto ().speed (), 1'100);
+
+  c = Derive ("chariot", {"expander"});
+  EXPECT_EQ (c->GetProto ().cargo_space (), 1'100);
+}
+
+TEST_F (DeriveCharacterStatsTests, MaxHpRegen)
+{
+  auto c = Derive ("chariot", {"plating", "shield"});
+  EXPECT_EQ (c->GetRegenData ().max_hp ().armour (), 1'100);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 110);
+
+  c = Derive ("chariot", {"replenisher"});
+  EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 11);
+}
+
+TEST_F (DeriveCharacterStatsTests, RangeDamage)
+{
+  auto c = Derive ("chariot", {"rangeext", "dmgext"});
+  const auto& a = c->GetProto ().combat_data ().attacks (0);
+  EXPECT_EQ (a.range (), 110);
+  EXPECT_EQ (a.min_damage (), 11);
+  EXPECT_EQ (a.max_damage (), 110);
+}
+
+TEST_F (DeriveCharacterStatsTests, StackingButNotCompounding)
+{
+  auto c = Derive ("chariot", {"turbo", "turbo", "turbo"});
+  EXPECT_EQ (c->GetProto ().speed (), 1'300);
+}
+
+TEST_F (DeriveCharacterStatsTests, FitmentAttacksAlsoBoosted)
+{
+  auto c = Derive ("chariot", {"bomb", "dmgext", "dmgext"});
+  const auto& a = c->GetProto ().combat_data ().attacks (2);
+  EXPECT_EQ (a.max_damage (), 6);
+}
+
+/* ************************************************************************** */
 
 } // anonymous namespace
 } // namespace pxd

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -87,6 +87,35 @@ TEST_F (StatModifierTests, Stacking)
   m += Modifier ("percent: 100");
 
   EXPECT_EQ (m (100), 300);
+}
+
+/* ************************************************************************** */
+
+using CheckVehicleFitmentsTests = testing::Test;
+
+TEST_F (CheckVehicleFitmentsTests, ComplexityLimit)
+{
+  EXPECT_FALSE (CheckVehicleFitments ("chariot", {"bow", "bow"}));
+  EXPECT_TRUE (CheckVehicleFitments ("chariot", {"sword", "sword"}));
+}
+
+TEST_F (CheckVehicleFitmentsTests, Slots)
+{
+  EXPECT_FALSE (CheckVehicleFitments ("rv st", {"sword"}));
+  EXPECT_FALSE (CheckVehicleFitments ("chariot",
+                                      {"bomb", "bomb", "bomb", "bomb"}));
+  EXPECT_TRUE (CheckVehicleFitments ("chariot", {
+      "bomb", "bomb", "bomb",
+      "turbo", "turbo",
+      "expander",
+  }));
+}
+
+TEST_F (CheckVehicleFitmentsTests, ComplexityMultiplier)
+{
+  EXPECT_FALSE (CheckVehicleFitments ("chariot", {"bow", "turbo"}));
+  EXPECT_TRUE (CheckVehicleFitments ("chariot",
+                                     {"bow", "turbo", "multiplier"}));
 }
 
 /* ************************************************************************** */

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -1,0 +1,89 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "fitments.hpp"
+
+#include "testutils.hpp"
+
+#include "database/dbtest.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+class FitmentsTests : public DBTestWithSchema
+{
+
+protected:
+
+  CharacterTable characters;
+
+  FitmentsTests ()
+    : characters(db)
+  {}
+
+  /**
+   * Returns a test character (with ID 1).
+   */
+  CharacterTable::Handle
+  GetTest ()
+  {
+    auto c = characters.GetById (1);
+    if (c != nullptr)
+      return c;
+
+    c = characters.CreateNew ("domob", Faction::RED);
+    CHECK_EQ (c->GetId (), 1);
+    return c;
+  }
+
+};
+
+using DeriveCharacterStatsTests = FitmentsTests;
+
+TEST_F (DeriveCharacterStatsTests, BaseVehicleStats)
+{
+  GetTest ()->MutableProto ().set_vehicle ("gv st");
+  DeriveCharacterStats (*GetTest ());
+
+  auto c = GetTest ();
+  const auto& pb = c->GetProto ();
+  EXPECT_EQ (pb.cargo_space (), 30);
+  EXPECT_EQ (pb.speed (), 2'000);
+  EXPECT_EQ (pb.combat_data ().attacks_size (), 1);
+  EXPECT_EQ (pb.mining ().rate ().max (), 5);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().armour (), 150);
+  EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 30);
+  EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 200);
+}
+
+TEST_F (DeriveCharacterStatsTests, HpAreReset)
+{
+  GetTest ()->MutableProto ().set_vehicle ("gv st");
+  GetTest ()->MutableHP ().set_armour (42);
+  DeriveCharacterStats (*GetTest ());
+
+  EXPECT_EQ (GetTest ()->GetHP ().armour (), 150);
+  EXPECT_EQ (GetTest ()->GetHP ().shield (), 30);
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -254,6 +254,7 @@ template <>
   res["id"] = IntToJson (c.GetId ());
   res["owner"] = c.GetOwner ();
   res["faction"] = FactionToString (c.GetFaction ());
+  res["vehicle"] = c.GetProto ().vehicle ();
 
   if (c.IsInBuilding ())
     res["inbuilding"] = IntToJson (c.GetBuildingId ());

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -256,6 +256,11 @@ template <>
   res["faction"] = FactionToString (c.GetFaction ());
   res["vehicle"] = c.GetProto ().vehicle ();
 
+  Json::Value fitments(Json::arrayValue);
+  for (const auto& f : c.GetProto ().fitments ())
+    fitments.append (f);
+  res["fitments"] = fitments;
+
   if (c.IsInBuilding ())
     res["inbuilding"] = IntToJson (c.GetBuildingId ());
   else

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -265,6 +265,22 @@ TEST_F (CharacterJsonTests, MultipleStep)
   })");
 }
 
+TEST_F (CharacterJsonTests, Vehicle)
+{
+  auto c = tbl.CreateNew ("domob", Faction::RED);
+  c->MutableProto ().set_vehicle ("rv st");
+  c.reset ();
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "vehicle": "rv st"
+        }
+      ]
+  })");
+}
+
 TEST_F (CharacterJsonTests, Target)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -265,17 +265,25 @@ TEST_F (CharacterJsonTests, MultipleStep)
   })");
 }
 
-TEST_F (CharacterJsonTests, Vehicle)
+TEST_F (CharacterJsonTests, VehicleAndFitments)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);
   c->MutableProto ().set_vehicle ("rv st");
+  c->MutableProto ().add_fitments ("turbo");
+  c->MutableProto ().add_fitments ("bomb");
   c.reset ();
+
+  tbl.CreateNew ("andy", Faction::GREEN);
 
   ExpectStateJson (R"({
     "characters":
       [
         {
-          "vehicle": "rv st"
+          "vehicle": "rv st",
+          "fitments": ["turbo", "bomb"]
+        },
+        {
+          "fitments": []
         }
       ]
   })");

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -40,6 +40,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 namespace pxd
 {
@@ -191,6 +192,13 @@ protected:
                              Database::IdT& regionId);
 
   /**
+   * Parses and verifies a potential command to set fitments on a character's
+   * current vehicle.
+   */
+  bool ParseSetFitments (const Character& c, const Json::Value& upd,
+                         std::vector<std::string>& fitments);
+
+  /**
    * Parses and verifies a potential character creation as part of the
    * given move.  For all valid creations, PerformCharacterCreation
    * is called with the relevant data.
@@ -326,6 +334,11 @@ private:
    * Processes a command to start mining at the current location.
    */
   void MaybeStartMining (Character& c, const Json::Value& upd);
+
+  /**
+   * Processes a command to set fitments.
+   */
+  void MaybeSetFitments (Character& c, const Json::Value& upd);
 
   /**
    * Processes a command to drop loot from the character's inventory

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -284,67 +284,6 @@ Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
     }
 }
 
-void
-Params::InitCharacterStats (const Faction f,
-                            proto::RegenData& regen, proto::Character& pb) const
-{
-  auto* miningRate = pb.mutable_mining ()->mutable_rate ();
-  miningRate->set_min (0);
-  miningRate->set_max (5);
-
-  auto* cd = pb.mutable_combat_data ();
-  proto::Attack* attack;
-
-  auto* maxHP = regen.mutable_max_hp ();
-  maxHP->set_shield (30);
-
-  switch (f)
-    {
-    case Faction::RED:
-      pb.set_speed (2'100);
-      pb.set_cargo_space (20);
-
-      maxHP->set_armour (75);
-      regen.set_shield_regeneration_mhp (500);
-
-      attack = cd->add_attacks ();
-      attack->set_range (7);
-      attack->set_area (true);
-      attack->set_min_damage (1);
-      attack->set_max_damage (20);
-      break;
-
-    case Faction::BLUE:
-      pb.set_speed (2'200);
-      pb.set_cargo_space (20);
-
-      maxHP->set_armour (50);
-      regen.set_shield_regeneration_mhp (1'000);
-
-      attack = cd->add_attacks ();
-      attack->set_range (10);
-      attack->set_min_damage (1);
-      attack->set_max_damage (12);
-      break;
-
-    case Faction::GREEN:
-      pb.set_speed (2'000);
-      pb.set_cargo_space (30);
-
-      maxHP->set_armour (150);
-      regen.set_shield_regeneration_mhp (200);
-
-      attack = cd->add_attacks ();
-      attack->set_range (10);
-      attack->set_min_damage (1);
-      attack->set_max_damage (20);
-      break;
-
-    default:
-      LOG (FATAL) << "Invalid faction: " << static_cast<int> (f);
-    }
-}
-
 bool
 Params::GodModeEnabled () const
 {

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -23,7 +23,6 @@
 #include "database/amount.hpp"
 #include "database/faction.hpp"
 #include "database/inventory.hpp"
-#include "proto/character.pb.h"
 
 #include <xayagame/gamelogic.hpp>
 
@@ -176,13 +175,6 @@ public:
    * Returns the spawn centre and radius for the given faction.
    */
   HexCoord SpawnArea (Faction f, HexCoord::IntT& radius) const;
-
-  /**
-   * Initialises the stats for a newly created character.  This fills in the
-   * combat data and other fields in the protocol buffer as needed.
-   */
-  void InitCharacterStats (Faction f, proto::RegenData& regen,
-                           proto::Character& pb) const;
 
   /**
    * Returns true if god-mode commands are allowed (on regtest).

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -203,6 +203,18 @@ PendingState::AddCharacterMining (const Character& ch,
 }
 
 void
+PendingState::AddCharacterFitments (const Character& ch,
+                                    const std::vector<std::string>& fitments)
+{
+  VLOG (1) << "Character " << ch.GetId () << " has pending fitments";
+
+  auto& chState = GetCharacterState (ch);
+  chState.fitments = Json::Value(Json::arrayValue);
+  for (const auto& f : fitments)
+    chState.fitments.append (f);
+}
+
+void
 PendingState::AddCharacterCreation (const std::string& name, const Faction f)
 {
   VLOG (1)
@@ -286,6 +298,9 @@ PendingState::CharacterState::ToJson () const
     res["prospecting"] = IntToJson (prospectingRegionId);
   if (miningRegionId != RegionMap::OUT_OF_MAP)
     res["mining"] = IntToJson (miningRegionId);
+
+  if (!fitments.isNull ())
+    res["fitments"] = fitments;
 
   return res;
 }
@@ -411,6 +426,10 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
     state.AddEnterBuilding (c, buildingId);
   if (ParseExitBuilding (c, upd))
     state.AddExitBuilding (c);
+
+  std::vector<std::string> fitments;
+  if (ParseSetFitments (c, upd, fitments))
+    state.AddCharacterFitments (c, fitments);
 }
 
 void

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -97,6 +97,12 @@ private:
     Database::IdT miningRegionId = RegionMap::OUT_OF_MAP;
 
     /**
+     * Placed fitments on the character, if any.  This is already in JSON
+     * format for simplicity, and None if there are no fitment moves.
+     */
+    Json::Value fitments;
+
+    /**
      * Returns the JSON representation of the pending state.
      */
     Json::Value ToJson () const;
@@ -223,6 +229,13 @@ public:
    * is ignored.
    */
   void AddCharacterMining (const Character& ch, Database::IdT regionId);
+
+  /**
+   * Updates the state to add a move that sets fitments to the
+   * given list of items.
+   */
+  void AddCharacterFitments (const Character& ch,
+                             const std::vector<std::string>& fitments);
 
   /**
    * Updates the state for a new pending character creation.

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -18,6 +18,8 @@
 
 #include "spawn.hpp"
 
+#include "fitments.hpp"
+
 #include "hexagonal/coord.hpp"
 #include "hexagonal/ring.hpp"
 
@@ -121,10 +123,25 @@ SpawnCharacter (const std::string& owner, const Faction f,
   c->SetPosition (pos);
   dyn.AddVehicle (pos, f);
 
-  auto& regen = c->MutableRegenData ();
-  auto& pb = c->MutableProto ();
-  ctx.Params ().InitCharacterStats (f, regen, pb);
-  c->MutableHP () = regen.max_hp ();
+  switch (f)
+    {
+    case Faction::RED:
+      c->MutableProto ().set_vehicle ("rv st");
+      break;
+    case Faction::GREEN:
+      c->MutableProto ().set_vehicle ("gv st");
+      break;
+    case Faction::BLUE:
+      c->MutableProto ().set_vehicle ("bv st");
+      break;
+    default:
+      LOG (FATAL)
+          << "Unexpected faction for spawned character: "
+          << static_cast<int> (f);
+      break;
+    }
+
+  DeriveCharacterStats (*c);
 
   return c;
 }

--- a/src/spawn_tests.cpp
+++ b/src/spawn_tests.cpp
@@ -24,6 +24,7 @@
 #include "hexagonal/coord.hpp"
 #include "hexagonal/ring.hpp"
 
+#include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
 
 #include <unordered_set>
@@ -32,6 +33,8 @@ namespace pxd
 {
 namespace
 {
+
+using google::protobuf::util::MessageDifferencer;
 
 /* ************************************************************************** */
 
@@ -97,6 +100,8 @@ TEST_F (SpawnTests, DataInitialised)
 
   EXPECT_TRUE (c->GetProto ().has_combat_data ());
   EXPECT_FALSE (c->GetProto ().combat_data ().attacks ().empty ());
+  EXPECT_TRUE (MessageDifferencer::Equals (c->GetHP (),
+                                           c->GetRegenData ().max_hp ()));
 }
 
 TEST_F (SpawnTests, PerFactionStats)


### PR DESCRIPTION
This implements the basic infrastructure for vehicle fitments / upgrades, and adds a few basic fitments (mostly for testing).

Fitment changes are only possible while inside a building and when shield and armour are fully healed; also all fitments placed must either be already on the vehicle or in the building inventory.  When placing fitments, all of the character inventory is auto-dropped into the building (to avoid issues with removed cargo expanders or things like that).

The move to set fitments looks like this:

    {"c": {"1": {"fit": ["expander", "multiplier", "cannon", "cannon"]}}}

It simply changes the fitments to the precise list as given, replacing any fitments currently on the vehicle (either reusing them if listed again or dropping into the building inventory if not).

Each fitment needs an equipment slot on the vehicle, which come in three types (`high`, `med` and `low`).  Also, the sum of complexities for all fitments must be at most the complexity of the vehicle item.  If some of the fitments cannot be placed (e.g. because of hitting the complexity limit, missing the item in the inventory or lack of slots), then the entire move is ignored.