### PR TITLE
Support AoE damage around target

### DIFF
--- a/database/building.cpp
+++ b/database/building.cpp
@@ -193,7 +193,7 @@ BuildingsTable::QueryWithAttacks ()
   auto stmt = db.Prepare (R"(
     SELECT *
       FROM `buildings`
-      WHERE `attackrange` > 0
+      WHERE `attackrange` IS NOT NULL
       ORDER BY `id`
   )");
   return stmt.Query<BuildingResult> ();

--- a/database/building_tests.cpp
+++ b/database/building_tests.cpp
@@ -119,7 +119,7 @@ TEST_F (BuildingTests, CombatFields)
   const auto id = tbl.CreateNew ("turret", "andy", Faction::RED)->GetId ();
 
   auto h = tbl.GetById (id);
-  EXPECT_EQ (h->GetAttackRange (), 0);
+  EXPECT_EQ (h->GetAttackRange (), CombatEntity::NO_ATTACKS);
   auto* att = h->MutableProto ().mutable_combat_data ()->add_attacks ();
   att->set_range (5);
   h.reset ();
@@ -183,7 +183,7 @@ TEST_F (BuildingsTableTests, QueryWithAttacks)
 {
   tbl.CreateNew ("checkmark", "domob", Faction::RED);
   tbl.CreateNew ("checkmark", "andy", Faction::RED)
-    ->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (1);
+    ->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (0);
 
   auto res = tbl.QueryWithAttacks ();
   ASSERT_TRUE (res.Step ());

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -316,7 +316,7 @@ CharacterTable::QueryWithAttacks ()
   auto stmt = db.Prepare (R"(
     SELECT *
       FROM `characters`
-      WHERE `attackrange` > 0 AND `inBuilding` IS NULL
+      WHERE `attackrange` IS NOT NULL AND `inBuilding` IS NULL
       ORDER BY `id`
   )");
   return stmt.Query<CharacterResult> ();

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -215,6 +215,11 @@ TEST_F (CharacterTests, AttackRange)
   c.reset ();
 
   c = tbl.GetById (id);
+  EXPECT_EQ (c->GetAttackRange (), CombatEntity::NO_ATTACKS);
+  c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (0);
+  c.reset ();
+
+  c = tbl.GetById (id);
   EXPECT_EQ (c->GetAttackRange (), 0);
   c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (5);
   c.reset ();
@@ -224,7 +229,7 @@ TEST_F (CharacterTests, AttackRange)
   c->MutableProto ().clear_combat_data ();
   c.reset ();
 
-  EXPECT_EQ (tbl.GetById (id)->GetAttackRange (), 0);
+  EXPECT_EQ (tbl.GetById (id)->GetAttackRange (), CombatEntity::NO_ATTACKS);
 }
 
 TEST_F (CharacterTests, UsedCargoSpace)
