### PR TITLE
Add getserviceinfo RPC

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -21,6 +21,7 @@ REGTESTS = \
   fame.py \
   findpath.py \
   getbuildingshape.py \
+  getserviceinfo.py \
   getregionat.py \
   godmode.py \
   loot.py \

--- a/gametest/getserviceinfo.py
+++ b/gametest/getserviceinfo.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from pxtest import PXTest
+
+"""
+Tests the getserviceinfo RPC command.
+"""
+
+
+class GetServiceInfoTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    def getserviceinfo (name, op):
+      return self.getRpc ("getserviceinfo", name=name, op=op)
+
+    self.mainLogger.info ("Setting up basic situation...")
+    self.initAccount ("domob", "r")
+    self.initAccount ("andy", "r")
+    self.generate (1)
+
+    self.build ("ancient1", "domob", {"x": 0, "y": 0}, 0)
+    building = 1001
+    self.assertEqual (self.getBuildings ()[building].getOwner (), "domob")
+
+    self.getBuildings ()[building].sendMove ({"sf": 50})
+    self.generate (1)
+    self.assertEqual (self.getBuildings ()[building].data["servicefee"], 50)
+
+    self.dropIntoBuilding (building, "andy", {"test ore": 3})
+
+    self.mainLogger.info ("Testing invalid account...")
+    self.expectError (-2, "account does not exist",
+                      getserviceinfo, "invalid", {})
+
+    self.mainLogger.info ("Testing fully invalid service...")
+    self.assertEqual (getserviceinfo ("andy", {"foo": "bar"}), None)
+
+    self.mainLogger.info ("Testing validly parsed service...")
+    op = {"b": building, "t": "ref", "i": "test ore", "n": 3}
+    self.assertEqual (getserviceinfo ("andy", op), {
+      "type": "refining",
+      "building": building,
+      "input": {"test ore": 3},
+      "output": {"bar": 2, "zerospace": 1},
+      "cost": {"base": 10, "fee": 5},
+      "valid": False,
+    })
+    self.giftCoins ({"andy": 100})
+    self.assertEqual (getserviceinfo ("andy", op)["valid"], True)
+
+
+if __name__ == "__main__":
+  GetServiceInfoTest ().main ()

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -102,6 +102,7 @@ using PXRpcMethod = void (PXRpcServer::*) (const Json::Value&, Json::Value&);
 const std::map<std::string, PXRpcMethod> CHARON_METHODS = {
   {"getnullstate", &PXRpcServer::getnullstateI},
   {"getpendingstate", &PXRpcServer::getpendingstateI},
+
   {"getaccounts", &PXRpcServer::getaccountsI},
   {"getbuildings", &PXRpcServer::getbuildingsI},
   {"getcharacters", &PXRpcServer::getcharactersI},
@@ -109,6 +110,8 @@ const std::map<std::string, PXRpcMethod> CHARON_METHODS = {
   {"getongoings", &PXRpcServer::getongoingsI},
   {"getregions", &PXRpcServer::getregionsI},
   {"getprizestats", &PXRpcServer::getprizestatsI},
+
+  {"getserviceinfo", &PXRpcServer::getserviceinfoI},
 };
 
 /**

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -173,8 +173,7 @@ PXLogic::GetStateAsJson (const xaya::SQLiteDatabase& db)
 }
 
 Json::Value
-PXLogic::GetCustomStateData (xaya::Game& game,
-                             const JsonStateFromDatabaseWithBlock& cb)
+PXLogic::GetCustomStateData (xaya::Game& game, const JsonStateFromRawDb& cb)
 {
   return SQLiteGame::GetCustomStateData (game, "data",
       [this, &cb] (const xaya::SQLiteDatabase& db, const xaya::uint256& hash,
@@ -182,9 +181,19 @@ PXLogic::GetCustomStateData (xaya::Game& game,
         {
           SQLiteGameDatabase dbObj(const_cast<xaya::SQLiteDatabase&> (db),
                                    *this);
-          const Params params(GetChain ());
-          GameStateJson gsj(dbObj, params, map);
+          return cb (dbObj, hash, height);
+        });
+}
 
+Json::Value
+PXLogic::GetCustomStateData (xaya::Game& game,
+                             const JsonStateFromDatabaseWithBlock& cb)
+{
+  return GetCustomStateData (game,
+    [this, &cb] (Database& db, const xaya::uint256& hash, const unsigned height)
+        {
+          const Params params(GetChain ());
+          GameStateJson gsj(db, params, map);
           return cb (gsj, hash, height);
         });
 }

--- a/src/logic.hpp
+++ b/src/logic.hpp
@@ -134,6 +134,14 @@ protected:
 
 public:
 
+  /**
+   * Type for a callback that retrieves some JSON data from the database
+   * directly (not using GameStateJson).
+   */
+  using JsonStateFromRawDb
+      = std::function<Json::Value (Database& db, const xaya::uint256& hash,
+                                   unsigned height)>;
+
   /** Type for a callback that retrieves JSON data from the database.  */
   using JsonStateFromDatabase = std::function<Json::Value (GameStateJson& gsj)>;
 
@@ -156,6 +164,14 @@ public:
   {
     return map;
   }
+
+  /**
+   * Returns custom game-state data as JSON, with a callback that
+   * directly receives the database (and does not go through the
+   * GameStateJson class).
+   */
+  Json::Value GetCustomStateData (xaya::Game& game,
+                                  const JsonStateFromRawDb& cb);
 
   /**
    * Returns custom game-state data as JSON.  The provided callback is invoked

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -306,7 +306,7 @@ BaseMoveProcessor::TryServiceOperations (const std::string& name,
                                              buildings, buildingInv,
                                              characters, itemCounts,
                                              ongoings);
-      if (parsed != nullptr)
+      if (parsed != nullptr && parsed->IsFullyValid ())
         PerformServiceOperation (*parsed);
     }
 }

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -136,6 +136,9 @@ public:
 
   Json::Value getbootstrapdata () override;
 
+  Json::Value getserviceinfo (const std::string& name,
+                              const Json::Value& op) override;
+
   Json::Value
   findpath (int l1range, const Json::Value& source,
             const Json::Value& target, int wpdist) override

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -74,6 +74,15 @@
   },
 
   {
+    "name": "getserviceinfo",
+    "params": {
+      "name": "foo",
+      "op": {}
+    },
+    "returns": {}
+  },
+
+  {
     "name": "findpath",
     "params":
       {

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -60,6 +60,9 @@ private:
   /** The building in which the operation is happening.  */
   BuildingsTable::Handle building;
 
+  /** The operation's raw move JSON (used for logs and error reporting).  */
+  Json::Value rawMove;
+
   /**
    * Computes the base and service cost.  The base cost is burnt (and defined
    * by the service operation subclasses), while the service fee is sent
@@ -143,6 +146,13 @@ public:
   }
 
   /**
+   * Performs some additional validations (over what Parse already does)
+   * and returns true if the operation is fully valid (i.e. should be executed
+   * when confirmed / reported in the pending state).
+   */
+  bool IsFullyValid () const;
+
+  /**
    * Returns a JSON representation of this operation for pending moves.
    */
   Json::Value ToPendingJson () const;
@@ -154,7 +164,7 @@ public:
 
   /**
    * Tries to parse a service operation from JSON move data.  Returns nullptr
-   * if the format is invalid or the operation would not be valid.
+   * if the format is invalid.
    */
   static std::unique_ptr<ServiceOperation> Parse (
       Account& acc, const Json::Value& data,

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -81,7 +81,7 @@ protected:
                                        ctx, accounts, buildings,
                                        inv, characters, itemCounts, ongoings);
 
-    if (op == nullptr)
+    if (op == nullptr || !op->IsFullyValid ())
       return false;
 
     op->Execute (rnd);


### PR DESCRIPTION
This adds a new RPC `getserviceinfo (name="foo", op={...})`.  It accepts a service operation in the same format as for a move (e.g. `op={"b":123,"t":ref,"i":"test ore","n":3}`) and then attempts to parse and validate it as possible operation sent by the given account name.

If it is valid, then the operation's data is returned in the same format as for the pending state.  If it is invalid, then JSON `null` is returned.

The validation performed here is not exhaustive; for instance, it is ok if the account balance is too small for the service costs.  In that cases, the JSON object is still returned, but has an `"valid": false` flag set.