### PR TITLE
Implement changing of vehicles

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -34,7 +34,8 @@ REGTESTS = \
   services_refining.py \
   services_repair.py \
   services_reveng.py \
-  splitstaterpcs.py
+  splitstaterpcs.py \
+  vehiclefitments.py
 
 EXTRA_DIST = $(REGTESTS) $(TEST_LIBRARY)
 TESTS = $(REGTESTS)

--- a/gametest/vehiclefitments.py
+++ b/gametest/vehiclefitments.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python2
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests vehicle changes and fitments.
+"""
+
+from pxtest import PXTest
+
+
+class VehicleFitmentsTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.mainLogger.info ("Setting up initial situation...")
+    self.build ("ancient1", None, {"x": 0, "y": 0}, 0)
+    building = 1001
+    self.assertEqual (self.getBuildings ()[building].getType (), "ancient1")
+
+    self.initAccount ("domob", "r")
+    self.generate (1)
+    self.dropIntoBuilding (building, "domob", {
+      "chariot": 1,
+      "plating": 1,
+      "bomb": 1,
+    })
+    self.createCharacters ("domob")
+    self.generate (1)
+    self.moveCharactersTo ({"domob": {"x": 30, "y": 0}})
+    self.getCharacters ()["domob"].sendMove ({"eb": building})
+    self.generate (1)
+
+    self.mainLogger.info ("Changing vehicle...")
+    self.getCharacters ()["domob"].sendMove ({"v": "chariot"})
+    self.generate (1)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.data["vehicle"], "chariot")
+    self.assertEqual (c.data["fitments"], [])
+    self.assertEqual (c.data["combat"]["hp"], {
+      "current": {"armour": 1000, "shield": 100},
+      "max": {"armour": 1000, "shield": 100},
+      "regeneration": 0.01,
+    })
+    self.assertEqual (len (c.data["combat"]["attacks"]), 2)
+
+    self.mainLogger.info ("Adding fitments...")
+    self.getCharacters ()["domob"].sendMove ({"fit": ["plating", "bomb"]})
+    self.generate (1)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.data["vehicle"], "chariot")
+    self.assertEqual (c.data["fitments"], ["plating", "bomb"])
+    self.assertEqual (c.data["combat"]["hp"], {
+      "current": {"armour": 1100, "shield": 100},
+      "max": {"armour": 1100, "shield": 100},
+      "regeneration": 0.01,
+    })
+    self.assertEqual (len (c.data["combat"]["attacks"]), 3)
+
+    self.mainLogger.info ("Removing fitments...")
+    self.getCharacters ()["domob"].sendMove ({"fit": []})
+    self.generate (1)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.data["vehicle"], "chariot")
+    self.assertEqual (c.data["fitments"], [])
+    self.assertEqual (c.data["combat"]["hp"], {
+      "current": {"armour": 1000, "shield": 100},
+      "max": {"armour": 1000, "shield": 100},
+      "regeneration": 0.01,
+    })
+    self.assertEqual (len (c.data["combat"]["attacks"]), 2)
+
+
+if __name__ == "__main__":
+  VehicleFitmentsTest ().main ()

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -192,6 +192,12 @@ protected:
                              Database::IdT& regionId);
 
   /**
+   * Parses and verifies a potential "change vehicle" command.
+   */
+  bool ParseChangeVehicle (const Character& c, const Json::Value& upd,
+                           std::string& vehicle);
+
+  /**
    * Parses and verifies a potential command to set fitments on a character's
    * current vehicle.
    */
@@ -334,6 +340,11 @@ private:
    * Processes a command to start mining at the current location.
    */
   void MaybeStartMining (Character& c, const Json::Value& upd);
+
+  /**
+   * Processes a command to change character vehicle.
+   */
+  void MaybeChangeVehicle (Character& c, const Json::Value& upd);
 
   /**
    * Processes a command to set fitments.

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -203,6 +203,14 @@ PendingState::AddCharacterMining (const Character& ch,
 }
 
 void
+PendingState::AddCharacterVehicle (const Character& ch,
+                                   const std::string& vehicle)
+{
+  VLOG (1) << "Character " << ch.GetId () << " changes to vehicle " << vehicle;
+  GetCharacterState (ch).changeVehicle = vehicle;
+}
+
+void
 PendingState::AddCharacterFitments (const Character& ch,
                                     const std::vector<std::string>& fitments)
 {
@@ -299,6 +307,8 @@ PendingState::CharacterState::ToJson () const
   if (miningRegionId != RegionMap::OUT_OF_MAP)
     res["mining"] = IntToJson (miningRegionId);
 
+  if (!changeVehicle.empty ())
+    res["changevehicle"] = changeVehicle;
   if (!fitments.isNull ())
     res["fitments"] = fitments;
 
@@ -427,6 +437,9 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
   if (ParseExitBuilding (c, upd))
     state.AddExitBuilding (c);
 
+  std::string vehicle;
+  if (ParseChangeVehicle (c, upd, vehicle))
+    state.AddCharacterVehicle (c, vehicle);
   std::vector<std::string> fitments;
   if (ParseSetFitments (c, upd, fitments))
     state.AddCharacterFitments (c, fitments);

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -96,6 +96,9 @@ private:
      */
     Database::IdT miningRegionId = RegionMap::OUT_OF_MAP;
 
+    /** The vehicle the character is changing to (if non-empty).  */
+    Json::Value changeVehicle;
+
     /**
      * Placed fitments on the character, if any.  This is already in JSON
      * format for simplicity, and None if there are no fitment moves.
@@ -229,6 +232,11 @@ public:
    * is ignored.
    */
   void AddCharacterMining (const Character& ch, Database::IdT regionId);
+
+  /**
+   * Updates the state to add a "change vehicle" move.
+   */
+  void AddCharacterVehicle (const Character& ch, const std::string& vehicle);
 
   /**
    * Updates the state to add a move that sets fitments to the


### PR DESCRIPTION
This defines a new move, with which characters inside buildings (and with full HP) can change to a different vehicle:

    {"c": {"42": {"v": "vehicle type"}}}

The vehicle to change to must be in the owner account's building inventory.  When successful, all inventory is dropped into the building and all fitments are removed.  (But both inventory items and fitments can be pickedup/re-equiped again in the same move if desired.)