@@ -318,7 +323,7 @@ TEST_F (CharacterTableTests, QueryWithAttacks)
 {
   tbl.CreateNew ("domob", Faction::RED);
   tbl.CreateNew ("andy", Faction::RED)
-    ->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (1);
+    ->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (0);
   auto h = tbl.CreateNew ("inbuilding", Faction::RED);
   h->SetBuildingId (100);
   h->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (1);

--- a/database/combat.cpp
+++ b/database/combat.cpp
@@ -23,6 +23,8 @@
 namespace pxd
 {
 
+constexpr HexCoord::IntT CombatEntity::NO_ATTACKS;
+
 CombatEntity::CombatEntity (Database& d)
   : db(d), isNew(true), oldCanRegen(false)
 {
@@ -38,7 +40,12 @@ CombatEntity::BindFullFields (Database::Statement& stmt,
                               const unsigned indAttackRange) const
 {
   stmt.BindProto (indRegenData, regenData);
-  stmt.Bind (indAttackRange, FindAttackRange (GetCombatData ()));
+
+  const auto range = FindAttackRange (GetCombatData ());
+  if (range == NO_ATTACKS)
+    stmt.BindNull (indAttackRange);
+  else
+    stmt.Bind (indAttackRange, range);
 
   if (HasTarget ())
     stmt.BindProto (indTarget, target);
@@ -64,7 +71,7 @@ CombatEntity::Validate () const
 #ifdef ENABLE_SLOW_ASSERTS
 
   if (!isNew && !IsDirtyCombatData ())
-    CHECK_EQ (attackRange, FindAttackRange (pb.combat_data ()));
+    CHECK_EQ (oldAttackRange, FindAttackRange (pb.combat_data ()));
 
 #endif // ENABLE_SLOW_ASSERTS
 }
@@ -111,11 +118,12 @@ CombatEntity::ComputeCanRegen (const proto::HP& hp,
 HexCoord::IntT
 CombatEntity::FindAttackRange (const proto::CombatData& cd)
 {
-  HexCoord::IntT res = 0;
+  HexCoord::IntT res = NO_ATTACKS;
   for (const auto& attack : cd.attacks ())
     {
-      CHECK_GT (attack.range (), 0);
-      res = std::max<HexCoord::IntT> (res, attack.range ());
+      const HexCoord::IntT cur = attack.range ();
+      if (res == NO_ATTACKS || cur > res)
+        res = cur;
     }
 
   return res;

--- a/database/combat.cpp
+++ b/database/combat.cpp
@@ -121,7 +121,15 @@ CombatEntity::FindAttackRange (const proto::CombatData& cd)
   HexCoord::IntT res = NO_ATTACKS;
   for (const auto& attack : cd.attacks ())
     {
-      const HexCoord::IntT cur = attack.range ();
+      HexCoord::IntT cur;
+      if (attack.has_range ())
+        cur = attack.range ();
+      else
+        {
+          CHECK (attack.has_area ());
+          cur = attack.area ();
+        }
+
       if (res == NO_ATTACKS || cur > res)
         res = cur;
     }

--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -100,7 +100,7 @@ private:
 
   /**
    * Computes the attack range of a fighter with the given combat data.
-   * Returns zero if there are no attacks at all.
+   * Returns NO_ATTACKS if there are no attacks at all.
    */
   static HexCoord::IntT FindAttackRange (const proto::CombatData& cd);
 
@@ -170,6 +170,9 @@ protected:
 
 public:
 
+  /** Magic value for attack range if there are no attacks.  */
+  static constexpr HexCoord::IntT NO_ATTACKS = -1;
+
   /**
    * The destructor here does nothing.  It is the subclasses' job to
    * update the database row, using the IsDirty and BindField functions.
@@ -212,7 +215,7 @@ public:
   void SetTarget (const proto::TargetId& t);
 
   /**
-   * Returns the entity's attack range or zero if there are no attacks.
+   * Returns the entity's attack range or NO_ATTACKS if there are no attacks.
    * Note that this method must only be called if the instance has been
    * read from the database (not newly constructed) and if its main proto
    * has not been modified.  That allows us to use the cached attack-range

--- a/database/combat.tpp
+++ b/database/combat.tpp
@@ -38,7 +38,11 @@ template <typename T>
   else
     target = res.template GetProto<typename T::target> ();
 
-  oldAttackRange = res.template Get<typename T::attackrange> ();
+  if (res.template IsNull<typename T::attackrange> ())
+    oldAttackRange = NO_ATTACKS;
+  else
+    oldAttackRange = res.template Get<typename T::attackrange> ();
+
   oldCanRegen = res.template Get<typename T::canregen> ();
 }
 

--- a/database/combat_tests.cpp
+++ b/database/combat_tests.cpp
@@ -119,7 +119,7 @@ namespace
 
 TEST_F (FindAttackRangeTests, NoAttacks)
 {
-  EXPECT_EQ (FindRange (""), 0);
+  EXPECT_EQ (FindRange (""), CombatEntity::NO_ATTACKS);
 }
 
 TEST_F (FindAttackRangeTests, MaximumRange)
@@ -129,6 +129,13 @@ TEST_F (FindAttackRangeTests, MaximumRange)
     attacks: { range: 42 }
     attacks: { range: 1 }
   )"), 42);
+}
+
+TEST_F (FindAttackRangeTests, ZeroRange)
+{
+  EXPECT_EQ (FindRange (R"(
+    attacks: { range: 0 }
+  )"), 0);
 }
 
 } // anonymous namespace

--- a/database/combat_tests.cpp
+++ b/database/combat_tests.cpp
@@ -131,6 +131,16 @@ TEST_F (FindAttackRangeTests, MaximumRange)
   )"), 42);
 }
 
+TEST_F (FindAttackRangeTests, AreaAttacks)
+{
+  EXPECT_EQ (FindRange (R"(
+    attacks: { range: 5 area: 2 }
+  )"), 5);
+  EXPECT_EQ (FindRange (R"(
+    attacks: { area: 3 }
+  )"), 3);
+}
+
 TEST_F (FindAttackRangeTests, ZeroRange)
 {
   EXPECT_EQ (FindRange (R"(

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -13,6 +13,7 @@ REGTESTS = \
   characters.py \
   charon.py \
   coinops.py \
+  combat_aoe.py \
   combat_damage.py \
   combat_targets.py \
   damage_lists.py \

--- a/gametest/combat_aoe.py
+++ b/gametest/combat_aoe.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests combat with AoE attacks.
+"""
+
+from pxtest import PXTest, offsetCoord
+
+
+class CombatAoETest (PXTest):
+
+  def resetHP (self):
+    """
+    Resets the HP of all target characters to the original value,
+    so we can start a fresh test.
+    """
+
+    self.setCharactersHP ({
+      nm: {"ma": 100, "a": 100, "ms": 0, "s": 0}
+      for nm in self.targetNames
+    })
+
+  def expectDamaged (self, lst):
+    """
+    Expects that the given characters out of all targets have been damaged,
+    and that at the same HP for all of them.
+    """
+
+    c = self.getCharacters ()
+    hp = c[lst[0]].data["combat"]["hp"]["current"]["armour"]
+    assert hp < 100
+
+    lst = set (lst)
+    for nm in self.targetNames:
+      if nm in lst:
+        self.assertEqual (c[nm].data["combat"]["hp"]["current"]["armour"], hp)
+      else:
+        self.assertEqual (c[nm].data["combat"]["hp"]["current"]["armour"], 100)
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("Creating test characters...")
+    self.initAccount ("attacker", "r")
+    self.createCharacters ("attacker")
+    self.generate (1)
+    self.changeCharacterVehicle ("attacker", "basetank")
+
+    # We set up four potential targets:  Two within the "bomb" range
+    # of 2 (a closer and b further).  Then one within the "missile" area
+    # around each of those (c for a and d for b).
+    self.targetNames = ["a", "b", "c", "d"]
+    for nm in self.targetNames:
+      self.initAccount (nm, "g")
+      self.createCharacters (nm)
+    self.generate (1)
+    self.moveCharactersTo ({
+      "a": {"x": 1, "y": 0},
+      "b": {"x": -2, "y": 0},
+      "c": {"x": 1, "y": 2},
+      "d": {"x": -2, "y": -2},
+    })
+
+    self.mainLogger.info ("Testing AoE centred on attacker...")
+    self.changeCharacterVehicle ("attacker", "basetank", ["bomb"])
+    self.resetHP ()
+    self.moveCharactersTo ({"attacker": {"x": 0, "y": 0}})
+    self.generate (2)
+    self.expectDamaged (["a", "b"])
+
+    self.mainLogger.info ("Testing AoE centred on target...")
+    self.changeCharacterVehicle ("attacker", "basetank", ["missile"])
+    self.resetHP ()
+    self.moveCharactersTo ({"attacker": {"x": 0, "y": 0}})
+    self.generate (2)
+    self.expectDamaged (["a", "c"])
+
+
+if __name__ == "__main__":
+  CombatAoETest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -391,6 +391,13 @@ class PXTest (XayaGameTest):
         inv[f] = 1
     self.dropIntoBuilding (b.getId (), c.getOwner (), inv)
 
+    # Make sure that we can change vehicle and fitments by maxing the
+    # character's HP (just in case).
+    maxHp = self.getCharacters ()[char].data["combat"]["hp"]["max"]
+    self.setCharactersHP ({
+      char: {"a": maxHp["armour"], "s": maxHp["shield"]},
+    })
+
     self.getCharacters ()[char].sendMove ({
       "v": vehicleType,
       "fit": fitments,

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -59,14 +59,22 @@ message TargetId
 message Attack
 {
 
-  /** The range of the attack (as L1 distance on our hex grid).  */
+  /**
+   * The range of the attack (as L1 distance on our hex grid).  This may be
+   * zero in which case it affects only enemies on the same tile.
+   *
+   * If the value is missing entirely instead, it implies that there will not
+   * be a concrete "target", which is the case e.g. for AoE effects
+   * around the attacker itself.
+   */
   optional uint32 range = 1;
 
   /**
-   * If true, then the attack applies to all enemies in range (rather than
-   * just the single selected target).
+   * The size of the AoE for this attack, around the selected target (if range
+   * is present) or the attacker (if range is not present).  If this is not
+   * present, then it means that only the target itself is affected.
    */
-  optional bool area = 2;
+  optional uint32 area = 2;
 
   /* Maximum and minimum damage of the attack.  The actual damage will be
      chosen uniformly from the both-inclusive range.  */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -157,7 +157,7 @@ message FitmentData
   /** Modification to shield regeneration rate.  */
   optional StatModifier shield_regen = 7;
 
-  /** Modification of all attack ranges.  */
+  /** Modification of all attack ranges (and AoE area sizes).  */
   optional StatModifier range = 8;
 
   /** Modification of all attack damages (min and max).  */

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -11,10 +11,31 @@ fungible_items:
             slot: "high"
             attack:
               {
-                range: 2
-                area: true
+                area: 2
                 min_damage: 2
                 max_damage: 5
+              }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "missile"
+    value:
+      {
+        space: 5
+        complexity: 4
+        with_blueprint: true
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                area: 2
+                min_damage: 1
+                max_damage: 3
               }
           }
       }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -102,8 +102,7 @@ fungible_items:
                   }
                 attacks:
                   {
-                    range: 10
-                    area: true
+                    area: 10
                     min_damage: 1
                     max_damage: 10
                   }
@@ -112,6 +111,33 @@ fungible_items:
             equipment_slots: { key: "high" value: 3 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 1 }
+          }
+      }
+  }
+
+# Test vehicle without intrinsic attacks, so that we can equip it with
+# attack fitments and test them in isolation.
+fungible_items:
+  {
+    key: "basetank"
+    value:
+      {
+        space: 50
+        complexity: 100
+        with_blueprint: true
+        vehicle:
+          {
+            cargo_space: 1000
+            speed: 1000
+            regen_data:
+              {
+                max_hp: { armour: 1000 shield: 100 }
+                shield_regeneration_mhp: 1000
+              }
+            combat_data: {}
+            equipment_slots: { key: "high" value: 10 }
+            equipment_slots: { key: "mid" value: 10 }
+            equipment_slots: { key: "low" value: 10 }
           }
       }
   }

