### PR TITLE
Building foundations

### DIFF
--- a/database/inventory_tests.cpp
+++ b/database/inventory_tests.cpp
@@ -136,6 +136,25 @@ TEST_F (InventoryTests, AdditionOfOtherInventory)
   EXPECT_EQ (inv.GetFungibleCount ("bar"), 3);
 }
 
+TEST_F (InventoryTests, ProtoRef)
+{
+  proto::Inventory pb;
+  pb.mutable_fungible ()->insert ({"foo", 5});
+
+  Inventory other(pb);
+  EXPECT_EQ (other.GetFungibleCount ("foo"), 5);
+  other.AddFungibleCount ("foo", -5);
+  other.AddFungibleCount ("bar", 10);
+
+  EXPECT_EQ (pb.fungible ().size (), 1);
+  EXPECT_EQ (pb.fungible ().at ("bar"), 10);
+
+  const proto::Inventory& constRef(pb);
+  Inventory ro(constRef);
+  EXPECT_EQ (ro.GetFungibleCount ("bar"), 10);
+  EXPECT_DEATH (ro.AddFungibleCount ("foo", 1), "non-mutable");
+}
+
 TEST_F (InventoryTests, DualProduct)
 {
   const auto val = Inventory::Product (MAX_ITEM_QUANTITY, -MAX_ITEM_DUAL);

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -6,6 +6,7 @@ REGTESTS = \
   buildings_basic.py \
   buildings_combat.py \
   buildings_enterexit.py \
+  buildings_foundations.py \
   buildings_inventory.py \
   character_limit.py \
   characters.py \

--- a/gametest/buildings_foundations.py
+++ b/gametest/buildings_foundations.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests basic behaviour of foundations in the game.
+"""
+
+from pxtest import PXTest
+
+
+class BuildingFoundationsTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("Creating and preparing test character...")
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob")
+    self.generate (1)
+    self.changeCharacterVehicle ("domob", "chariot", ["sword"])
+    pos = {"x": 0, "y": 0}
+    self.dropLoot (pos, {"foo": 100})
+    self.moveCharactersTo ({"domob": pos})
+    self.getCharacters ()["domob"].sendMove ({"pu": {"f": {"foo": 4}}})
+    self.generate (1)
+
+    self.mainLogger.info ("Building foundations...")
+    # It is actually possible to build *two* foundations (or more)
+    # in a single block in the way done below.
+    c = self.getCharacters ()["domob"]
+    c.sendMove ({
+      "fb": {"t": "huesli", "rot": 0},
+      "xb": {},
+    })
+    c.sendMove ({
+      "fb": {"t": "huesli", "rot": 0},
+      "xb": {},
+    })
+    self.generate (1)
+
+    buildings = self.getBuildings ()
+    bIds = buildings.keys ()[-2:]
+    for b in bIds:
+      self.assertEqual (buildings[b].isFoundation (), True)
+      self.assertEqual (buildings[b].getOwner (), "domob")
+      self.assertEqual (buildings[b].getFaction (), "r")
+      self.assertEqual (buildings[b].getType (), "huesli")
+
+    self.mainLogger.info ("Dropping into foundation...")
+    self.dropLoot (self.getCharacters ()["domob"].getPosition (),
+                   {"zerospace": 5})
+    self.getCharacters ()["domob"].sendMove ({
+      "pu": {"f": {"zerospace": 5}},
+      "eb": bIds[1],
+    })
+    self.generate (1)
+    self.getCharacters ()["domob"].sendMove ({"drop": {"f": {"zerospace": 5}}})
+    self.generate (1)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.getFungibleInventory (), {})
+    b = self.getBuildings ()[bIds[1]]
+    self.assertEqual (b.getConstructionInventory (), {"zerospace": 5})
+
+    self.mainLogger.info ("Foundations are restricted in use...")
+    self.giftCoins ({"domob": 1000000})
+    self.getCharacters ()["domob"].sendMove ({
+      "fit": [],
+      "pu": {"f": {"zerospace": 10}},
+    })
+    self.generate (1)
+
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.data["fitments"], ["sword"])
+    self.assertEqual (c.getFungibleInventory (), {})
+
+    self.setCharactersHP ({
+      "domob": {"a": 10},
+    })
+    self.sendMove ("domob", {"s": [
+      {"t": "fix", "c": c.getId (), "b": bIds[1]},
+    ]})
+    self.generate (10)
+    c = self.getCharacters ()["domob"]
+    self.assertEqual (c.getBusy (), None)
+    self.assertEqual (c.data["combat"]["hp"]["current"]["armour"], 10)
+
+
+if __name__ == "__main__":
+  BuildingFoundationsTest ().main ()

--- a/hexagonal/coord.hpp
+++ b/hexagonal/coord.hpp
@@ -85,6 +85,7 @@ public:
 
   void operator+= (const HexCoord& delta);
   friend HexCoord operator* (const IntT f, const HexCoord& c);
+  friend HexCoord operator+ (const HexCoord& a, const HexCoord& b);
 
   /**
    * Computes and returns the matching z coordinate in cubic hex coordinates.

--- a/hexagonal/coord.tpp
+++ b/hexagonal/coord.tpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -64,6 +64,12 @@ inline HexCoord
 operator* (const HexCoord::IntT f, const HexCoord& c)
 {
   return HexCoord (f * c.GetX (), f * c.GetY ());
+}
+
+inline HexCoord
+operator+ (const HexCoord& a, const HexCoord& b)
+{
+  return HexCoord (a.GetX () + b.GetX (), a.GetY () + b.GetY ());
 }
 
 inline HexCoord::IntT

--- a/hexagonal/coord_tests.cpp
+++ b/hexagonal/coord_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -65,6 +65,8 @@ TEST_F (CoordTests, Arithmetic)
 
   test += HexCoord (5, -5);
   EXPECT_EQ (test, HexCoord (3, 0));
+
+  EXPECT_EQ (HexCoord (1, 2) + HexCoord (-5, 3), HexCoord (-4, 5));
 }
 
 TEST_F (CoordTests, Rotation)

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -19,6 +19,7 @@
 syntax = "proto2";
 
 import "combat.proto";
+import "inventory.proto";
 
 package pxd.proto;
 
@@ -53,17 +54,23 @@ message Building
   optional bool foundation = 2;
 
   /**
+   * The inventory with materials for construction of the full building,
+   * while this is just a foundation.
+   */
+  optional Inventory construction_inventory = 3;
+
+  /**
    * Static combat data for this building (besides regeneration).  This is
    * mostly based on the building type, but may change if the building is
    * upgraded or the account gains skills.
    */
-  optional CombatData combat_data = 3;
+  optional CombatData combat_data = 4;
 
   /**
    * The service fee that users need to pay to the building owner for using
    * services in the building.  This is a percentage of the service's base
    * fee (the burnt amount).
    */
-  optional uint32 service_fee_percent = 4;
+  optional uint32 service_fee_percent = 5;
 
 }

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -49,18 +49,21 @@ message Building
   /** The transformation applied to the building's base shape.  */
   optional ShapeTransformation shape_trafo = 1;
 
+  /** True if this is just a foundation for now (and not the full building).  */
+  optional bool foundation = 2;
+
   /**
    * Static combat data for this building (besides regeneration).  This is
    * mostly based on the building type, but may change if the building is
    * upgraded or the account gains skills.
    */
-  optional CombatData combat_data = 2;
+  optional CombatData combat_data = 3;
 
   /**
    * The service fee that users need to pay to the building owner for using
    * services in the building.  This is a percentage of the service's base
    * fee (the burnt amount).
    */
-  optional uint32 service_fee_percent = 3;
+  optional uint32 service_fee_percent = 4;
 
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -236,15 +236,50 @@ message BuildingData
   repeated HexCoord shape_tiles = 2;
 
   /**
-   * Combat data (attacks) the building has in its base (unupgraded)
-   * form, if any.
+   * Combination of combat and regen data for a building or
+   * the foundation.
    */
-  optional CombatData combat_data = 3;
+  message AllCombatData
+  {
+    optional CombatData combat_data = 1;
+    optional RegenData regen_data = 2;
+  }
 
   /**
-   * Maximum HP and regeneration data the building has in its base form.
+   * Combat data for the foundation of the building alone.
    */
-  optional RegenData regen_data = 4;
+  optional AllCombatData foundation = 3;
+
+  /**
+   * Combat data for the full building (after construction is done).
+   */
+  optional AllCombatData full_building = 4;
+
+  /**
+   * Required resources and other data for constructing the building.
+   */
+  message ConstructionData
+  {
+
+    /**
+     * Resources (keyed by item type, value is the quantity) required to
+     * lay the foundation.
+     */
+    map<string, uint32> foundation = 1;
+
+    /** Resources for upgrading the foundation to the full building.  */
+    map<string, uint32> construction = 2;
+
+    /**
+     * Number of blocks the construction (from foundation to full building)
+     * takes for this type.
+     */
+    optional uint32 blocks = 3;
+
+  }
+
+  /** The data for constructing this building.  */
+  optional ConstructionData construction = 5;
 
   /**
    * The set of services offered by a building.  Since "false" is the default
@@ -262,7 +297,7 @@ message BuildingData
   }
 
   /** Services this building type offers.  */
-  optional Services offered_services = 5;
+  optional Services offered_services = 6;
 
 }
 

--- a/proto/roconfig/buildings/test.pb.text
+++ b/proto/roconfig/buildings/test.pb.text
@@ -1,5 +1,7 @@
 # Some test buildings that can only be constructed through god mode or
-# in unit tests.
+# in unit tests.  This is enforced by having them either be unconstructible
+# outright, or require test-resources (not available through normal
+# gameplay) for construction.
 
 building_types:
   {
@@ -17,9 +19,16 @@ building_types:
         shape_tiles: { x: 0 y: 1 }
         shape_tiles: { x: 0 y: 2 }
 
+        construction:
+          {
+            foundation: { key: "foo" value: 1 }
+          }
+
       }
   }
 
+# Buildings that allow testing the differentiation between the
+# "construct item" and "construct vehicle" services.
 building_types:
   {
     key: "itemmaker"
@@ -38,5 +47,39 @@ building_types:
         enter_radius: 5
         shape_tiles: { x: 0 y: 0 }
         offered_services: { vehicle_construction: true }
+      }
+  }
+
+# Simple building with well-defined construction data for use in
+# tests of building construction logic.
+building_types:
+  {
+    key: "huesli"
+    value:
+      {
+        enter_radius: 5
+        shape_tiles: { x: 0 y: 0 }
+        offered_services: { armour_repair: true }
+        foundation:
+          {
+            regen_data:
+              {
+                max_hp: { armour: 10 }
+              }
+          }
+        full_building:
+          {
+            regen_data:
+              {
+                max_hp: { armour: 100 }
+              }
+          }
+        construction:
+          {
+            foundation: { key: "foo" value: 2 }
+            construction: { key: "foo" value: 3 }
+            construction: { key: "zerospace" value: 10 }
+            blocks: 10
+          }
       }
   }

--- a/proto/roconfig/buildings/turrets.pb.text
+++ b/proto/roconfig/buildings/turrets.pb.text
@@ -7,24 +7,32 @@ building_types:
         enter_radius: 1
         shape_tiles: { x: 0 y: 0 }
 
-        combat_data:
+        foundation:
           {
-            attacks:
+            combat_data: {}
+            regen_data:
               {
-                range: 5
-                min_damage: 1
-                max_damage: 3
+                max_hp: { armour: 50 shield: 0 }
+                shield_regeneration_mhp: 0
               }
           }
 
-        regen_data:
+        full_building:
           {
-            max_hp:
+            combat_data:
               {
-                armour: 1000
-                shield: 200
+                attacks:
+                  {
+                    range: 5
+                    min_damage: 1
+                    max_damage: 3
+                  }
               }
-            shield_regeneration_mhp: 500
+            regen_data:
+              {
+                max_hp: { armour: 1000 shield: 200 }
+                shield_regeneration_mhp: 500
+              }
           }
 
       }

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -147,6 +147,16 @@ UpdateBuildingStats (Building& b)
 }
 
 void
+EnterBuilding (Character& c, const Building& b)
+{
+  c.SetBuildingId (b.GetId ());
+  c.ClearTarget ();
+  c.SetEnterBuilding (Database::EMPTY_ID);
+  StopCharacter (c);
+  StopMining (c);
+}
+
+void
 ProcessEnterBuildings (Database& db)
 {
   BuildingsTable buildings(db);
@@ -194,12 +204,7 @@ ProcessEnterBuildings (Database& db)
       LOG (INFO)
           << "Character " << c->GetId () << " is entering " << buildingId;
       ++entered;
-
-      c->SetBuildingId (buildingId);
-      c->ClearTarget ();
-      c->SetEnterBuilding (Database::EMPTY_ID);
-      StopCharacter (*c);
-      StopMining (*c);
+      EnterBuilding (*c, *b);
     }
 
   LOG (INFO)

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -78,10 +78,16 @@ void
 UpdateBuildingStats (Building& b)
 {
   const auto& roData = b.RoConfigData ();
+  const proto::BuildingData::AllCombatData* data;
 
-  *b.MutableProto ().mutable_combat_data () = roData.combat_data ();
-  b.MutableRegenData () = roData.regen_data ();
-  b.MutableHP () = roData.regen_data ().max_hp ();
+  if (b.GetProto ().foundation ())
+    data = &roData.foundation ();
+  else
+    data = &roData.full_building ();
+
+  *b.MutableProto ().mutable_combat_data () = data->combat_data ();
+  b.MutableRegenData () = data->regen_data ();
+  b.MutableHP () = data->regen_data ().max_hp ();
 }
 
 void

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -147,8 +147,9 @@ UpdateBuildingStats (Building& b)
 }
 
 void
-EnterBuilding (Character& c, const Building& b)
+EnterBuilding (Character& c, const Building& b, DynObstacles& dyn)
 {
+  dyn.RemoveVehicle (c.GetPosition (), c.GetFaction ());
   c.SetBuildingId (b.GetId ());
   c.ClearTarget ();
   c.SetEnterBuilding (Database::EMPTY_ID);
@@ -157,7 +158,7 @@ EnterBuilding (Character& c, const Building& b)
 }
 
 void
-ProcessEnterBuildings (Database& db)
+ProcessEnterBuildings (Database& db, DynObstacles& dyn)
 {
   BuildingsTable buildings(db);
   CharacterTable characters(db);
@@ -204,7 +205,7 @@ ProcessEnterBuildings (Database& db)
       LOG (INFO)
           << "Character " << c->GetId () << " is entering " << buildingId;
       ++entered;
-      EnterBuilding (*c, *b);
+      EnterBuilding (*c, *b, dyn);
     }
 
   LOG (INFO)
@@ -231,6 +232,7 @@ LeaveBuilding (BuildingsTable& buildings, Character& c,
       << " is leaving building " << b->GetId ()
       << " to location " << pos;
   c.SetPosition (pos);
+  dyn.AddVehicle (pos, c.GetFaction ());
 }
 
 } // namespace pxd

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -23,6 +23,7 @@
 #include "protoutils.hpp"
 #include "spawn.hpp"
 
+#include "mapdata/regionmap.hpp"
 #include "proto/config.pb.h"
 #include "proto/roconfig.hpp"
 
@@ -31,13 +32,22 @@
 namespace pxd
 {
 
-std::vector<HexCoord>
-GetBuildingShape (const Building& b)
+namespace
 {
-  const auto& roData = b.RoConfigData ();
 
-  const auto centre = b.GetCentre ();
-  const auto& trafo = b.GetProto ().shape_trafo ();
+/**
+ * Returns the building shape based on the raw data, so that it can be used
+ * also for not-yet-existing buildings (e.g. while placing).
+ */
+std::vector<HexCoord>
+GetBuildingShape (const std::string& type,
+                  const proto::ShapeTransformation& trafo,
+                  const HexCoord& pos)
+{
+  const auto& roConfig = RoConfigData ().building_types ();
+  const auto mit = roConfig.find (type);
+  CHECK (mit != roConfig.end ()) << "Building has undefined type: " << type;
+  const auto& roData = mit->second;
 
   std::vector<HexCoord> res;
   res.reserve (roData.shape_tiles ().size ());
@@ -45,11 +55,57 @@ GetBuildingShape (const Building& b)
     {
       HexCoord c = CoordFromProto (pbTile);
       c = c.RotateCW (trafo.rotation_steps ()); 
-      c += centre;
+      c += pos;
       res.push_back (c);
     }
 
   return res;
+}
+
+} // anonymous namespace
+
+std::vector<HexCoord>
+GetBuildingShape (const Building& b)
+{
+  return GetBuildingShape (b.GetType (), b.GetProto ().shape_trafo (),
+                           b.GetCentre ());
+}
+
+bool
+CanPlaceBuilding (const std::string& type,
+                  const proto::ShapeTransformation& trafo,
+                  const HexCoord& pos,
+                  const DynObstacles& dyn, const Context& ctx)
+{
+  RegionMap::IdT region = RegionMap::OUT_OF_MAP;
+  for (const auto& c : GetBuildingShape (type, trafo, pos))
+    {
+      if (!ctx.Map ().IsPassable (c))
+        {
+          VLOG (1) << "Position " << c << " is not passable in the base map";
+          return false;
+        }
+      if (!dyn.IsFree (c))
+        {
+          VLOG (1) << "Position " << c << " has a dynamic obstacle";
+          return false;
+        }
+
+      const auto curRegion = ctx.Map ().Regions ().GetRegionId (c);
+      CHECK_NE (curRegion, RegionMap::OUT_OF_MAP);
+
+      if (region == RegionMap::OUT_OF_MAP)
+        region = curRegion;
+      else if (region != curRegion)
+        {
+          VLOG (1)
+              << "Position " << c << " has region " << curRegion
+              << ", while other parts are on region " << region;
+          return false;
+        }
+    }
+
+  return true;
 }
 
 void

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -67,13 +67,13 @@ void UpdateBuildingStats (Building& b);
  * Processes the updates (without any validation) for entering the given
  * building with the given character.
  */
-void EnterBuilding (Character& c, const Building& b);
+void EnterBuilding (Character& c, const Building& b, DynObstacles& dyn);
 
 /**
  * Processes all characters that want to enter a building, and lets them in
  * if it is possible for them.
  */
-void ProcessEnterBuildings (Database& db);
+void ProcessEnterBuildings (Database& db, DynObstacles& dyn);
 
 /**
  * Makes the given character leave the building it is currently in.

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -64,6 +64,12 @@ void InitialiseBuildings (Database& db);
 void UpdateBuildingStats (Building& b);
 
 /**
+ * Processes the updates (without any validation) for entering the given
+ * building with the given character.
+ */
+void EnterBuilding (Character& c, const Building& b);
+
+/**
  * Processes all characters that want to enter a building, and lets them in
  * if it is possible for them.
  */

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -26,6 +26,7 @@
 #include "database/character.hpp"
 #include "database/database.hpp"
 #include "hexagonal/coord.hpp"
+#include "proto/building.pb.h"
 
 #include <xayautil/random.hpp>
 
@@ -39,6 +40,17 @@ namespace pxd
  * its shape trafo into account.
  */
 std::vector<HexCoord> GetBuildingShape (const Building& b);
+
+/**
+ * Checks if a building of the given type and rotation can be placed
+ * at the given location.  The conditions are that no tile must be taken
+ * already by another building or character, and that all tiles must be
+ * of the same region.
+ */
+bool CanPlaceBuilding (const std::string& type,
+                       const proto::ShapeTransformation& trafo,
+                       const HexCoord& pos,
+                       const DynObstacles& dyn, const Context& ctx);
 
 /**
  * Places initial buildings (ancient and obelisks) onto the map.

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -76,8 +76,14 @@ TEST_F (BuildingsTests, UpdateBuildingStats)
   auto h = tbl.CreateNew ("r_rt", "domob", Faction::RED);
   UpdateBuildingStats (*h);
   EXPECT_EQ (h->GetProto ().combat_data ().attacks_size (), 1);
-  EXPECT_GT (h->GetRegenData ().max_hp ().armour (), 0);
-  EXPECT_GT (h->GetHP ().armour (), 0);
+  EXPECT_EQ (h->GetRegenData ().max_hp ().armour (), 1'000);
+  EXPECT_EQ (h->GetHP ().armour (), 1'000);
+
+  h->MutableProto ().set_foundation (true);
+  UpdateBuildingStats (*h);
+  EXPECT_EQ (h->GetProto ().combat_data ().attacks_size (), 0);
+  EXPECT_EQ (h->GetRegenData ().max_hp ().armour (), 50);
+  EXPECT_EQ (h->GetHP ().armour (), 50);
 }
 
 /* ************************************************************************** */

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -395,6 +395,11 @@ KillProcessor::ProcessBuilding (const Database::IdT id)
       }
   }
 
+  auto b = buildings.GetById (id);
+  CHECK (b != nullptr) << "Killed non-existant building " << id;
+  if (b->GetProto ().has_construction_inventory ())
+    totalInv += Inventory (b->GetProto ().construction_inventory ());
+
   /* The underlying proto map does not have a well-defined order.  Since the
      random rolls depend on the other, make sure to explicitly sort the
      the list of inventory positions.  */
@@ -402,8 +407,6 @@ KillProcessor::ProcessBuilding (const Database::IdT id)
   const std::map<std::string, Inventory::QuantityT> invItems (
       protoInvMap.begin (), protoInvMap.end ());
 
-  auto b = buildings.GetById (id);
-  CHECK (b != nullptr) << "Killed non-existant building " << id;
   auto lootHandle = loot.GetByCoord (b->GetCentre ());
   b.reset ();
 

--- a/src/dynobstacles.hpp
+++ b/src/dynobstacles.hpp
@@ -80,6 +80,12 @@ public:
   bool IsPassable (const HexCoord& c, Faction f) const;
 
   /**
+   * Checks whether the given tile is entirely free (which is needed to
+   * place buildings).
+   */
+  bool IsFree (const HexCoord& c) const;
+
+  /**
    * Adds a new vehicle with the given faction and position.
    */
   void AddVehicle (const HexCoord& c, Faction f);

--- a/src/dynobstacles.tpp
+++ b/src/dynobstacles.tpp
@@ -45,6 +45,12 @@ DynObstacles::IsPassable (const HexCoord& c, const Faction f) const
   return !buildings.Get (c) && !FactionVehicles (f).Get (c);
 }
 
+inline bool
+DynObstacles::IsFree (const HexCoord& c) const
+{
+  return !buildings.Get (c) && !red.Get (c) && !green.Get (c) && !blue.Get (c);
+}
+
 inline void
 DynObstacles::AddVehicle (const HexCoord& c, const Faction f)
 {

--- a/src/dynobstacles_tests.cpp
+++ b/src/dynobstacles_tests.cpp
@@ -102,5 +102,23 @@ TEST_F (DynObstaclesTests, Modifications)
   EXPECT_FALSE (dyn.IsPassable (HexCoord (1, 0), Faction::RED));
 }
 
+TEST_F (DynObstaclesTests, IsFree)
+{
+  auto b = buildings.CreateNew ("huesli", "", Faction::ANCIENT);
+  b->SetCentre (HexCoord (0, 0));
+
+  DynObstacles dyn(db);
+  dyn.AddBuilding (*b);
+  dyn.AddVehicle (HexCoord (1, 0), Faction::RED);
+  dyn.AddVehicle (HexCoord (2, 0), Faction::GREEN);
+  dyn.AddVehicle (HexCoord (3, 0), Faction::BLUE);
+
+  EXPECT_TRUE (dyn.IsFree (HexCoord (0, 1)));
+  EXPECT_FALSE (dyn.IsFree (HexCoord (0, 0)));
+  EXPECT_FALSE (dyn.IsFree (HexCoord (1, 0)));
+  EXPECT_FALSE (dyn.IsFree (HexCoord (2, 0)));
+  EXPECT_FALSE (dyn.IsFree (HexCoord (3, 0)));
+}
+
 } // anonymous namespace
 } // namespace pxd

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -308,15 +308,19 @@ template <>
   Json::Value
   GameStateJson::Convert<Building> (const Building& b) const
 {
+  const auto& pb = b.GetProto ();
+
   Json::Value res(Json::objectValue);
   res["id"] = IntToJson (b.GetId ());
   res["type"] = b.GetType ();
+  if (pb.foundation ())
+    res["foundation"] = true;
+
   res["faction"] = FactionToString (b.GetFaction ());
   if (b.GetFaction () != Faction::ANCIENT)
     res["owner"] = b.GetOwner ();
   res["centre"] = CoordToJson (b.GetCentre ());
 
-  const auto& pb = b.GetProto ();
   res["rotationsteps"] = IntToJson (pb.shape_trafo ().rotation_steps ());
   res["servicefee"] = IntToJson (pb.service_fee_percent ());
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -331,14 +331,19 @@ template <>
 
   res["combat"] = GetCombatJsonObject (b);
 
-  auto invRes = buildingInventories.QueryForBuilding (b.GetId ());
-  Json::Value inv(Json::objectValue);
-  while (invRes.Step ())
+  if (pb.foundation ())
+    res["constructioninv"] = Convert (Inventory (pb.construction_inventory ()));
+  else
     {
-      auto h = buildingInventories.GetFromResult (invRes);
-      inv[h->GetAccount ()] = Convert (h->GetInventory ());
+      auto invRes = buildingInventories.QueryForBuilding (b.GetId ());
+      Json::Value inv(Json::objectValue);
+      while (invRes.Step ())
+        {
+          auto h = buildingInventories.GetFromResult (invRes);
+          inv[h->GetAccount ()] = Convert (h->GetInventory ());
+        }
+      res["inventories"] = inv;
     }
-  res["inventories"] = inv;
 
   return res;
 }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -637,6 +637,37 @@ TEST_F (BuildingJsonTests, Ancient)
   })");
 }
 
+TEST_F (BuildingJsonTests, Foundation)
+{
+  tbl.CreateNew ("checkmark", "foo", Faction::RED);
+
+  auto b = tbl.CreateNew ("checkmark", "foo", Faction::RED);
+  b->MutableProto ().set_foundation (false);
+  b.reset ();
+
+  b = tbl.CreateNew ("checkmark", "foo", Faction::RED);
+  b->MutableProto ().set_foundation (true);
+  b.reset ();
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "foundation": null
+        },
+        {
+          "id": 2,
+          "foundation": null
+        },
+        {
+          "id": 3,
+          "foundation": true
+        }
+      ]
+  })");
+}
+
 TEST_F (BuildingJsonTests, Inventories)
 {
   ASSERT_EQ (tbl.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId (), 1);

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -647,6 +647,8 @@ TEST_F (BuildingJsonTests, Foundation)
 
   b = tbl.CreateNew ("checkmark", "foo", Faction::RED);
   b->MutableProto ().set_foundation (true);
+  b->MutableProto ().mutable_construction_inventory ()
+      ->mutable_fungible ()->insert ({"bar", 10});
   b.reset ();
 
   ExpectStateJson (R"({
@@ -654,7 +656,9 @@ TEST_F (BuildingJsonTests, Foundation)
       [
         {
           "id": 1,
-          "foundation": null
+          "foundation": null,
+          "constructioninv": null,
+          "inventories": {}
         },
         {
           "id": 2,
@@ -662,7 +666,12 @@ TEST_F (BuildingJsonTests, Foundation)
         },
         {
           "id": 3,
-          "foundation": true
+          "foundation": true,
+          "constructioninv":
+            {
+              "fungible": {"bar": 10}
+            },
+          "inventories": null
         }
       ]
   })");

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -88,7 +88,7 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
      enter as soon as possible (perhaps in the same instant the move for it
      gets confirmed).  It should be before combat targets, so that players
      entering a building won't be attacked any more.  */
-  ProcessEnterBuildings (db);
+  ProcessEnterBuildings (db, dyn);
 
   FindCombatTargets (db, rnd);
 

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -1020,6 +1020,19 @@ TEST_F (ValidateStateTests, BuildingInventories)
   EXPECT_DEATH (ValidateState (), "non-existant building");
   buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
   ValidateState ();
+
+  buildings.GetById (10)->MutableProto ().set_foundation (true);
+  EXPECT_DEATH (ValidateState (), "in foundation");
+  buildings.GetById (10)->MutableProto ().set_foundation (false);
+  ValidateState ();
+
+  auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  ASSERT_EQ (b->GetId (), 12);
+  b->MutableProto ().mutable_construction_inventory ();
+  b.reset ();
+  EXPECT_DEATH (ValidateState (), "has construction inventory");
+  buildings.GetById (12)->MutableProto ().set_foundation (true);
+  ValidateState ();
 }
 
 TEST_F (ValidateStateTests, OngoingsToCharacterLink)

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -286,6 +286,38 @@ TEST_F (PXLogicTests, KilledVehicleNoLongerBlocks)
   EXPECT_EQ (characters.GetById (idMoving)->GetPosition (), HexCoord (10, 0));
 }
 
+TEST_F (PXLogicTests, NewBuildingBlocksMovement)
+{
+  auto c = CreateCharacter ("builder", Faction::GREEN);
+  ASSERT_EQ (c->GetId (), 1);
+  c->SetPosition (HexCoord (0, 0));
+  c->GetInventory ().AddFungibleCount ("foo", 10);
+  c.reset ();
+
+  c = CreateCharacter ("moving", Faction::RED);
+  ASSERT_EQ (c->GetId (), 2);
+  c->SetPosition (HexCoord (1, 0));
+  c->MutableProto ().set_speed (1'000);
+  c.reset ();
+
+  /* Building a foundation should immediately block future movement in the
+     same round already.  */
+  db.SetNextId (101);
+  UpdateState (R"([
+    {
+      "name": "moving",
+      "move": {"c": {"2": {"wp": [{"x": 0, "y": 0}]}}}
+    },
+    {
+      "name": "builder",
+      "move": {"c": {"1": {"fb": {"t": "huesli", "rot": 0}}}}
+    }
+  ])");
+
+  EXPECT_NE (buildings.GetById (101), nullptr);
+  EXPECT_EQ (characters.GetById (2)->GetPosition (), HexCoord (1, 0));
+}
+
 TEST_F (PXLogicTests, DamageInNextRound)
 {
   auto c = CreateCharacter ("domob", Faction::RED);

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -291,48 +291,6 @@ template <typename Fcn>
     }
 }
 
-/**
- * RAII helper class to remove a vehicle from the dynamic obstacles and
- * then add it back again at the (potentially) changed position.
- */
-class MoveInDynObstacles
-{
-
-private:
-
-  /** The character to move.  */
-  const Character& character;
-
-  /** Dynamic obstacles instance to update.  */
-  DynObstacles& dyn;
-
-public:
-
-  MoveInDynObstacles () = delete;
-  MoveInDynObstacles (const MoveInDynObstacles&) = delete;
-  void operator= (const MoveInDynObstacles&) = delete;
-
-  explicit MoveInDynObstacles (const Character& c, DynObstacles& d)
-    : character(c), dyn(d)
-  {
-    VLOG (1)
-        << "Removing character " << character.GetId ()
-        << " at position " << character.GetPosition ()
-        << " from the dynamic obstacle map before moving it...";
-    dyn.RemoveVehicle (character.GetPosition (), character.GetFaction ());
-  }
-
-  ~MoveInDynObstacles ()
-  {
-    VLOG (1)
-        << "Adding back character " << character.GetId ()
-        << " at position " << character.GetPosition ()
-        << " to the dynamic obstacle map...";
-    dyn.AddVehicle (character.GetPosition (), character.GetFaction ());
-  }
-
-};
-
 } // anonymous namespace
 
 void
@@ -358,6 +316,25 @@ ProcessAllMovement (Database& db, DynObstacles& dyn, const Context& ctx)
 
       CharacterMovement (*c, ctx, edges);
     }
+}
+
+MoveInDynObstacles::MoveInDynObstacles (const Character& c, DynObstacles& d)
+  : character(c), dyn(d)
+{
+  VLOG (1)
+      << "Removing character " << character.GetId ()
+      << " at position " << character.GetPosition ()
+      << " from the dynamic obstacle map before moving it...";
+  dyn.RemoveVehicle (character.GetPosition (), character.GetFaction ());
+}
+
+MoveInDynObstacles::~MoveInDynObstacles ()
+{
+  VLOG (1)
+      << "Adding back character " << character.GetId ()
+      << " at position " << character.GetPosition ()
+      << " to the dynamic obstacle map...";
+  dyn.AddVehicle (character.GetPosition (), character.GetFaction ());
 }
 
 namespace test

--- a/src/movement.hpp
+++ b/src/movement.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -45,6 +45,32 @@ void StopCharacter (Character& c);
  * the given edge weights.
  */
 void ProcessAllMovement (Database& db, DynObstacles& dyn, const Context& ctx);
+
+/**
+ * RAII helper class to remove a vehicle from the dynamic obstacles and
+ * then add it back again at the (potentially) changed position.
+ */
+class MoveInDynObstacles
+{
+
+private:
+
+  /** The character to move.  */
+  const Character& character;
+
+  /** Dynamic obstacles instance to update.  */
+  DynObstacles& dyn;
+
+public:
+
+  MoveInDynObstacles () = delete;
+  MoveInDynObstacles (const MoveInDynObstacles&) = delete;
+  void operator= (const MoveInDynObstacles&) = delete;
+
+  explicit MoveInDynObstacles (const Character& c, DynObstacles& d);
+  ~MoveInDynObstacles ();
+
+};
 
 namespace test
 {

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1618,6 +1618,12 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl,
         }
       const unsigned rot = val.asUInt ();
 
+      /* Note that we do not check CanPlaceBuilding here on purpose.  It is ok
+         if god-mode can in theory result in invalid situations.  But by not
+         enforcing the conditions here we ensure that buildings can be easily
+         placed as needed in tests, without having to worry about regions
+         and the ability to build in them.  */
+
       auto h = tbl.CreateNew (type, owner, f);
       h->SetCentre (centre);
       h->MutableProto ().mutable_shape_trafo ()->set_rotation_steps (rot);

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -875,6 +875,122 @@ BaseMoveProcessor::ParseSetFitments (const Character& c, const Json::Value& upd,
   return CheckVehicleFitments (c.GetProto ().vehicle (), fitments);
 }
 
+namespace
+{
+
+/**
+ * Parses a building configuration (type and shape trafo) from
+ * JSON.  This is shared between proper "found building" moves
+ * and god-mode build commands.
+ */
+bool
+ParseBuildingConfig (const Json::Value& build,
+                     std::string& type, proto::ShapeTransformation& trafo)
+{
+  CHECK (build.isObject ());
+
+  auto val = build["t"];
+  if (!val.isString ())
+    {
+      LOG (WARNING) << "Building element has invalid type: " << build;
+      return false;
+    }
+  type = val.asString ();
+
+  const auto& buildingTypes = RoConfigData ().building_types ();
+  if (buildingTypes.find (type) == buildingTypes.end ())
+    {
+      LOG (WARNING) << "Invalid type for building: " << type;
+      return false;
+    }
+
+  val = build["rot"];
+  if (!val.isUInt () || val.asUInt () > 5)
+    {
+      LOG (WARNING) << "Building element has invalid rotation: " << build;
+      return false;
+    }
+  const unsigned rot = val.asUInt ();
+
+  trafo.Clear ();
+  trafo.set_rotation_steps (rot);
+
+  return true;
+}
+
+} // anonymous namespace
+
+bool
+BaseMoveProcessor::ParseFoundBuilding (const Character& c,
+                                       const Json::Value& upd,
+                                       const DynObstacles& d,
+                                       std::string& type,
+                                       proto::ShapeTransformation& trafo)
+{
+  CHECK (upd.isObject ());
+  const auto& build = upd["fb"];
+  if (!build.isObject ())
+    return false;
+
+  if (build.size () != 2 || !ParseBuildingConfig (build, type, trafo))
+    {
+      LOG (WARNING) << "Invalid building element: " << build;
+      return false;
+    }
+
+  if (c.IsBusy ())
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId () << " is busy, can't found a building";
+      return false;
+    }
+
+  if (c.IsInBuilding ())
+    {
+      LOG (WARNING)
+          << "Character " << c.GetId ()
+          << " is inside a building, can't found a building";
+      return false;
+    }
+
+  const auto& roData = RoConfigData ().building_types ().at (type);
+  if (!roData.has_construction ())
+    {
+      LOG (WARNING) << "Building " << type << " cannot be constructed";
+      return false;
+    }
+
+  const auto& inv = c.GetInventory ();
+  for (const auto& entry : roData.construction ().foundation ())
+    {
+      const auto available = inv.GetFungibleCount (entry.first);
+      if (entry.second > available)
+        {
+          LOG (WARNING)
+              << "Character " << c.GetId ()
+              << " has only " << available << " " << entry.first
+              << " but needs " << entry.second
+              << " to build foundations of " << type;
+          return false;
+        }
+    }
+
+  /* Before we check the placement, we have to temporarily remove the
+     building character itself.  It is fine if they are in the way, as they
+     will automatically enter the foundation once placed.  */
+  MoveInDynObstacles dynMover(c, const_cast<DynObstacles&> (d));
+  if (!CanPlaceBuilding (type, trafo, c.GetPosition (), d, ctx))
+    {
+      LOG (WARNING)
+          << "Can't place building in this configuration at "
+          << c.GetPosition ()
+          << ": " << build;
+      return false;
+    }
+
+  return true;
+}
+
 /* ************************************************************************** */
 
 void
@@ -1204,6 +1320,35 @@ MoveProcessor::MaybeSetFitments (Character& c, const Json::Value& upd)
   DeriveCharacterStats (c);
 }
 
+void
+MoveProcessor::MaybeFoundBuilding (Character& c, const Json::Value& upd)
+{
+  std::string type;
+  proto::ShapeTransformation trafo;
+  if (!ParseFoundBuilding (c, upd, dyn, type, trafo))
+    return;
+
+  VLOG (1)
+      << "Building foundation for " << type
+      << " at " << c.GetPosition ();
+
+  auto b = buildings.CreateNew (type, c.GetOwner (), c.GetFaction ());
+  b->SetCentre (c.GetPosition ());
+  auto& pb = b->MutableProto ();
+  pb.set_foundation (true);
+  *pb.mutable_shape_trafo () = trafo;
+
+  auto& inv = c.GetInventory ();
+  for (const auto& entry : b->RoConfigData ().construction ().foundation ())
+    inv.AddFungibleCount (entry.first, -static_cast<int> (entry.second));
+
+  dyn.RemoveVehicle (c.GetPosition (), c.GetFaction ());
+  dyn.AddBuilding (*b);
+
+  UpdateBuildingStats (*b);
+  EnterBuilding (c, *b);
+}
+
 namespace
 {
 
@@ -1372,6 +1517,11 @@ MoveProcessor::PerformCharacterUpdate (Character& c, const Json::Value& upd)
      waypoints and a chosen speed in a single move.  */
   MaybeSetCharacterWaypoints (c, upd);
   MaybeSetCharacterSpeed (c, upd);
+
+  /* Founding a building puts the character into the newly created foundation.
+     They may want to then drop resources there (for further construction),
+     and/or exit immediately again.  */
+  MaybeFoundBuilding (c, upd);
 
   /* Dropping items is done before trying to pick items up.  This allows
      a player to drop stuff (and thus free cargo) before picking up something
@@ -1553,8 +1703,6 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl,
   if (!cmd.isArray ())
     return;
 
-  const auto& buildingTypes = RoConfigData ().building_types ();
-
   for (const auto& build : cmd)
     {
       if (!build.isObject () || build.size () != 4)
@@ -1563,16 +1711,11 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl,
           continue;
         }
 
-      auto val = build["t"];
-      if (!val.isString ())
+      std::string type;
+      proto::ShapeTransformation trafo;
+      if (!ParseBuildingConfig (build, type, trafo))
         {
-          LOG (WARNING) << "God-build element has invalid type: " << build;
-          continue;
-        }
-      const std::string type = val.asString ();
-      if (buildingTypes.find (type) == buildingTypes.end ())
-        {
-          LOG (WARNING) << "Invalid type for god build: " << type;
+          LOG (WARNING) << "Invalid god-build element: " << build;
           continue;
         }
 
@@ -1581,7 +1724,7 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl,
           LOG (WARNING) << "God-build element has no owner field: " << build;
           continue;
         }
-      val = build["o"];
+      const auto val = build["o"];
       Faction f;
       std::string owner;
       if (val.isNull ())
@@ -1610,14 +1753,6 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl,
           continue;
         }
 
-      val = build["rot"];
-      if (!val.isUInt () || val.asUInt () > 5)
-        {
-          LOG (WARNING) << "God-build element has invalid rotation: " << build;
-          continue;
-        }
-      const unsigned rot = val.asUInt ();
-
       /* Note that we do not check CanPlaceBuilding here on purpose.  It is ok
          if god-mode can in theory result in invalid situations.  But by not
          enforcing the conditions here we ensure that buildings can be easily
@@ -1626,14 +1761,14 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl,
 
       auto h = tbl.CreateNew (type, owner, f);
       h->SetCentre (centre);
-      h->MutableProto ().mutable_shape_trafo ()->set_rotation_steps (rot);
+      *h->MutableProto ().mutable_shape_trafo () = trafo;
       UpdateBuildingStats (*h);
       LOG (INFO)
           << "God building " << type
           << " for " << owner << " of faction " << FactionToString (f) << ":\n"
           << "  id: " << h->GetId () << "\n"
           << "  centre: " << centre << "\n"
-          << "  rotation: " << rot;
+          << "  rotation: " << trafo.rotation_steps ();
     }
 }
 

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1455,11 +1455,22 @@ MoveProcessor::MaybeDropLoot (Character& c, const Json::Value& cmd)
   if (c.IsInBuilding ())
     {
       toName << "building " << c.GetBuildingId ();
-      auto inv = buildingInv.Get (c.GetBuildingId (), c.GetOwner ());
-      MoveFungibleBetweenInventories (fungible,
-                                      c.GetInventory (),
-                                      inv->GetInventory (),
-                                      fromName.str (), toName.str ());
+      auto b = buildings.GetById (c.GetBuildingId ());
+      if (b->GetProto ().foundation ())
+        {
+          Inventory inv(*b->MutableProto ().mutable_construction_inventory ());
+          MoveFungibleBetweenInventories (fungible,
+                                          c.GetInventory (), inv,
+                                          fromName.str (), toName.str ());
+        }
+      else
+        {
+          auto inv = buildingInv.Get (c.GetBuildingId (), c.GetOwner ());
+          MoveFungibleBetweenInventories (fungible,
+                                          c.GetInventory (),
+                                          inv->GetInventory (),
+                                          fromName.str (), toName.str ());
+        }
     }
   else
     {

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1363,11 +1363,12 @@ MoveProcessor::MaybeFoundBuilding (Character& c, const Json::Value& upd)
   for (const auto& entry : b->RoConfigData ().construction ().foundation ())
     inv.AddFungibleCount (entry.first, -static_cast<int> (entry.second));
 
-  dyn.RemoveVehicle (c.GetPosition (), c.GetFaction ());
-  dyn.AddBuilding (*b);
-
   UpdateBuildingStats (*b);
-  EnterBuilding (c, *b);
+  EnterBuilding (c, *b, dyn);
+
+  /* EnterBuilding already removes the vehicle from dyn, but we have to add
+     the building afterwards manually.  */
+  dyn.AddBuilding (*b);
 }
 
 namespace

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -104,6 +104,14 @@ protected:
    */
   Database& db;
 
+  /**
+   * Dynamic obstacle layer, used for spawning characters and placing buildings.
+   * This is costly to create, and thus we use a passed-in reference instead
+   * of having our own instance.  (Also for processing blocks, it needs to
+   * stick around in the modified form for post-processing like movement.)
+   */
+  DynObstacles& dyn;
+
   /** Access handle for the accounts database table.  */
   AccountsTable accounts;
 
@@ -128,7 +136,7 @@ protected:
   /** Access to the regions table.  */
   RegionsTable regions;
 
-  explicit BaseMoveProcessor (Database& d, const Context& c);
+  explicit BaseMoveProcessor (Database& d, DynObstacles& o, const Context& c);
 
   /**
    * Parses some basic stuff from a move JSON object.  This extracts the
@@ -210,7 +218,6 @@ protected:
    * at the character's position.
    */
   bool ParseFoundBuilding (const Character& c, const Json::Value& upd,
-                           const DynObstacles& d,
                            std::string& type,
                            proto::ShapeTransformation& trafo);
 
@@ -295,9 +302,6 @@ class MoveProcessor : public BaseMoveProcessor
 {
 
 private:
-
-  /** Dynamic obstacle layer, used for spawning characters.  */
-  DynObstacles& dyn;
 
   /** Handle for random numbers.  */
   xaya::Random& rnd;
@@ -404,8 +408,7 @@ public:
 
   explicit MoveProcessor (Database& d, DynObstacles& dyo, xaya::Random& r,
                           const Context& c)
-    : BaseMoveProcessor(d, c),
-      dyn(dyo), rnd(r)
+    : BaseMoveProcessor(d, dyo, c), rnd(r)
   {}
 
   /**

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -33,6 +33,7 @@
 #include "database/ongoing.hpp"
 #include "database/region.hpp"
 #include "mapdata/basemap.hpp"
+#include "proto/building.pb.h"
 
 #include <xayautil/random.hpp>
 
@@ -205,6 +206,15 @@ protected:
                          std::vector<std::string>& fitments);
 
   /**
+   * Parses and verifies a potential command to place a building foundation
+   * at the character's position.
+   */
+  bool ParseFoundBuilding (const Character& c, const Json::Value& upd,
+                           const DynObstacles& d,
+                           std::string& type,
+                           proto::ShapeTransformation& trafo);
+
+  /**
    * Parses and verifies a potential character creation as part of the
    * given move.  For all valid creations, PerformCharacterCreation
    * is called with the relevant data.
@@ -350,6 +360,11 @@ private:
    * Processes a command to set fitments.
    */
   void MaybeSetFitments (Character& c, const Json::Value& upd);
+
+  /**
+   * Processes a command to build a foundation.
+   */
+  void MaybeFoundBuilding (Character& c, const Json::Value& upd);
 
   /**
    * Processes a command to drop loot from the character's inventory

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -491,6 +491,7 @@ void
 PendingMoves::Clear ()
 {
   state.Clear ();
+  dyn.reset ();
 }
 
 void
@@ -500,10 +501,13 @@ PendingMoves::AddPendingMove (const Json::Value& mv)
   PXLogic& rules = dynamic_cast<PXLogic&> (GetSQLiteGame ());
   SQLiteGameDatabase dbObj(db, rules);
 
+  if (dyn == nullptr)
+    dyn = std::make_unique<DynObstacles> (dbObj);
+
   const Context ctx(GetChain (), rules.GetBaseMap (),
                     GetConfirmedHeight () + 1, Context::NO_TIMESTAMP);
 
-  PendingStateUpdater updater(dbObj, state, ctx);
+  PendingStateUpdater updater(dbObj, *dyn, state, ctx);
   updater.ProcessMove (mv);
 }
 

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -436,6 +436,10 @@ void
 PendingStateUpdater::PerformCharacterUpdate (Character& c,
                                              const Json::Value& upd)
 {
+  BuildingsTable::Handle b;
+  if (c.IsInBuilding ())
+    b = buildings.GetById (c.GetBuildingId ());
+
   Database::IdT regionId;
   if (ParseCharacterProspecting (c, upd, regionId))
     state.AddCharacterProspecting (c, regionId);
@@ -446,7 +450,14 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
   FungibleAmountMap items;
   items = ParseDropPickupFungible (upd["pu"]);
   if (!items.empty ())
-    state.AddCharacterPickup (c);
+    {
+      if (b != nullptr && b->GetProto ().foundation ())
+        LOG (WARNING)
+            << "Ignoring pending move for character " << c.GetId ()
+            << " to pick up in foundation " << b->GetId ();
+      else
+        state.AddCharacterPickup (c);
+    }
   items = ParseDropPickupFungible (upd["drop"]);
   if (!items.empty ())
     state.AddCharacterDrop (c);

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -29,6 +29,7 @@
 #include "database/faction.hpp"
 #include "hexagonal/coord.hpp"
 #include "mapdata/basemap.hpp"
+#include "proto/building.pb.h"
 
 #include <xayagame/sqlitegame.hpp>
 
@@ -96,6 +97,9 @@ private:
      * RegionMap::OUT_OF_MAP if no mining is being started.
      */
     Database::IdT miningRegionId = RegionMap::OUT_OF_MAP;
+
+    /** A pending move to found a building, if any (otherwise JSON null).  */
+    Json::Value foundBuilding;
 
     /** The vehicle the character is changing to (if non-empty).  */
     Json::Value changeVehicle;
@@ -233,6 +237,13 @@ public:
    * is ignored.
    */
   void AddCharacterMining (const Character& ch, Database::IdT regionId);
+
+  /**
+   * Updates the state of a character to indiciate that it will
+   * found a building.
+   */
+  void AddFoundBuilding (const Character& ch, const std::string& type,
+                         const proto::ShapeTransformation& trafo);
 
   /**
    * Updates the state to add a "change vehicle" move.

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -20,6 +20,7 @@
 #define PXD_PENDING_HPP
 
 #include "context.hpp"
+#include "dynobstacles.hpp"
 #include "moveprocessor.hpp"
 #include "services.hpp"
 
@@ -271,6 +272,9 @@ public:
  * BaseMoveProcessor class that updates the pending state.  This contains the
  * main logic for PendingMoves::AddPendingMove, and is also accessible from
  * the unit tests independently of SQLiteGame.
+ *
+ * Instances of this class are light-weight and just contain the logic.  They
+ * are created on-the-fly for processing a single move.
  */
 class PendingStateUpdater : public BaseMoveProcessor
 {
@@ -288,8 +292,9 @@ protected:
 
 public:
 
-  explicit PendingStateUpdater (Database& d, PendingState& s, const Context& c)
-    : BaseMoveProcessor(d, c), state(s)
+  explicit PendingStateUpdater (Database& d, DynObstacles& o,
+                                PendingState& s, const Context& c)
+    : BaseMoveProcessor(d, o, c), state(s)
   {}
 
   /**
@@ -311,6 +316,14 @@ private:
 
   /** The current state of pending moves.  */
   PendingState state;
+
+  /**
+   * A DynObstacles instance based on the confirmed database state.
+   * This is costly to create, thus we create it on-demand and keep it cached
+   * for all pending moves until the next call to Clear (when the confirmed
+   * state changes).
+   */
+  std::unique_ptr<DynObstacles> dyn;
 
 protected:
 

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -621,16 +621,6 @@ protected:
 
   ContextForTesting ctx;
 
-private:
-
-  PendingStateUpdater updater;
-
-protected:
-
-  PendingStateUpdaterTests ()
-    : updater(db, state, ctx)
-  {}
-
   /**
    * Processes a move for the given name and with the given move data, parsed
    * from JSON string.  If paidToDev is non-zero, then add an "out" entry
@@ -648,6 +638,8 @@ protected:
       moveObj["out"][ctx.Params ().DeveloperAddress ()]
           = AmountToJson (paidToDev);
 
+    DynObstacles dyn(db);
+    PendingStateUpdater updater(db, dyn, state, ctx);
     updater.ProcessMove (moveObj);
   }
 
@@ -682,7 +674,8 @@ TEST_F (PendingStateUpdaterTests, InvalidCreation)
 
   accounts.CreateNew ("at limit", Faction::BLUE);
   for (unsigned i = 0; i < ctx.Params ().CharacterLimit (); ++i)
-    characters.CreateNew ("at limit", Faction::BLUE);
+    characters.CreateNew ("at limit", Faction::BLUE)
+        ->SetPosition (HexCoord (i, 1));
 
   ProcessWithDevPayment ("domob", ctx.Params ().CharacterCost (), R"(
     {
@@ -771,9 +764,9 @@ TEST_F (PendingStateUpdaterTests, Waypoints)
 {
   accounts.CreateNew ("domob", Faction::RED);
 
-  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
-  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 2);
-  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 3);
+  characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 1));
+  characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 2));
+  characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 3));
 
   /* Some invalid updates that will just not show up (i.e. ID 1 will have no
      pending updates later on).  */
@@ -815,13 +808,15 @@ TEST_F (PendingStateUpdaterTests, EnterBuilding)
 {
   accounts.CreateNew ("domob", Faction::RED);
 
-  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
-  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 2);
-  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 3);
+  characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, -1));
+  characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 0));
+  characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 1));
 
   db.SetNextId (100);
-  buildings.CreateNew ("checkmark", "domob", Faction::RED);
-  buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  buildings.CreateNew ("huesli", "domob", Faction::RED)
+      ->SetCentre (HexCoord (-1, 0));
+  buildings.CreateNew ("huesli", "domob", Faction::RED)
+      ->SetCentre (HexCoord (1, 0));
 
   /* Some invalid updates that will just not show up (i.e. ID 1 will have no
      pending updates later on).  */
@@ -906,8 +901,8 @@ TEST_F (PendingStateUpdaterTests, ExitBuilding)
 TEST_F (PendingStateUpdaterTests, DropPickup)
 {
   accounts.CreateNew ("domob", Faction::RED);
-  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
-  CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 2);
+  characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 0));
+  characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (1, 0));
 
   /* Some invalid / empty commands.  */
   Process ("domob", R"({
@@ -1230,8 +1225,10 @@ TEST_F (PendingStateUpdaterTests, ServiceOperations)
   accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
 
   db.SetNextId (100);
-  buildings.CreateNew ("ancient1", "", Faction::ANCIENT);
-  buildings.CreateNew ("ancient2", "", Faction::ANCIENT);
+  buildings.CreateNew ("ancient1", "", Faction::ANCIENT)
+      ->SetCentre  (HexCoord (100, 0));
+  buildings.CreateNew ("ancient2", "", Faction::ANCIENT)
+      ->SetCentre (HexCoord (-100, 0));
 
   buildingInv.Get (100, "domob")->GetInventory ().AddFungibleCount ("foo", 7);
 

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -974,6 +974,29 @@ TEST_F (PendingStateUpdaterTests, DropPickup)
   )");
 }
 
+TEST_F (PendingStateUpdaterTests, PickupInFoundation)
+{
+  accounts.CreateNew ("domob", Faction::RED);
+  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  const auto bId = b->GetId ();
+  b->MutableProto ().set_foundation (true);
+  Inventory (*b->MutableProto ().mutable_construction_inventory ())
+      .AddFungibleCount ("foo", 10);
+  b.reset ();
+
+  db.SetNextId (101);
+  characters.CreateNew ("domob", Faction::RED)->SetBuildingId (bId);
+
+  Process ("domob", R"({
+    "c": {"101": {"pu": {"f": {"foo": 100}}}}
+  })");
+  ExpectStateJson (R"(
+    {
+      "characters": []
+    }
+  )");
+}
+
 TEST_F (PendingStateUpdaterTests, Prospecting)
 {
   accounts.CreateNew ("domob", Faction::RED);

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -1004,6 +1004,12 @@ ServiceOperation::Parse (Account& acc, const Json::Value& data,
           << buildingId;
       return nullptr;
     }
+  if (b->GetProto ().foundation ())
+    {
+      LOG (WARNING)
+          << "Service operation requested in foundation " << buildingId;
+      return nullptr;
+    }
 
   const auto& typeVal = data["t"];
   if (!typeVal.isString ())

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -190,11 +190,20 @@ TEST_F (ServicesTests, UnsupportedBuilding)
 {
   db.SetNextId (200);
   buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  buildings.CreateNew ("ancient1", "", Faction::ANCIENT)
+      ->MutableProto ().set_foundation (true);
   inv.Get (200, "domob")->GetInventory ().AddFungibleCount ("foo", 10);
+  inv.Get (201, "domob")->GetInventory ().AddFungibleCount ("foo", 10);
 
   EXPECT_FALSE (Process ("domob", R"({
     "t": "ref",
     "b": 200,
+    "i": "foo",
+    "n": 3
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "t": "ref",
+    "b": 201,
     "i": "foo",
     "n": 3
   })"));


### PR DESCRIPTION
This is the first (and main) part of implementing "building buildings".  It introduces the concept of building foundations (as opposed to full buildings).  They can be constructed by a character with sufficient resources in their inventory with a command like this:

    {"c": {"1": {"fb": {"t": "building type", "rot": 3}}}}

If successful, this places a foundation at the character's location and puts the character inside it.  This is only possible if there are no other obstacles on any future building tile, and also if the entire building is contained in a single region.

Foundations are restricted in their use:  They offer no services, cannot be used to change vehicles / fitments, and also do not have account inventories.  Instead, anything dropped in them goes towards a "construction inventory", which will be used to upgrade the foundation to a full building later (and excess items are given to the building's owner).