### PR TITLE
Full construction of buildings

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -5,6 +5,7 @@ REGTESTS = \
   accounts.py \
   buildings_basic.py \
   buildings_combat.py \
+  buildings_construction.py \
   buildings_enterexit.py \
   buildings_foundations.py \
   buildings_inventory.py \

--- a/gametest/buildings_construction.py
+++ b/gametest/buildings_construction.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests construction of buildings.
+"""
+
+from pxtest import PXTest
+
+
+class BuildingConstructionTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("Creating and preparing test character...")
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob")
+    self.generate (1)
+    self.changeCharacterVehicle ("domob", "chariot")
+    pos = {"x": 0, "y": 0}
+    inv = {"foo": 100, "zerospace": 100}
+    self.dropLoot (pos, inv)
+    self.moveCharactersTo ({"domob": pos})
+    self.getCharacters ()["domob"].sendMove ({"pu": {"f": inv}})
+    self.generate (1)
+
+    self.mainLogger.info ("Building foundation...")
+    c = self.getCharacters ()["domob"]
+    c.sendMove ({
+      "fb": {"t": "huesli", "rot": 0},
+      "drop": {"f": {"foo": 100}},
+    })
+    self.generate (1)
+
+    buildings = self.getBuildings ()
+    bId = buildings.keys ()[-1]
+    self.assertEqual (buildings[bId].isFoundation (), True)
+    self.assertEqual (buildings[bId].getConstructionInventory (), {
+      "foo": 98,
+    })
+    self.assertEqual (buildings[bId].getOngoingConstruction (), None)
+
+    self.mainLogger.info ("Starting the construction...")
+    self.getCharacters ()["domob"].sendMove ({
+      "drop": {"f": {"zerospace": 100}},
+    })
+    self.generate (10)
+    b = self.getBuildings ()[bId]
+    self.assertEqual (b.isFoundation (), True)
+    self.assertEqual (b.getConstructionInventory (), {
+      "foo": 98,
+      "zerospace": 100,
+    })
+    self.assertEqual (b.getOngoingConstruction (), {
+      "operation": "build",
+      "blocks": 1,
+    })
+
+    self.mainLogger.info ("Finishing construction...")
+    self.generate (1)
+    b = self.getBuildings ()[bId]
+    self.assertEqual (b.isFoundation (), False)
+    self.assertEqual (b.getFungibleInventory ("domob"), {
+      "foo": 95,
+      "zerospace": 90,
+    })
+    self.assertEqual (b.getOngoingConstruction (), None)
+
+
+if __name__ == "__main__":
+  BuildingConstructionTest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -163,6 +163,35 @@ class Building (object):
   def isFoundation (self):
     return "foundation" in self.data
 
+  def getOngoingConstruction (self):
+    """
+    Returns the ongoing operation data for the building's construction
+    (from foundation to full building) or None if there is no ongoing
+    construction for it.
+
+    To make asserting of the value easy, the IDs (ongoing and building ID)
+    are removed, and the "height" value is translated to "blocks" based
+    on the current height of Xaya Core.
+    """
+
+    if "construction" not in self.data:
+      return None
+    if "ongoing" not in self.data["construction"]:
+      return None
+
+    opId = self.data["construction"]["ongoing"]
+    ongoings = self.test.getRpc ("getongoings")
+    for o in ongoings:
+      if o["id"] == opId:
+        del o["id"]
+        assert o["buildingid"] == self.getId ()
+        del o["buildingid"]
+        o["blocks"] = o["height"] - self.test.rpc.xaya.getblockcount ()
+        del o["height"]
+        return o
+
+    raise AssertionError ("Ongoing construction %d not found in ongoings", opId)
+
   def getConstructionInventory (self):
     constr = self.data["construction"]
     return collections.Counter (constr["inventory"]["fungible"])

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -164,7 +164,8 @@ class Building (object):
     return "foundation" in self.data
 
   def getConstructionInventory (self):
-    return collections.Counter (self.data["constructioninv"]["fungible"])
+    constr = self.data["construction"]
+    return collections.Counter (constr["inventory"]["fungible"])
 
   def getFungibleInventory (self, account):
     inv = self.data["inventories"]

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -60,17 +60,23 @@ message Building
   optional Inventory construction_inventory = 3;
 
   /**
+   * If this is a foundation being upgraded to full building right now,
+   * then this is the ID of the ongoing operation corresponding to it.
+   */
+  optional uint64 ongoing_construction = 4;
+
+  /**
    * Static combat data for this building (besides regeneration).  This is
    * mostly based on the building type, but may change if the building is
    * upgraded or the account gains skills.
    */
-  optional CombatData combat_data = 4;
+  optional CombatData combat_data = 5;
 
   /**
    * The service fee that users need to pay to the building owner for using
    * services in the building.  This is a percentage of the service's base
    * fee (the burnt amount).
    */
-  optional uint32 service_fee_percent = 5;
+  optional uint32 service_fee_percent = 6;
 
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -268,7 +268,7 @@ message BuildingData
     map<string, uint32> foundation = 1;
 
     /** Resources for upgrading the foundation to the full building.  */
-    map<string, uint32> construction = 2;
+    map<string, uint32> full_building = 2;
 
     /**
      * Number of blocks the construction (from foundation to full building)

--- a/proto/ongoing.proto
+++ b/proto/ongoing.proto
@@ -97,6 +97,19 @@ message ItemConstruction
 }
 
 /**
+ * An operation to finish building construction (i.e. upgrade it from
+ * a foundation to the full building).
+ */
+message BuildingConstruction
+{
+
+  /* No extra data is needed.  The building and end-height are already general
+     fields of any ongoing operation, and the resources to take away on
+     completion are known as well from the building type.  */
+
+}
+
+/**
  * Data about an ongoing operation.
  */
 message OngoingOperation
@@ -109,6 +122,7 @@ message OngoingOperation
     ArmourRepair armour_repair = 2;
     BlueprintCopy blueprint_copy = 3;
     ItemConstruction item_construction = 4;
+    BuildingConstruction building_construction = 5;
   }
 
   /* The database stores extra data directly in columns:

--- a/proto/ongoing.proto
+++ b/proto/ongoing.proto
@@ -75,7 +75,7 @@ message BlueprintCopy
  * resources required for the construction are always just removed when the
  * operation starts (and thus not related to the operation state).
  */
-message Construction
+message ItemConstruction
 {
 
   /** The account doing the operation, which will receive items when done.  */
@@ -108,7 +108,7 @@ message OngoingOperation
     OngoingProspection prospection = 1;
     ArmourRepair armour_repair = 2;
     BlueprintCopy blueprint_copy = 3;
-    Construction construction = 4;
+    ItemConstruction item_construction = 4;
   }
 
   /* The database stores extra data directly in columns:

--- a/proto/roconfig/buildings/test.pb.text
+++ b/proto/roconfig/buildings/test.pb.text
@@ -23,6 +23,7 @@ building_types:
           {
             foundation: { key: "foo" value: 1 }
             full_building: { key: "zerospace" value: 10 }
+            blocks: 10
           }
 
       }

--- a/proto/roconfig/buildings/test.pb.text
+++ b/proto/roconfig/buildings/test.pb.text
@@ -22,6 +22,7 @@ building_types:
         construction:
           {
             foundation: { key: "foo" value: 1 }
+            full_building: { key: "zerospace" value: 10 }
           }
 
       }
@@ -77,8 +78,8 @@ building_types:
         construction:
           {
             foundation: { key: "foo" value: 2 }
-            construction: { key: "foo" value: 3 }
-            construction: { key: "zerospace" value: 10 }
+            full_building: { key: "foo" value: 3 }
+            full_building: { key: "zerospace" value: 10 }
             blocks: 10
           }
       }

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -25,6 +25,7 @@
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/database.hpp"
+#include "database/ongoing.hpp"
 #include "hexagonal/coord.hpp"
 #include "proto/building.pb.h"
 
@@ -56,6 +57,14 @@ bool CanPlaceBuilding (const std::string& type,
  * Places initial buildings (ancient and obelisks) onto the map.
  */
 void InitialiseBuildings (Database& db);
+
+/**
+ * Check if the given building has all required resources to start
+ * construction (from foundation to full building).  If so, actually
+ * start the relevant ongoing operation for it.
+ */
+void MaybeStartBuildingConstruction (Building& b, OngoingsTable& ongoings,
+                                     const Context& ctx);
 
 /**
  * Computes and updates the stats of a building (e.g. combat data, HP) from

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -385,9 +385,9 @@ KillProcessor::ProcessBuilding (const Database::IdT id)
             continue;
           }
 
-        if (op->GetProto ().has_construction ())
+        if (op->GetProto ().has_item_construction ())
           {
-            const auto& c = op->GetProto ().construction ();
+            const auto& c = op->GetProto ().item_construction ();
             if (c.has_original_type ())
               totalInv.AddFungibleCount (c.original_type (), 1);
             continue;

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -961,7 +961,7 @@ TEST_F (ProcessKillsBuildingTests, MayDropBlueprintsFromConstruction)
       auto op = ongoings.CreateNew ();
       op->SetHeight (42);
       op->SetBuildingId (bId);
-      auto* c = op->MutableProto ().mutable_construction ();
+      auto* c = op->MutableProto ().mutable_item_construction ();
       c->set_account ("domob");
       c->set_output_type ("bow");
       c->set_num_items (42);
@@ -971,7 +971,7 @@ TEST_F (ProcessKillsBuildingTests, MayDropBlueprintsFromConstruction)
       op = ongoings.CreateNew ();
       op->SetHeight (42);
       op->SetBuildingId (bId);
-      c = op->MutableProto ().mutable_construction ();
+      c = op->MutableProto ().mutable_item_construction ();
       c->set_account ("domob");
       c->set_output_type ("sword");
       c->set_num_items (10);

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -399,9 +399,9 @@ template <>
         break;
       }
 
-    case proto::OngoingOperation::kConstruction:
+    case proto::OngoingOperation::kItemConstruction:
       {
-        const auto& c = pb.construction ();
+        const auto& c = pb.item_construction ();
 
         res["operation"] = "construct";
         res["account"] = c.account ();

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -416,6 +416,10 @@ template <>
         break;
       }
 
+    case proto::OngoingOperation::kBuildingConstruction:
+      res["operation"] = "build";
+      break;
+
     default:
       LOG (FATAL) << "Unexpected ongoing operation case: " << pb.op_case ();
     }

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -332,7 +332,13 @@ template <>
   res["combat"] = GetCombatJsonObject (b);
 
   if (pb.foundation ())
-    res["constructioninv"] = Convert (Inventory (pb.construction_inventory ()));
+    {
+      Json::Value constr(Json::objectValue);
+      if (pb.has_ongoing_construction ())
+        constr["ongoing"] = IntToJson (pb.ongoing_construction ());
+      constr["inventory"] = Convert (Inventory (pb.construction_inventory ()));
+      res["construction"] = constr;
+    }
   else
     {
       auto invRes = buildingInventories.QueryForBuilding (b.GetId ());

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -651,27 +651,43 @@ TEST_F (BuildingJsonTests, Foundation)
       ->mutable_fungible ()->insert ({"bar", 10});
   b.reset ();
 
+  b = tbl.CreateNew ("checkmark", "foo", Faction::RED);
+  b->MutableProto ().set_foundation (true);
+  b->MutableProto ().set_ongoing_construction (42);
+  b.reset ();
+
   ExpectStateJson (R"({
     "buildings":
       [
         {
           "id": 1,
           "foundation": null,
-          "constructioninv": null,
+          "construction": null,
           "inventories": {}
         },
         {
           "id": 2,
-          "foundation": null
+          "foundation": null,
+          "construction": null
         },
         {
           "id": 3,
           "foundation": true,
-          "constructioninv":
+          "construction":
             {
-              "fungible": {"bar": 10}
+              "ongoing": null,
+              "inventory": {"fungible": {"bar": 10}}
             },
           "inventories": null
+        },
+        {
+          "id": 4,
+          "foundation": true,
+          "construction":
+            {
+              "ongoing": 42,
+              "inventory": {"fungible": {}}
+            }
         }
       ]
   })");

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -962,11 +962,11 @@ TEST_F (OngoingsJsonTests, BlueprintCopy)
   })");
 }
 
-TEST_F (OngoingsJsonTests, Construction)
+TEST_F (OngoingsJsonTests, ItemConstruction)
 {
   auto op = tbl.CreateNew ();
   ASSERT_EQ (op->GetId (), 1);
-  auto* c = op->MutableProto ().mutable_construction ();
+  auto* c = op->MutableProto ().mutable_item_construction ();
   c->set_account ("domob");
   c->set_output_type ("bow");
   c->set_num_items (42);
@@ -974,7 +974,7 @@ TEST_F (OngoingsJsonTests, Construction)
 
   op = tbl.CreateNew ();
   ASSERT_EQ (op->GetId (), 2);
-  c = op->MutableProto ().mutable_construction ();
+  c = op->MutableProto ().mutable_item_construction ();
   c->set_account ("domob");
   c->set_output_type ("bow");
   c->set_num_items (5);

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -999,6 +999,26 @@ TEST_F (OngoingsJsonTests, ItemConstruction)
   })");
 }
 
+TEST_F (OngoingsJsonTests, BuildingConstruction)
+{
+  auto op = tbl.CreateNew ();
+  ASSERT_EQ (op->GetId (), 1);
+  op->SetBuildingId (42);
+  op->MutableProto ().mutable_building_construction ();
+  op.reset ();
+
+  ExpectStateJson (R"({
+    "ongoings":
+      [
+        {
+          "id": 1,
+          "operation": "build",
+          "buildingid": 42
+        }
+      ]
+  })");
+}
+
 /* ************************************************************************** */
 
 class RegionJsonTests : public GameStateJsonTests

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1463,6 +1463,10 @@ MoveProcessor::MaybeDropLoot (Character& c, const Json::Value& cmd)
           MoveFungibleBetweenInventories (fungible,
                                           c.GetInventory (), inv,
                                           fromName.str (), toName.str ());
+
+          /* Since items were added to the construction inventory, this may
+             be the time to start construction itself.  */
+          MaybeStartBuildingConstruction (*b, ongoings, ctx);
         }
       else
         {

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -18,6 +18,7 @@
 
 #include "ongoings.hpp"
 
+#include "buildings.hpp"
 #include "prospecting.hpp"
 
 #include "database/building.hpp"
@@ -30,6 +31,44 @@
 
 namespace pxd
 {
+
+namespace
+{
+
+/**
+ * Finishes construction of the given building.
+ */
+void
+FinishBuildingConstruction (Building& b, BuildingInventoriesTable& buildingInv)
+{
+  CHECK (b.GetProto ().foundation ())
+      << "Building " << b.GetId () << " is not a foundation";
+  const auto& roData = b.RoConfigData ();
+  CHECK (roData.has_construction ())
+      << "Building type " << b.GetType () << " is not constructible";
+
+  LOG (INFO)
+      << "Construction of building " << b.GetId ()
+      << " owned by " << b.GetOwner () << " is finished";
+
+  auto& pb = b.MutableProto ();
+  Inventory cInv(*pb.mutable_construction_inventory ());
+  for (const auto& entry : roData.construction ().full_building ())
+    cInv.AddFungibleCount (entry.first,
+                           -static_cast<Inventory::QuantityT> (entry.second));
+
+  /* All resources not used for the actual construction go to the owner's
+     account inside the new building.  */
+  auto inv = buildingInv.Get (b.GetId (), b.GetOwner ());
+  inv->GetInventory () += cInv;
+
+  pb.clear_construction_inventory ();
+  pb.set_foundation (false);
+
+  UpdateBuildingStats (b);
+}
+
+} // anonymous namespace
 
 void
 ProcessAllOngoings (Database& db, xaya::Random& rnd, const Context& ctx)
@@ -104,6 +143,11 @@ ProcessAllOngoings (Database& db, xaya::Random& rnd, const Context& ctx)
               inv->GetInventory ().AddFungibleCount (c.original_type (), 1);
             break;
           }
+
+        case proto::OngoingOperation::kBuildingConstruction:
+          CHECK (b != nullptr);
+          FinishBuildingConstruction (*b, buildingInv);
+          break;
 
         default:
           LOG (FATAL)

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -89,10 +89,10 @@ ProcessAllOngoings (Database& db, xaya::Random& rnd, const Context& ctx)
             break;
           }
 
-        case proto::OngoingOperation::kConstruction:
+        case proto::OngoingOperation::kItemConstruction:
           {
             CHECK (b != nullptr);
-            const auto& c = op->GetProto ().construction ();
+            const auto& c = op->GetProto ().item_construction ();
             LOG (INFO)
                 << c.account () << " finished constructing "
                 << c.num_items () << " " << c.output_type ()

--- a/src/ongoings_tests.cpp
+++ b/src/ongoings_tests.cpp
@@ -283,5 +283,37 @@ TEST_F (OngoingsTests, ItemConstructionFromCopy)
   EXPECT_EQ (GetNumOngoing (), 0);
 }
 
+TEST_F (OngoingsTests, BuildingConstruction)
+{
+  auto b = buildings.CreateNew ("huesli", "domob", Faction::RED);
+  const auto bId = b->GetId ();
+  b->MutableProto ().set_foundation (true);
+  b->MutableHP ().set_armour (1);
+  Inventory cInv(*b->MutableProto ().mutable_construction_inventory ());
+  cInv.AddFungibleCount ("foo", 5);
+  cInv.AddFungibleCount ("bar", 42);
+  cInv.AddFungibleCount ("zerospace", 10);
+
+  auto op = AddOp (*b);
+  op->SetHeight (10);
+  op->MutableProto ().mutable_building_construction ();
+
+  op.reset ();
+  b.reset ();
+
+  ctx.SetHeight (10);
+  ProcessAllOngoings (db, rnd, ctx);
+
+  b = buildings.GetById (bId);
+  auto inv = buildingInv.Get (bId, "domob");
+  EXPECT_FALSE (b->GetProto ().foundation ());
+  EXPECT_FALSE (b->GetProto ().has_construction_inventory ());
+  EXPECT_EQ (b->GetHP ().armour (), 100);
+  EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("foo"), 2);
+  EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bar"), 42);
+  EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("zerospace"), 0);
+  EXPECT_EQ (GetNumOngoing (), 0);
+}
+
 } // anonymous namespace
 } // namespace pxd

--- a/src/ongoings_tests.cpp
+++ b/src/ongoings_tests.cpp
@@ -228,13 +228,13 @@ TEST_F (OngoingsTests, BlueprintCopy)
   EXPECT_EQ (GetNumOngoing (), 0);
 }
 
-TEST_F (OngoingsTests, ConstructionFromOriginal)
+TEST_F (OngoingsTests, ItemConstructionFromOriginal)
 {
   auto b = buildings.CreateNew ("ancient1", "", Faction::ANCIENT);
   const auto bId = b->GetId ();
   auto op = AddOp (*b);
   op->SetHeight (10);
-  auto& c = *op->MutableProto ().mutable_construction ();
+  auto& c = *op->MutableProto ().mutable_item_construction ();
   c.set_account ("domob");
   c.set_output_type ("bow");
   c.set_num_items (20);
@@ -256,13 +256,13 @@ TEST_F (OngoingsTests, ConstructionFromOriginal)
   EXPECT_EQ (GetNumOngoing (), 0);
 }
 
-TEST_F (OngoingsTests, ConstructionFromCopy)
+TEST_F (OngoingsTests, ItemConstructionFromCopy)
 {
   auto b = buildings.CreateNew ("ancient1", "", Faction::ANCIENT);
   const auto bId = b->GetId ();
   auto op = AddOp (*b);
   op->SetHeight (10);
-  auto& c = *op->MutableProto ().mutable_construction ();
+  auto& c = *op->MutableProto ().mutable_item_construction ();
   c.set_account ("domob");
   c.set_output_type ("bow");
   c.set_num_items (5);

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -893,7 +893,7 @@ ConstructionOperation::ExecuteSpecific (xaya::Random& rnd)
   else
     op->SetHeight (ctx.Height () + baseDuration);
 
-  auto& c = *op->MutableProto ().mutable_construction ();
+  auto& c = *op->MutableProto ().mutable_item_construction ();
   c.set_account (name);
   c.set_output_type (output);
   c.set_num_items (num);

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -1124,8 +1124,8 @@ TEST_F (ConstructionTests, FromOriginal)
   ASSERT_NE (op, nullptr);
   EXPECT_EQ (op->GetHeight (), 100 + 5 * 10);
   EXPECT_EQ (op->GetBuildingId (), ANCIENT_BUILDING);
-  ASSERT_TRUE (op->GetProto ().has_construction ());
-  const auto& c = op->GetProto ().construction ();
+  ASSERT_TRUE (op->GetProto ().has_item_construction ());
+  const auto& c = op->GetProto ().item_construction ();
   EXPECT_EQ (c.account (), "domob");
   EXPECT_EQ (c.output_type (), "sword");
   EXPECT_EQ (c.num_items (), 5);
@@ -1154,8 +1154,8 @@ TEST_F (ConstructionTests, FromCopy)
   ASSERT_NE (op, nullptr);
   EXPECT_EQ (op->GetHeight (), 100 + 10);
   EXPECT_EQ (op->GetBuildingId (), ANCIENT_BUILDING);
-  ASSERT_TRUE (op->GetProto ().has_construction ());
-  const auto& c = op->GetProto ().construction ();
+  ASSERT_TRUE (op->GetProto ().has_item_construction ());
+  const auto& c = op->GetProto ().item_construction ();
   EXPECT_EQ (c.account (), "domob");
   EXPECT_EQ (c.output_type (), "sword");
   EXPECT_EQ (c.num_items (), 5);


### PR DESCRIPTION
This is the second part of "building buildings", following #103.  When enough resources to finish a construction are dropped into the foundation's construction inventory, then an ongoing operation to finish the building is started automatically.  After it finishes (based on the configured construction time of the building type), the resources are taken from the inventory, the remaining resources (if any) are given to the building owner's account inventory in the building, and the building becomes "full" (no longer a foundation).