--- a/proto/roconfig/items/vehicles.pb.text
+++ b/proto/roconfig/items/vehicles.pb.text
@@ -21,8 +21,7 @@ fungible_items:
               {
                 attacks:
                   {
-                    range: 7
-                    area: true
+                    area: 7
                     min_damage: 1
                     max_damage: 20
                   }

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -50,12 +50,12 @@ SelectTarget (TargetFinder& targets, xaya::Random& rnd, FighterTable::Handle f)
   const HexCoord pos = f->GetCombatPosition ();
 
   const HexCoord::IntT range = f->GetAttackRange ();
-  if (range == 0)
+  if (range == CombatEntity::NO_ATTACKS)
     {
       VLOG (1) << "Fighter at " << pos << " has no attacks";
       return;
     }
-  CHECK_GT (range, 0);
+  CHECK_GE (range, 0);
 
   HexCoord::IntT closestRange;
   std::vector<proto::TargetId> closestTargets;

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -156,6 +156,34 @@ TEST_F (TargetSelectionTests, ClosestTarget)
     }
 }
 
+TEST_F (TargetSelectionTests, ZeroRange)
+{
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  const auto idFighter = c->GetId ();
+  c->SetPosition (HexCoord (0, 0));
+  AddAttackWithRange (*c->MutableProto ().mutable_combat_data (), 0);
+  c.reset ();
+
+  c = characters.CreateNew ("andy", Faction::GREEN);
+  const auto idTarget = c->GetId ();
+  c->SetPosition (HexCoord (1, 0));
+  NoAttacks (c->MutableProto ());
+  c.reset ();
+
+  FindCombatTargets (db, rnd);
+
+  EXPECT_FALSE (characters.GetById (idFighter)->HasTarget ());
+  characters.GetById (idTarget)->SetPosition (HexCoord (0, 0));
+
+  FindCombatTargets (db, rnd);
+
+  c = characters.GetById (idFighter);
+  ASSERT_TRUE (c->HasTarget ());
+  const auto& t = c->GetTarget ();
+  EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
+  EXPECT_EQ (t.id (), idTarget);
+}
+
 TEST_F (TargetSelectionTests, WithBuildings)
 {
   auto c = characters.CreateNew ("domob", Faction::RED);

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -151,7 +151,13 @@ ApplyFitments (Character& c)
 
   for (auto& a : *pb.mutable_combat_data ()->mutable_attacks ())
     {
-      a.set_range (range (a.range ()));
+      /* Both the targeting range and size of AoE area (if applicable)
+         are modified in the same way through the "range" modifier.  */
+      if (a.has_range ())
+        a.set_range (range (a.range ()));
+      if (a.has_area ())
+        a.set_area (range (a.area ()));
+
       a.set_min_damage (damage (a.min_damage ()));
       a.set_max_damage (damage (a.max_damage ()));
     }

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -181,8 +181,8 @@ TEST_F (DeriveCharacterStatsTests, FitmentAttacks)
   const auto& attacks = c->GetProto ().combat_data ().attacks ();
   ASSERT_EQ (attacks.size (), 3);
   EXPECT_EQ (attacks[0].range (), 100);
-  EXPECT_EQ (attacks[1].range (), 10);
-  EXPECT_EQ (attacks[2].range (), 2);
+  EXPECT_EQ (attacks[1].area (), 10);
+  EXPECT_EQ (attacks[2].area (), 2);
 }
 
 TEST_F (DeriveCharacterStatsTests, CargoSpeed)
