### PR TITLE
Implement "last breath" attack

### DIFF
--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -220,6 +220,10 @@ public:
    * read from the database (not newly constructed) and if its main proto
    * has not been modified.  That allows us to use the cached attack-range
    * column in the database directly.
+   *
+   * The attack range returned is just based on the base stats of the entity.
+   * It does not take combat effects, low-HP-boosts or things like that
+   * into account.
    */
   HexCoord::IntT GetAttackRange () const;
 

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -110,6 +110,24 @@ message Attack
 }
 
 /**
+ * Stats for a boost to combat stats that is in effect when a character
+ * has low armour HP (i.e. "final breath" attack).
+ */
+message LowHpBoost
+{
+
+  /** The percentage of armour HP at which it activates.  */
+  optional uint32 max_hp_percent = 1;
+
+  /** Boost to damage.  */
+  optional StatModifier damage = 2;
+
+  /** Boost to range.  */
+  optional StatModifier range = 3;
+
+}
+
+/**
  * Small utility message to hold stats about HP (both the permanent
  * armour-based ones and the regenerating shield).
  */
@@ -160,5 +178,8 @@ message CombatData
 
   /** The offensive attacks the figher has.  */
   repeated Attack attacks = 1;
+
+  /** Any low-HP boosts for the fighter.  */
+  repeated LowHpBoost low_hp_boosts = 2;
 
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -152,6 +152,9 @@ message FitmentData
   /** Modification to the vehicle's allowed fitment complexity.  */
   optional StatModifier complexity = 10;
 
+  /** Low-HP-boost this fitment provides (if any).  */
+  optional LowHpBoost low_hp_boost = 11;
+
 }
 
 /**

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -114,6 +114,27 @@ fungible_items:
 
 fungible_items:
   {
+    key: "lowhpboost"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment:
+          {
+            slot: "low"
+            low_hp_boost:
+              {
+                max_hp_percent: 10
+                damage: { percent: 50 }
+                range: { percent: 20 }
+              }
+          }
+      }
+  }
+
+fungible_items:
+  {
     key: "plating"
     value:
       {

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -132,6 +132,9 @@ ApplyFitments (Character& c)
 
       if (fitment.has_attack ())
         *pb.mutable_combat_data ()->add_attacks () = fitment.attack ();
+      if (fitment.has_low_hp_boost ())
+        *pb.mutable_combat_data ()->add_low_hp_boosts ()
+            = fitment.low_hp_boost ();
 
       cargo += fitment.cargo_space ();
       speed += fitment.speed ();

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -125,6 +125,19 @@ TEST_F (DeriveCharacterStatsTests, FitmentAttacks)
   EXPECT_EQ (attacks[2].area (), 2);
 }
 
+TEST_F (DeriveCharacterStatsTests, FitmentLowHpBoosts)
+{
+  auto c = Derive ("chariot", {"lowhpboost", "lowhpboost"});
+  const auto& boosts = c->GetProto ().combat_data ().low_hp_boosts ();
+  ASSERT_EQ (boosts.size (), 2);
+  for (const auto& b : boosts)
+    {
+      EXPECT_EQ (b.max_hp_percent (), 10);
+      EXPECT_EQ (b.damage ().percent (), 50);
+      EXPECT_EQ (b.range ().percent (), 20);
+    }
+}
+
 TEST_F (DeriveCharacterStatsTests, CargoSpeed)
 {
   auto c = Derive ("chariot", {"turbo"});


### PR DESCRIPTION
This implements a new concept of "low-HP boosts":  Stat modifiers to combat range and damage that are only in effect when the entity's HP are at or below a certain threshold (e.g. 10% of max armour).  This is used for the "last breath" fitment.

For processing each block, the modifiers for all fighters are computed before any damage is dealt, so that there is no effect by the order in which damage is applied.