@@ -207,10 +207,16 @@ TEST_F (DeriveCharacterStatsTests, MaxHpRegen)
 TEST_F (DeriveCharacterStatsTests, RangeDamage)
 {
   auto c = Derive ("chariot", {"rangeext", "dmgext"});
-  const auto& a = c->GetProto ().combat_data ().attacks (0);
-  EXPECT_EQ (a.range (), 110);
-  EXPECT_EQ (a.min_damage (), 11);
-  EXPECT_EQ (a.max_damage (), 110);
+
+  const auto* a = &c->GetProto ().combat_data ().attacks (0);
+  EXPECT_FALSE (a->has_area ());
+  EXPECT_EQ (a->range (), 110);
+  EXPECT_EQ (a->min_damage (), 11);
+  EXPECT_EQ (a->max_damage (), 110);
+
+  a = &c->GetProto ().combat_data ().attacks (1);
+  EXPECT_FALSE (a->has_range ());
+  EXPECT_EQ (a->area (), 11);
 }
 
 TEST_F (DeriveCharacterStatsTests, StackingButNotCompounding)

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -154,8 +154,10 @@ GetCombatJsonObject (const CombatEntity& h)
   for (const auto& attack : pb.attacks ())
     {
       Json::Value obj(Json::objectValue);
-      obj["range"] = IntToJson (attack.range ());
-      obj["area"] = attack.area ();
+      if (attack.has_range ())
+        obj["range"] = IntToJson (attack.range ());
+      if (attack.has_area ())
+        obj["area"] = IntToJson (attack.area ());
       obj["mindamage"] = IntToJson (attack.min_damage ());
       obj["maxdamage"] = IntToJson (attack.max_damage ());
       attacks.append (obj);

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -325,8 +325,7 @@ TEST_F (CharacterJsonTests, Attacks)
   attack->set_min_damage (2);
   attack->set_max_damage (10);
   attack = cd->add_attacks ();
-  attack->set_range (1);
-  attack->set_area (true);
+  attack->set_area (1);
   attack->set_min_damage (0);
   attack->set_max_damage (1);
   c.reset ();
@@ -339,8 +338,8 @@ TEST_F (CharacterJsonTests, Attacks)
             {
               "attacks":
                 [
-                  {"range": 5, "area": false, "mindamage": 2, "maxdamage": 10},
-                  {"range": 1, "area": true, "mindamage": 0, "maxdamage": 1}
+                  {"range": 5, "mindamage": 2, "maxdamage": 10},
+                  {"area": 1, "mindamage": 0, "maxdamage": 1}
                 ]
             }
         }
@@ -790,7 +789,7 @@ TEST_F (BuildingJsonTests, CombatData)
                 },
               "attacks":
                 [
-                  {"range": 5, "area": false, "mindamage": 1, "maxdamage": 2}
+                  {"range": 5, "mindamage": 1, "maxdamage": 2}
                 ],
               "target": { "id": 10 }
             }


### PR DESCRIPTION
This refactors the way in which attack ranges and AoE are configured.  Instead of having a single range and a boolean "is AoE" flag, we now have two ranges (normal `range` and `area`).  This allows us to specify three different configurations:

- `range` set to `R` and `area` unset:  This is a normal attack, which targets an enemy up to `R` tiles away.
- `range` unset and `area` set to `A`:  This is what area-attacks were previously.  It applies AoE damage to all enemies in an area of size `A` around the attacker.
- `range` set to `R` and `area` set to `A`:  This is newly supported.  It targets an enemy up to `R` away (like normal attacks) and then applies AoE damage in an `A` range *around that target*.

This also defines a new fitment `missile` which uses this type of damage, and does some code cleanups of the combat code in general.