### PR TITLE
Chain-dependent roconfig

### DIFF
--- a/database/character.cpp
+++ b/database/character.cpp
@@ -18,8 +18,6 @@
 
 #include "character.hpp"
 
-#include "proto/roconfig.hpp"
-
 #include <glog/logging.h>
 
 namespace pxd
@@ -229,12 +227,12 @@ Character::IsBusy () const
 }
 
 uint64_t
-Character::UsedCargoSpace () const
+Character::UsedCargoSpace (const RoConfig& cfg) const
 {
   uint64_t res = 0;
   for (const auto& entry : inv.GetFungible ())
     {
-      const auto& ro = RoConfig ().Item (entry.first);
+      const auto& ro = cfg.Item (entry.first);
       res += Inventory::Product (entry.second, ro.space ());
     }
 

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -31,6 +31,7 @@
 #include "proto/character.pb.h"
 #include "proto/combat.pb.h"
 #include "proto/movement.pb.h"
+#include "proto/roconfig.hpp"
 
 #include <functional>
 #include <memory>
@@ -290,7 +291,7 @@ public:
   /**
    * Returns the used cargo space for the character's inventory.
    */
-  uint64_t UsedCargoSpace () const;
+  uint64_t UsedCargoSpace (const RoConfig& cfg) const;
 
   proto::TargetId GetIdAsTarget () const override;
 

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -256,11 +256,14 @@ TEST_F (CharacterTests, AttackRange)
 
 TEST_F (CharacterTests, UsedCargoSpace)
 {
+  const RoConfig cfg(xaya::Chain::REGTEST);
+
   auto c = tbl.CreateNew ("domob", Faction::RED);
   c->MutableProto ().set_cargo_space (1000);
   c->GetInventory ().SetFungibleCount ("foo", 10);
   c->GetInventory ().SetFungibleCount ("bar", 3);
-  EXPECT_EQ (c->UsedCargoSpace (), 100 + 60);
+
+  EXPECT_EQ (c->UsedCargoSpace (cfg), 100 + 60);
 }
 
 /* ************************************************************************** */

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -8,7 +8,6 @@ ROCONFIG_TEXT_PROTOS = \
   roconfig/items/materials.pb.text \
   roconfig/items/prizes.pb.text \
   roconfig/items/vehicles.pb.text \
-  roconfig/items/test.pb.text \
   \
   roconfig/buildings/ancient1.pb.text \
   roconfig/buildings/ancient2.pb.text \
@@ -16,8 +15,11 @@ ROCONFIG_TEXT_PROTOS = \
   roconfig/buildings/obelisk1.pb.text \
   roconfig/buildings/obelisk2.pb.text \
   roconfig/buildings/obelisk3.pb.text \
-  roconfig/buildings/turrets.pb.text \
-  roconfig/buildings/test.pb.text
+  roconfig/buildings/turrets.pb.text
+
+ROCONFIG_TEXT_PROTOS_REGTEST = \
+  roconfig/buildings/test.pb.text \
+  roconfig/items/test.pb.text
 
 PROTOS = \
   account.proto \
@@ -32,8 +34,8 @@ PROTOS = \
   ongoing.proto \
   region.proto
 EXTRA_DIST = \
-  $(PROTOS) $(ROCONFIG_TEXT_PROTOS) \
-  roconfig_gen_head.cpp roconfig_gen_tail.cpp
+  $(PROTOS) $(ROCONFIG_TEXT_PROTOS) $(ROCONFIG_TEXT_PROTOS_REGTEST) \
+  roconfig_gen_head.cpp roconfig_gen_mid.cpp roconfig_gen_tail.cpp
 
 BUILT_SOURCES = \
   $(PROTOS:.proto=.pb.h) \
@@ -79,12 +81,11 @@ tests_SOURCES = \
 %.pb.h %.pb.cc: $(srcdir)/%.proto
 	protoc -I$(srcdir) --cpp_out=. "$<"
 
-roconfig.pb.text: $(ROCONFIG_TEXT_PROTOS)
+roconfig_gen.cpp: roconfig_gen_head.cpp $(ROCONFIG_TEXT_PROTOS) roconfig_gen_mid.cpp $(ROCONFIG_TEXT_PROTOS_REGTEST) roconfig_gen_tail.cpp
 	cat $^ >$@
 
-roconfig_gen.cpp: roconfig_gen_head.cpp roconfig.pb.text roconfig_gen_tail.cpp
-	cat $^ >$@
-
-roconfig.pb: $(builddir)/roconfig_gen
-	$(builddir)/roconfig_gen --output="$@"
+roconfig.pb roconfig.pb.text: $(builddir)/roconfig_gen
+	$(builddir)/roconfig_gen \
+          --out_binary="$(builddir)/roconfig.pb" \
+          --out_text="$(builddir)/roconfig.pb.text"
 	touch $(srcdir)/roconfig_blob.s

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -43,8 +43,8 @@ CLEANFILES = \
   $(PROTOS:.proto=.pb.h) $(PROTOS:.proto=.pb.cc) \
   roconfig_gen.cpp roconfig.pb.text roconfig.pb
 
-libpxproto_la_CXXFLAGS = $(PROTOBUF_CFLAGS)
-libpxproto_la_LBADD = $(PROTOBUF_LIBS)
+libpxproto_la_CXXFLAGS = $(XAYAGAME_CFLAGS) $(PROTOBUF_CFLAGS)
+libpxproto_la_LBADD = $(XAYAGAME_LIBS) $(PROTOBUF_LIBS)
 libpxproto_la_SOURCES = \
   roconfig.cpp \
   \

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -357,4 +357,10 @@ message ConfigData
   /** Distribution of resources for prospecting.  */
   optional ResourceDistribution resource_dist = 3;
 
+  /**
+   * The regtest-specific configuration data.  This is merged into the main
+   * instance by the RoConfig-helper class when running on regtest.
+   */
+  optional ConfigData regtest_merge = 100;
+
 }

--- a/proto/roconfig.cpp
+++ b/proto/roconfig.cpp
@@ -73,9 +73,11 @@ struct RoConfig::Data
 
 RoConfig::Data* RoConfig::instance = nullptr;
 
-RoConfig::RoConfig ()
+RoConfig::RoConfig (const xaya::Chain chain)
 {
   std::lock_guard<std::mutex> lock(mutInstances);
+
+  /* FIXME: Construct different data for regtest.  */
 
   if (instance == nullptr)
     {

--- a/proto/roconfig.hpp
+++ b/proto/roconfig.hpp
@@ -46,10 +46,13 @@ private:
   const Data* data;
 
   /**
-   * The global singleton data instance or null when it is not yet initialised.
-   * This is never destructed.
+   * The global singleton data instance for mainnet or null when it is not yet
+   * initialised.  This is never destructed.
    */
-  static Data* instance;
+  static Data* mainnet;
+
+  /** The singleton instance for regtest.  */
+  static Data* regtest;
 
 public:
 

--- a/proto/roconfig.hpp
+++ b/proto/roconfig.hpp
@@ -21,6 +21,8 @@
 
 #include "config.pb.h"
 
+#include <xayagame/gamelogic.hpp>
+
 namespace pxd
 {
 
@@ -58,7 +60,7 @@ public:
    * On the first call, this will also instantiate and set up the underlying
    * singleton instance with the real data.
    */
-  RoConfig ();
+  explicit RoConfig (xaya::Chain chain);
 
   RoConfig (const RoConfig&) = delete;
   void operator= (const RoConfig&) = delete;

--- a/proto/roconfig/buildings/test.pb.text
+++ b/proto/roconfig/buildings/test.pb.text
@@ -1,8 +1,3 @@
-# Some test buildings that can only be constructed through god mode or
-# in unit tests.  This is enforced by having them either be unconstructible
-# outright, or require test-resources (not available through normal
-# gameplay) for construction.
-
 building_types:
   {
     key: "checkmark"

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -1,7 +1,3 @@
-# The following items are used only for tests.  They are defined also
-# in the real game, but since they are never generated (except through
-# god-mode or direct intervention in tests), that has no effect.
-
 fungible_items:
   {
     key: "foo"

--- a/proto/roconfig_gen_head.cpp
+++ b/proto/roconfig_gen_head.cpp
@@ -23,6 +23,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <google/protobuf/text_format.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
 
 #include <cstdlib>
 #include <fstream>

--- a/proto/roconfig_gen_mid.cpp
+++ b/proto/roconfig_gen_mid.cpp
@@ -1,0 +1,3 @@
+)";
+
+constexpr const char* ROCONFIG_PROTO_TEXT_REGTEST = R"(

--- a/proto/roconfig_gen_tail.cpp
+++ b/proto/roconfig_gen_tail.cpp
@@ -1,6 +1,7 @@
 )";
 
-DEFINE_string (output, "", "Output file for the binary roconfig proto data");
+DEFINE_string (out_binary, "", "Output file for the binary data");
+DEFINE_string (out_text, "", "Output file for the text data");
 
 } // anonymous namespace
 
@@ -17,13 +18,22 @@ main (int argc, char** argv)
   LOG (INFO) << "Parsing hard-coded text proto...";
   pxd::proto::ConfigData pb;
   CHECK (TextFormat::ParseFromString (ROCONFIG_PROTO_TEXT, &pb));
+  CHECK (TextFormat::ParseFromString (ROCONFIG_PROTO_TEXT_REGTEST,
+                                      pb.mutable_regtest_merge ()));
 
-  if (!FLAGS_output.empty ())
+  if (!FLAGS_out_binary.empty ())
     {
-      LOG (INFO) << "Writing binary proto to output file " << FLAGS_output;
-      std::ofstream out(FLAGS_output, std::ios::binary);
+      LOG (INFO) << "Writing binary proto to output file " << FLAGS_out_binary;
+      std::ofstream out(FLAGS_out_binary, std::ios::binary);
       CHECK (pb.SerializeToOstream (&out));
-      out.close ();
+    }
+
+  if (!FLAGS_out_text.empty ())
+    {
+      LOG (INFO) << "Writing text proto to output file " << FLAGS_out_text;
+      std::ofstream out(FLAGS_out_text);
+      google::protobuf::io::OstreamOutputStream zcOut(&out);
+      CHECK (TextFormat::Print (pb, &zcOut));
     }
 
   google::protobuf::ShutdownProtobufLibrary ();

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -39,12 +39,25 @@ TEST (RoConfigTests, ProtoIsSingleton)
 {
   const auto* ptr1 = &(*RoConfig (xaya::Chain::MAIN));
   const auto* ptr2 = &(*RoConfig (xaya::Chain::MAIN));
+  const auto* ptr3 = &(*RoConfig (xaya::Chain::REGTEST));
   EXPECT_EQ (ptr1, ptr2);
+  EXPECT_NE (ptr1, ptr3);
 }
 
-TEST (RoConfigTests, HasData)
+TEST (RoConfigTests, ChainDependence)
 {
-  EXPECT_GT (RoConfig (xaya::Chain::MAIN)->fungible_items ().size (), 0);
+  const RoConfig main(xaya::Chain::MAIN);
+  const RoConfig regtest(xaya::Chain::REGTEST);
+
+  EXPECT_NE (main.ItemOrNull ("raw a"), nullptr);
+  EXPECT_NE (regtest.ItemOrNull ("raw a"), nullptr);
+  EXPECT_EQ (main.ItemOrNull ("bow"), nullptr);
+  EXPECT_NE (regtest.ItemOrNull ("bow"), nullptr);
+
+  EXPECT_NE (main.BuildingOrNull ("ancient1"), nullptr);
+  EXPECT_NE (regtest.BuildingOrNull ("ancient1"), nullptr);
+  EXPECT_EQ (main.BuildingOrNull ("huesli"), nullptr);
+  EXPECT_NE (regtest.BuildingOrNull ("huesli"), nullptr);
 }
 
 TEST (RoConfigTests, Building)

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -28,27 +28,30 @@ namespace
 
 /* ************************************************************************** */
 
-TEST (RoConfigTests, Parses)
+TEST (RoConfigTests, ConstructionWorks)
 {
-  *RoConfig ();
+  *RoConfig (xaya::Chain::MAIN);
+  *RoConfig (xaya::Chain::TEST);
+  *RoConfig (xaya::Chain::REGTEST);
 }
 
 TEST (RoConfigTests, ProtoIsSingleton)
 {
-  const auto* ptr1 = &(*RoConfig ());
-  const auto* ptr2 = &(*RoConfig ());
+  const auto* ptr1 = &(*RoConfig (xaya::Chain::MAIN));
+  const auto* ptr2 = &(*RoConfig (xaya::Chain::MAIN));
   EXPECT_EQ (ptr1, ptr2);
 }
 
 TEST (RoConfigTests, HasData)
 {
-  EXPECT_GT (RoConfig ()->fungible_items ().size (), 0);
+  EXPECT_GT (RoConfig (xaya::Chain::MAIN)->fungible_items ().size (), 0);
 }
 
 TEST (RoConfigTests, Building)
 {
-  EXPECT_EQ (RoConfig ().BuildingOrNull ("invalid building"), nullptr);
-  EXPECT_GT (RoConfig ().Building ("ancient1").enter_radius (), 0);
+  const RoConfig cfg(xaya::Chain::REGTEST);
+  EXPECT_EQ (cfg.BuildingOrNull ("invalid building"), nullptr);
+  EXPECT_GT (cfg.Building ("ancient1").enter_radius (), 0);
 }
 
 /* ************************************************************************** */
@@ -59,6 +62,10 @@ class RoItemsTests : public testing::Test
 protected:
 
   RoConfig cfg;
+
+  RoItemsTests ()
+    : cfg(xaya::Chain::REGTEST)
+  {}
 
 };
 
@@ -261,7 +268,9 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
 
 TEST_F (RoConfigSanityTests, Valid)
 {
-  EXPECT_TRUE (IsConfigValid (RoConfig ()));
+  EXPECT_TRUE (IsConfigValid (RoConfig (xaya::Chain::MAIN)));
+  EXPECT_TRUE (IsConfigValid (RoConfig (xaya::Chain::TEST)));
+  EXPECT_TRUE (IsConfigValid (RoConfig (xaya::Chain::REGTEST)));
 }
 
 /* ************************************************************************** */

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -126,7 +126,7 @@ MaybeStartBuildingConstruction (Building& b, OngoingsTable& ongoings,
   if (b.GetProto ().has_ongoing_construction ())
     return;
 
-  const auto& roData = RoConfig (ctx.Chain ()).Building (b.GetType ());
+  const auto& roData = ctx.RoConfig ().Building (b.GetType ());
   CHECK (roData.has_construction ());
 
   const Inventory cInv(b.GetProto ().construction_inventory ());
@@ -176,7 +176,6 @@ EnterBuilding (Character& c, const Building& b, DynObstacles& dyn)
 void
 ProcessEnterBuildings (Database& db, DynObstacles& dyn, const Context& ctx)
 {
-  const RoConfig cfg(ctx.Chain ());
   BuildingsTable buildings(db);
   CharacterTable characters(db);
   auto res = characters.QueryForEnterBuilding ();
@@ -213,7 +212,7 @@ ProcessEnterBuildings (Database& db, DynObstacles& dyn, const Context& ctx)
 
       const unsigned dist
           = HexCoord::DistanceL1 (c->GetPosition (), b->GetCentre ());
-      if (dist > cfg.Building (b->GetType ()).enter_radius ())
+      if (dist > ctx.RoConfig ().Building (b->GetType ()).enter_radius ())
         {
           /* This is probably the most common case, no log spam here.  */
           continue;
@@ -239,8 +238,7 @@ LeaveBuilding (BuildingsTable& buildings, Character& c,
   auto b = buildings.GetById (c.GetBuildingId ());
   CHECK (b != nullptr);
 
-  const RoConfig cfg(ctx.Chain ());
-  const auto radius = cfg.Building (b->GetType ()).enter_radius ();
+  const auto radius = ctx.RoConfig ().Building (b->GetType ()).enter_radius ();
   const auto pos = ChooseSpawnLocation (b->GetCentre (), radius,
                                         c.GetFaction (), rnd, dyn, ctx.Map ());
 

--- a/src/buildings.hpp
+++ b/src/buildings.hpp
@@ -42,13 +42,13 @@ namespace pxd
  */
 std::vector<HexCoord> GetBuildingShape (const std::string& type,
                                         const proto::ShapeTransformation& trafo,
-                                        const HexCoord& pos);
+                                        const HexCoord& pos, xaya::Chain chain);
 
 /**
  * Returns all shape tiles of a given building, taking the centre and
  * its shape trafo into account.
  */
-std::vector<HexCoord> GetBuildingShape (const Building& b);
+std::vector<HexCoord> GetBuildingShape (const Building& b, const Context& ctx);
 
 /**
  * Checks if a building of the given type and rotation can be placed
@@ -64,7 +64,7 @@ bool CanPlaceBuilding (const std::string& type,
 /**
  * Places initial buildings (ancient and obelisks) onto the map.
  */
-void InitialiseBuildings (Database& db);
+void InitialiseBuildings (Database& db, xaya::Chain chain);
 
 /**
  * Check if the given building has all required resources to start
@@ -78,7 +78,7 @@ void MaybeStartBuildingConstruction (Building& b, OngoingsTable& ongoings,
  * Computes and updates the stats of a building (e.g. combat data, HP) from
  * its type and other attributes.
  */
-void UpdateBuildingStats (Building& b);
+void UpdateBuildingStats (Building& b, xaya::Chain chain);
 
 /**
  * Processes the updates (without any validation) for entering the given
@@ -90,7 +90,8 @@ void EnterBuilding (Character& c, const Building& b, DynObstacles& dyn);
  * Processes all characters that want to enter a building, and lets them in
  * if it is possible for them.
  */
-void ProcessEnterBuildings (Database& db, DynObstacles& dyn);
+void ProcessEnterBuildings (Database& db, DynObstacles& dyn,
+                            const Context& ctx);
 
 /**
  * Makes the given character leave the building it is currently in.

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -394,7 +394,7 @@ protected:
     : centre(10, 42)
   {
     const std::string type = "checkmark";
-    radius = RoConfig (ctx.Chain ()).Building (type).enter_radius ();
+    radius = ctx.RoConfig ().Building (type).enter_radius ();
 
     auto b = tbl.CreateNew (type, "", Faction::ANCIENT);
     CHECK_EQ (b->GetId (), 1);

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -415,7 +415,7 @@ const std::map<std::string, RealCharonClient::RpcServer::NonStateMethod>
 RealCharonClient::RpcServer::RpcServer (RealCharonClient& p,
                                         jsonrpc::AbstractServerConnector& conn)
   : jsonrpc::AbstractServer<RpcServer> (conn, jsonrpc::JSONRPC_SERVER_V2),
-    parent(p), nonstate(nullConnector, map)
+    parent(p), nonstate(nullConnector, map, xaya::Chain::MAIN)
 {
   jsonrpc::Procedure stopProc("stop", jsonrpc::PARAMS_BY_POSITION, nullptr);
   bindAndAddNotification (stopProc, &RpcServer::stop);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -28,6 +28,13 @@ Context::Context (const xaya::Chain c, const BaseMap& m,
   : map(m), chain(c), params(new pxd::Params (chain)), height(h), timestamp(ts)
 {}
 
+unsigned
+Context::Height () const
+{
+  CHECK_NE (height, NO_HEIGHT);
+  return height;
+}
+
 int64_t
 Context::Timestamp () const
 {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -25,7 +25,10 @@ namespace pxd
 
 Context::Context (const xaya::Chain c, const BaseMap& m,
                   const unsigned h, const int64_t ts)
-  : map(m), chain(c), params(new pxd::Params (chain)), height(h), timestamp(ts)
+  : map(m), chain(c),
+    params(new pxd::Params (chain)),
+    cfg(new pxd::RoConfig (chain)),
+    height(h), timestamp(ts)
 {}
 
 unsigned

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -72,6 +72,9 @@ public:
   /** Value for timestamp if this is a pending block.  */
   static constexpr int64_t NO_TIMESTAMP = -1;
 
+  /** Value for height if there is no height set (and shouldn't be used).  */
+  static constexpr unsigned NO_HEIGHT = static_cast<unsigned> (-1);
+
   /**
    * Constructs an instance based on the given data.
    */
@@ -95,11 +98,11 @@ public:
     return *params;
   }
 
-  unsigned
-  Height () const
-  {
-    return height;
-  }
+  /**
+   * Returns the context's block height.  Must not be used if NO_HEIGHT was
+   * passed to the constructor.
+   */
+  unsigned Height () const;
 
   /**
    * Returns the context's block timestamp.  This must not be called for

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@
 #include "params.hpp"
 
 #include "mapdata/basemap.hpp"
+#include "proto/roconfig.hpp"
 
 #include <xayagame/gamelogic.hpp>
 
@@ -51,6 +52,9 @@ private:
    * can recreate it with modified chain in tests.
    */
   std::unique_ptr<pxd::Params> params;
+
+  /** RoConfig instance dependant on the chain.  */
+  std::unique_ptr<pxd::RoConfig> cfg;
 
   /**
    * The current block's height.  This is set to the confirmed height plus
@@ -96,6 +100,12 @@ public:
   Params () const
   {
     return *params;
+  }
+
+  const pxd::RoConfig&
+  RoConfig () const
+  {
+    return *cfg;
   }
 
   /**

--- a/src/dynobstacles.cpp
+++ b/src/dynobstacles.cpp
@@ -25,8 +25,8 @@
 namespace pxd
 {
 
-DynObstacles::DynObstacles (Database& db)
-  : red(false), green(false), blue(false), buildings(false)
+DynObstacles::DynObstacles (Database& db, const Context& c)
+  : ctx(c), red(false), green(false), blue(false), buildings(false)
 {
   {
     CharacterTable tbl(db);
@@ -48,7 +48,7 @@ DynObstacles::DynObstacles (Database& db)
 void
 DynObstacles::AddBuilding (const Building& b)
 {
-  for (const auto& c : GetBuildingShape (b))
+  for (const auto& c : GetBuildingShape (b, ctx))
     {
       auto ref = buildings.Access (c);
       CHECK (!ref);

--- a/src/dynobstacles.hpp
+++ b/src/dynobstacles.hpp
@@ -19,6 +19,8 @@
 #ifndef PXD_DYNOBSTACLES_HPP
 #define PXD_DYNOBSTACLES_HPP
 
+#include "context.hpp"
+
 #include "database/building.hpp"
 #include "database/database.hpp"
 #include "database/faction.hpp"
@@ -39,6 +41,9 @@ class DynObstacles
 {
 
 private:
+
+  /** Context (used for roconfig).  */
+  const Context& ctx;
 
   /** Vehicles of the red faction on the map.  */
   DynTiles<bool> red;
@@ -67,7 +72,7 @@ public:
    * Constructs an initialised instance with all vehicles and buildings
    * from the database.
    */
-  DynObstacles (Database& db);
+  DynObstacles (Database& db, const Context& c);
 
   DynObstacles () = delete;
   DynObstacles (const DynObstacles&) = delete;

--- a/src/dynobstacles_tests.cpp
+++ b/src/dynobstacles_tests.cpp
@@ -18,6 +18,8 @@
 
 #include "dynobstacles.hpp"
 
+#include "testutils.hpp"
+
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
 
@@ -36,6 +38,8 @@ protected:
   BuildingsTable buildings;
   CharacterTable characters;
 
+  ContextForTesting ctx;
+
   DynObstaclesTests ()
     : buildings(db), characters(db)
   {}
@@ -51,7 +55,7 @@ TEST_F (DynObstaclesTests, VehiclesFromDb)
   characters.CreateNew ("domob", Faction::GREEN)->SetPosition (c1);
   characters.CreateNew ("domob", Faction::BLUE)->SetPosition (c2);
 
-  DynObstacles dyn(db);
+  DynObstacles dyn(db, ctx);
 
   EXPECT_FALSE (dyn.IsPassable (c1, Faction::RED));
   EXPECT_FALSE (dyn.IsPassable (c1, Faction::GREEN));
@@ -70,7 +74,7 @@ TEST_F (DynObstaclesTests, BuildingsFromDb)
 {
   buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
 
-  DynObstacles dyn(db);
+  DynObstacles dyn(db, ctx);
 
   EXPECT_FALSE (dyn.IsPassable (HexCoord (0, 2), Faction::RED));
   EXPECT_FALSE (dyn.IsPassable (HexCoord (0, 2), Faction::GREEN));
@@ -84,7 +88,7 @@ TEST_F (DynObstaclesTests, BuildingsFromDb)
 TEST_F (DynObstaclesTests, Modifications)
 {
   const HexCoord c(42, 0);
-  DynObstacles dyn(db);
+  DynObstacles dyn(db, ctx);
 
   EXPECT_TRUE (dyn.IsPassable (c, Faction::RED));
 
@@ -107,7 +111,7 @@ TEST_F (DynObstaclesTests, IsFree)
   auto b = buildings.CreateNew ("huesli", "", Faction::ANCIENT);
   b->SetCentre (HexCoord (0, 0));
 
-  DynObstacles dyn(db);
+  DynObstacles dyn(db, ctx);
   dyn.AddBuilding (*b);
   dyn.AddVehicle (HexCoord (1, 0), Faction::RED);
   dyn.AddVehicle (HexCoord (2, 0), Faction::GREEN);

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -32,8 +32,6 @@ CheckVehicleFitments (const std::string& vehicle,
                       const std::vector<std::string>& fitments,
                       const Context& ctx)
 {
-  const RoConfig cfg(ctx.Chain ());
-
   /* We first go through all fitments, and sum up what slots we need and
      what complexity is required.  We also keep track of any potential
      modification to the supported complexity.  */
@@ -42,7 +40,7 @@ CheckVehicleFitments (const std::string& vehicle,
   std::map<std::string, unsigned> slotsRequired;
   for (const auto& f : fitments)
     {
-      const auto& fitmentData = cfg.Item (f);
+      const auto& fitmentData = ctx.RoConfig ().Item (f);
       CHECK (fitmentData.has_fitment ())
           << "Item type " << f << " is not a fitment";
 
@@ -53,7 +51,7 @@ CheckVehicleFitments (const std::string& vehicle,
     }
 
   /* Now check up the required stats against the vehicle.  */
-  const auto& vehicleData = cfg.Item (vehicle);
+  const auto& vehicleData = ctx.RoConfig ().Item (vehicle);
   CHECK (vehicleData.has_vehicle ())
       << "Item type " << vehicle << " is not a vehicle";
 
@@ -118,8 +116,6 @@ InitCharacterStats (Character& c, const proto::VehicleData& data)
 void
 ApplyFitments (Character& c, const Context& ctx)
 {
-  const RoConfig cfg(ctx.Chain ());
-
   /* Boosts from stat modifiers are not compounding.  Thus we total up
      each modifier first and only apply them at the end.  */
   StatModifier cargo, speed;
@@ -130,7 +126,7 @@ ApplyFitments (Character& c, const Context& ctx)
   auto& pb = c.MutableProto ();
   for (const auto& f : pb.fitments ())
     {
-      const auto fItemData = cfg.Item (f);
+      const auto fItemData = ctx.RoConfig ().Item (f);
       CHECK (fItemData.has_fitment ())
           << "Non-fitment type " << f << " on character " << c.GetId ();
       const auto& fitment = fItemData.fitment ();
@@ -182,8 +178,7 @@ ApplyFitments (Character& c, const Context& ctx)
 void
 DeriveCharacterStats (Character& c, const Context& ctx)
 {
-  const RoConfig cfg(ctx.Chain ());
-  const auto& vehicleItemData = cfg.Item (c.GetProto ().vehicle ());
+  const auto& vehicleItemData = ctx.RoConfig ().Item (c.GetProto ().vehicle ());
   CHECK (vehicleItemData.has_vehicle ())
       << "Character " << c.GetId ()
       << " is in non-vehicle: " << c.GetProto ().vehicle ();

--- a/src/fitments.hpp
+++ b/src/fitments.hpp
@@ -19,6 +19,8 @@
 #ifndef PXD_FITMENTS_HPP
 #define PXD_FITMENTS_HPP
 
+#include "context.hpp"
+
 #include "database/character.hpp"
 
 #include <string>
@@ -31,13 +33,14 @@ namespace pxd
  * Checks if the given list of fitments can be put onto a given vehicle.
  */
 bool CheckVehicleFitments (const std::string& vehicle,
-                           const std::vector<std::string>& fitments);
+                           const std::vector<std::string>& fitments,
+                           const Context& ctx);
 
 /**
  * Updates the "derived" stats of the character based on the vehicle and
  * fitments it is equipped with.
  */
-void DeriveCharacterStats (Character& c);
+void DeriveCharacterStats (Character& c, const Context& ctx);
 
 } // namespace pxd
 

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -31,31 +31,40 @@ namespace
 
 /* ************************************************************************** */
 
-using CheckVehicleFitmentsTests = testing::Test;
+class CheckVehicleFitmentsTests : public testing::Test
+{
+
+protected:
+
+  ContextForTesting ctx;
+
+};
 
 TEST_F (CheckVehicleFitmentsTests, ComplexityLimit)
 {
-  EXPECT_FALSE (CheckVehicleFitments ("chariot", {"bow", "bow"}));
-  EXPECT_TRUE (CheckVehicleFitments ("chariot", {"sword", "sword"}));
+  EXPECT_FALSE (CheckVehicleFitments ("chariot", {"bow", "bow"}, ctx));
+  EXPECT_TRUE (CheckVehicleFitments ("chariot", {"sword", "sword"}, ctx));
 }
 
 TEST_F (CheckVehicleFitmentsTests, Slots)
 {
-  EXPECT_FALSE (CheckVehicleFitments ("rv st", {"sword"}));
+  EXPECT_FALSE (CheckVehicleFitments ("rv st", {"sword"}, ctx));
   EXPECT_FALSE (CheckVehicleFitments ("chariot",
-                                      {"bomb", "bomb", "bomb", "bomb"}));
+                                      {"bomb", "bomb", "bomb", "bomb"},
+                                      ctx));
   EXPECT_TRUE (CheckVehicleFitments ("chariot", {
       "bomb", "bomb", "bomb",
       "turbo", "turbo",
       "expander",
-  }));
+  }, ctx));
 }
 
 TEST_F (CheckVehicleFitmentsTests, ComplexityMultiplier)
 {
-  EXPECT_FALSE (CheckVehicleFitments ("chariot", {"bow", "turbo"}));
+  EXPECT_FALSE (CheckVehicleFitments ("chariot", {"bow", "turbo"}, ctx));
   EXPECT_TRUE (CheckVehicleFitments ("chariot",
-                                     {"bow", "turbo", "multiplier"}));
+                                     {"bow", "turbo", "multiplier"},
+                                     ctx));
 }
 
 /* ************************************************************************** */
@@ -68,6 +77,8 @@ private:
   CharacterTable characters;
 
 protected:
+
+  ContextForTesting ctx;
 
   DeriveCharacterStatsTests ()
     : characters(db)
@@ -86,7 +97,7 @@ protected:
     for (const auto& f : fitments)
       c->MutableProto ().add_fitments (f);
 
-    DeriveCharacterStats (*c);
+    DeriveCharacterStats (*c, ctx);
     return c;
   }
 
@@ -109,7 +120,7 @@ TEST_F (DeriveCharacterStatsTests, HpAreReset)
 {
   auto c = Derive ("chariot", {});
   c->MutableHP ().set_armour (42);
-  DeriveCharacterStats (*c);
+  DeriveCharacterStats (*c, ctx);
 
   EXPECT_EQ (c->GetHP ().armour (), 1'000);
   EXPECT_EQ (c->GetHP ().shield (), 100);

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -206,7 +206,7 @@ GetCombatJsonObject (const Character& c, const DamageLists& dl)
 Json::Value
 GetCargoSpaceJsonObject (const Character& c, const Context& ctx)
 {
-  const auto used = c.UsedCargoSpace (RoConfig (ctx.Chain ()));
+  const auto used = c.UsedCargoSpace (ctx.RoConfig ());
 
   Json::Value res(Json::objectValue);
   res["total"] = IntToJson (c.GetProto ().cargo_space ());

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -204,9 +204,9 @@ GetCombatJsonObject (const Character& c, const DamageLists& dl)
  * Constructs the JSON representation of a character's cargo space.
  */
 Json::Value
-GetCargoSpaceJsonObject (const Character& c)
+GetCargoSpaceJsonObject (const Character& c, const Context& ctx)
 {
-  const auto used = c.UsedCargoSpace ();
+  const auto used = c.UsedCargoSpace (RoConfig (ctx.Chain ()));
 
   Json::Value res(Json::objectValue);
   res["total"] = IntToJson (c.GetProto ().cargo_space ());
@@ -281,7 +281,7 @@ template <>
   res["combat"] = GetCombatJsonObject (c, dl);
   res["speed"] = c.GetProto ().speed ();
   res["inventory"] = Convert (c.GetInventory ());
-  res["cargospace"] = GetCargoSpaceJsonObject (c);
+  res["cargospace"] = GetCargoSpaceJsonObject (c, ctx);
 
   const Json::Value mv = GetMovementJsonObject (c);
   if (!mv.empty ())
@@ -290,7 +290,7 @@ template <>
   if (c.IsBusy ())
     res["busy"] = IntToJson (c.GetProto ().ongoing ());
 
-  const Json::Value mining = GetMiningJsonObject (map, c);
+  const Json::Value mining = GetMiningJsonObject (ctx.Map (), c);
   if (!mining.isNull ())
     res["mining"] = mining;
 
@@ -334,7 +334,7 @@ template <>
   res["servicefee"] = IntToJson (pb.service_fee_percent ());
 
   Json::Value tiles(Json::arrayValue);
-  for (const auto& c : GetBuildingShape (b))
+  for (const auto& c : GetBuildingShape (b, ctx))
     tiles.append (CoordToJson (c));
   res["tiles"] = tiles;
 
@@ -497,7 +497,7 @@ GameStateJson::PrizeStats ()
   ItemCounts cnt(db);
 
   Json::Value res(Json::objectValue);
-  for (const auto& p : params.ProspectingPrizes ())
+  for (const auto& p : ctx.Params ().ProspectingPrizes ())
     {
       Json::Value cur(Json::objectValue);
       cur["number"] = p.number;

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -19,7 +19,7 @@
 #ifndef PXD_GAMESTATEJSON_HPP
 #define PXD_GAMESTATEJSON_HPP
 
-#include "params.hpp"
+#include "context.hpp"
 
 #include "database/damagelists.hpp"
 #include "database/database.hpp"
@@ -52,11 +52,8 @@ private:
   /** Damage lists accessor (for adding the attackers to a character JSON).  */
   const DamageLists dl;
 
-  /** Game parameters.  */
-  const Params& params;
-
-  /** Basemap instance that can be used.  */
-  const BaseMap& map;
+  /** Current parameter context.  */
+  const Context& ctx;
 
   /**
    * Extracts all results from the Database::Result instance, converts them
@@ -67,8 +64,8 @@ private:
 
 public:
 
-  explicit GameStateJson (Database& d, const Params& p, const BaseMap& m)
-    : db(d), buildingInventories(db), dl(db), params(p), map(m)
+  explicit GameStateJson (Database& d, const Context& c)
+    : db(d), buildingInventories(db), dl(db), ctx(c)
   {}
 
   GameStateJson () = delete;

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -1138,7 +1138,9 @@ protected:
 
   PrizesJsonTests ()
     : cnt(db)
-  {}
+  {
+    ctx.SetChain (xaya::Chain::MAIN);
+  }
 
 };
 

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -48,21 +48,19 @@ namespace
 class GameStateJsonTests : public DBTestWithSchema
 {
 
-private:
+protected:
 
-  /** Parameter instance for testing.  */
-  const Params params;
+  ContextForTesting ctx;
+
+private:
 
   /** GameStateJson instance used in testing.  */
   GameStateJson converter;
 
 protected:
 
-  /** Basemap instance for the test.  */
-  BaseMap map;
-
   GameStateJsonTests ()
-    : params(xaya::Chain::MAIN), converter(db, params, map)
+    : converter(db, ctx)
   {}
 
   /**
@@ -433,7 +431,7 @@ TEST_F (CharacterJsonTests, CargoSpace)
 TEST_F (CharacterJsonTests, Mining)
 {
   const HexCoord pos(10, -5);
-  ASSERT_EQ (map.Regions ().GetRegionId (pos), 350146);
+  ASSERT_EQ (ctx.Map ().Regions ().GetRegionId (pos), 350146);
 
   tbl.CreateNew ("without mining", Faction::RED);
 

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -802,8 +802,6 @@ TEST_F (PXLogicTests, MiningAndDropping)
 
 TEST_F (PXLogicTests, MiningWhenReprospected)
 {
-  ctx.SetChain (xaya::Chain::REGTEST);
-
   const HexCoord pos(5, 5);
   const auto region = ctx.Map ().Regions ().GetRegionId (pos);
 

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -40,6 +40,8 @@ StopMining (Character& c)
 void
 ProcessAllMining (Database& db, xaya::Random& rnd, const Context& ctx)
 {
+  const RoConfig cfg(ctx.Chain ());
+
   CharacterTable characters(db);
   RegionsTable regions(db, ctx.Height ());
 
@@ -95,10 +97,10 @@ ProcessAllMining (Database& db, xaya::Random& rnd, const Context& ctx)
         }
 
       /* Restrict the quantity by cargo space.  */
-      const int64_t freeCargo = pb.cargo_space () - c->UsedCargoSpace ();
+      const int64_t freeCargo = pb.cargo_space () - c->UsedCargoSpace (cfg);
       CHECK_GE (freeCargo, 0);
 
-      const auto itemSpace = RoConfig ().Item (type).space ();
+      const auto itemSpace = cfg.Item (type).space ();
       CHECK_GT (itemSpace, 0)
           << "Minable resource " << type << " has zero space";
 

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -40,8 +40,6 @@ StopMining (Character& c)
 void
 ProcessAllMining (Database& db, xaya::Random& rnd, const Context& ctx)
 {
-  const RoConfig cfg(ctx.Chain ());
-
   CharacterTable characters(db);
   RegionsTable regions(db, ctx.Height ());
 
@@ -97,10 +95,11 @@ ProcessAllMining (Database& db, xaya::Random& rnd, const Context& ctx)
         }
 
       /* Restrict the quantity by cargo space.  */
-      const int64_t freeCargo = pb.cargo_space () - c->UsedCargoSpace (cfg);
+      const int64_t freeCargo
+          = pb.cargo_space () - c->UsedCargoSpace (ctx.RoConfig ());
       CHECK_GE (freeCargo, 0);
 
-      const auto itemSpace = cfg.Item (type).space ();
+      const auto itemSpace = ctx.RoConfig ().Item (type).space ();
       CHECK_GT (itemSpace, 0)
           << "Minable resource " << type << " has zero space";
 

--- a/src/movement_bench.cpp
+++ b/src/movement_bench.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -110,7 +110,7 @@ MovementOneSegment (benchmark::State& state)
           for (unsigned i = 0; i < numWP; ++i)
             *wp->Add () = CoordToProto (HexCoord (numTiles, id));
         }
-      DynObstacles dyn(db);
+      DynObstacles dyn(db, ctx);
       state.ResumeTiming ();
 
       for (int i = 0; i < numTiles; ++i)
@@ -193,7 +193,7 @@ MovementLongHaul (benchmark::State& state)
             << "Using " << wp->size () << " waypoints to move " << total
             << " tiles with spacing of " << wpDist;
       }
-      DynObstacles dyn(db);
+      DynObstacles dyn(db, ctx);
       state.ResumeTiming ();
 
       do

--- a/src/movement_tests.cpp
+++ b/src/movement_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -126,10 +126,11 @@ class MovementEdgeWeightTests : public DBTestWithSchema
 
 protected:
 
+  ContextForTesting ctx;
   DynObstacles dyn;
 
   MovementEdgeWeightTests ()
-    : dyn(db)
+    : dyn(db, ctx)
   {}
 
 };
@@ -459,7 +460,7 @@ protected:
   void
   StepAll ()
   {
-    DynObstacles dyn(db);
+    DynObstacles dyn(db, ctx);
     ProcessAllMovement (db, dyn, ctx);
   }
 

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -34,6 +34,7 @@
 #include "database/region.hpp"
 #include "mapdata/basemap.hpp"
 #include "proto/building.pb.h"
+#include "proto/roconfig.hpp"
 
 #include <xayautil/random.hpp>
 
@@ -97,6 +98,9 @@ protected:
 
   /** Processing context data.  */
   const Context& ctx;
+
+  /** RoConfig instance.  */
+  const RoConfig cfg;
 
   /**
    * The Database handle we use for making any changes (and looking up the
@@ -183,7 +187,7 @@ protected:
    * Parses and validates the content of a drop or pick-up character command.
    * Returns the fungible items and their quantities to drop or pick up.
    */
-  static FungibleAmountMap ParseDropPickupFungible (const Json::Value& cmd);
+  FungibleAmountMap ParseDropPickupFungible (const Json::Value& cmd) const;
 
   /**
    * Parses and verifies a potential prospecting command.  Returns true if the

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -99,9 +99,6 @@ protected:
   /** Processing context data.  */
   const Context& ctx;
 
-  /** RoConfig instance.  */
-  const RoConfig cfg;
-
   /**
    * The Database handle we use for making any changes (and looking up the
    * current state while validating moves).

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -2481,8 +2481,6 @@ TEST_F (ProspectingMoveTests, Success)
 
 TEST_F (ProspectingMoveTests, Reprospecting)
 {
-  ctx.SetChain (xaya::Chain::REGTEST);
-
   auto r = regions.GetById (region);
   r->MutableProto ().mutable_prospection ()->set_height (10);
   r.reset ();
@@ -2533,9 +2531,11 @@ TEST_F (ProspectingMoveTests, Invalid)
 TEST_F (ProspectingMoveTests, CannotProspectRegion)
 {
   auto r = regions.GetById (region);
+  r->MutableProto ().mutable_prospection ()->set_height (10);
   r->MutableProto ().mutable_prospection ()->set_name ("foo");
   r.reset ();
 
+  ctx.SetHeight (11);
   Process (R"([
     {
       "name": "domob",
@@ -3038,9 +3038,7 @@ protected:
 
   GodModeTests ()
     : buildings(db), buildingInv(db), tbl(db), loot(db)
-  {
-    ctx.SetChain (xaya::Chain::REGTEST);
-  }
+  {}
 
 };
 
@@ -3359,16 +3357,15 @@ TEST_F (GodModeTests, GiftCoins)
  * Test fixture for god mode but set up on mainnet, so that god mode is
  * actually not allowed.
  */
-class GodModeDisabledTests : public MoveProcessorTests
+class GodModeDisabledTests : public GodModeTests
 {
 
 protected:
 
-  CharacterTable tbl;
-
   GodModeDisabledTests ()
-    : tbl(db)
-  {}
+  {
+    ctx.SetChain (xaya::Chain::MAIN);
+  }
 
 };
 
@@ -3395,7 +3392,7 @@ TEST_F (GodModeDisabledTests, SetHp)
   c.reset ();
 
   ProcessAdmin (R"([{"cmd": {
-    "god": {"sethp": {"1": {"a": 10}}}
+    "god": {"sethp": {"c": {"1": {"a": 10}}}}
   }}])");
 
   EXPECT_EQ (tbl.GetById (id)->GetHP ().armour (), 50);

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -57,7 +57,7 @@ protected:
   void
   ProcessAdmin (const std::string& str)
   {
-    DynObstacles dyn(db);
+    DynObstacles dyn(db, ctx);
     MoveProcessor mvProc(db, dyn, rnd, ctx);
     mvProc.ProcessAdmin (ParseJson (str));
   }
@@ -69,7 +69,7 @@ protected:
   void
   Process (const std::string& str)
   {
-    DynObstacles dyn(db);
+    DynObstacles dyn(db, ctx);
     MoveProcessor mvProc(db, dyn, rnd, ctx);
     mvProc.ProcessAll (ParseJson (str));
   }
@@ -86,7 +86,7 @@ protected:
     for (auto& entry : val)
       entry["out"][ctx.Params ().DeveloperAddress ()] = AmountToJson (amount);
 
-    DynObstacles dyn(db);
+    DynObstacles dyn(db, ctx);
     MoveProcessor mvProc(db, dyn, rnd, ctx);
     mvProc.ProcessAll (val);
   }

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -45,7 +45,7 @@ FinishBuildingConstruction (Building& b, const Context& ctx,
 {
   CHECK (b.GetProto ().foundation ())
       << "Building " << b.GetId () << " is not a foundation";
-  const auto& roData = RoConfig (ctx.Chain ()).Building (b.GetType ());
+  const auto& roData = ctx.RoConfig ().Building (b.GetType ());
   CHECK (roData.has_construction ())
       << "Building type " << b.GetType () << " is not constructible";
 

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -40,11 +40,12 @@ namespace
  * Finishes construction of the given building.
  */
 void
-FinishBuildingConstruction (Building& b, BuildingInventoriesTable& buildingInv)
+FinishBuildingConstruction (Building& b, const Context& ctx,
+                            BuildingInventoriesTable& buildingInv)
 {
   CHECK (b.GetProto ().foundation ())
       << "Building " << b.GetId () << " is not a foundation";
-  const auto& roData = RoConfig ().Building (b.GetType ());
+  const auto& roData = RoConfig (ctx.Chain ()).Building (b.GetType ());
   CHECK (roData.has_construction ())
       << "Building type " << b.GetType () << " is not constructible";
 
@@ -66,7 +67,7 @@ FinishBuildingConstruction (Building& b, BuildingInventoriesTable& buildingInv)
   pb.clear_construction_inventory ();
   pb.set_foundation (false);
 
-  UpdateBuildingStats (b);
+  UpdateBuildingStats (b, ctx.Chain ());
 }
 
 } // anonymous namespace
@@ -147,7 +148,7 @@ ProcessAllOngoings (Database& db, xaya::Random& rnd, const Context& ctx)
 
         case proto::OngoingOperation::kBuildingConstruction:
           CHECK (b != nullptr);
-          FinishBuildingConstruction (*b, buildingInv);
+          FinishBuildingConstruction (*b, ctx, buildingInv);
           break;
 
         default:

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -546,15 +546,15 @@ PendingMoves::AddPendingMove (const Json::Value& mv)
   PXLogic& rules = dynamic_cast<PXLogic&> (GetSQLiteGame ());
   SQLiteGameDatabase dbObj(db, rules);
 
-  if (dyn == nullptr)
-    dyn = std::make_unique<DynObstacles> (dbObj);
-
   const auto& blk = GetConfirmedBlock ();
   const auto& heightVal = blk["height"];
   CHECK (heightVal.isUInt ());
 
   const Context ctx(GetChain (), rules.GetBaseMap (),
                     heightVal.asUInt () + 1, Context::NO_TIMESTAMP);
+
+  if (dyn == nullptr)
+    dyn = std::make_unique<DynObstacles> (dbObj, ctx);
 
   PendingStateUpdater updater(dbObj, *dyn, state, ctx);
   updater.ProcessMove (mv);

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -674,7 +674,7 @@ protected:
       moveObj["out"][ctx.Params ().DeveloperAddress ()]
           = AmountToJson (paidToDev);
 
-    DynObstacles dyn(db);
+    DynObstacles dyn(db, ctx);
     PendingStateUpdater updater(db, dyn, state, ctx);
     updater.ProcessMove (moveObj);
   }

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -73,8 +73,6 @@ void
 FinishProspecting (Character& c, Database& db, RegionsTable& regions,
                    xaya::Random& rnd, const Context& ctx)
 {
-  const RoConfig cfg(ctx.Chain ());
-
   const auto& pos = c.GetPosition ();
   const auto regionId = ctx.Map ().Regions ().GetRegionId (pos);
   LOG (INFO)
@@ -93,7 +91,7 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
   /* Determine the mine-able resource here.  */
   std::string type;
   Inventory::QuantityT amount;
-  DetectResource (pos, cfg->resource_dist (), rnd, type, amount);
+  DetectResource (pos, ctx.RoConfig ()->resource_dist (), rnd, type, amount);
   prosp->set_resource (type);
   r->SetResourceLeft (amount);
 

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -73,6 +73,8 @@ void
 FinishProspecting (Character& c, Database& db, RegionsTable& regions,
                    xaya::Random& rnd, const Context& ctx)
 {
+  const RoConfig cfg(ctx.Chain ());
+
   const auto& pos = c.GetPosition ();
   const auto regionId = ctx.Map ().Regions ().GetRegionId (pos);
   LOG (INFO)
@@ -91,7 +93,7 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
   /* Determine the mine-able resource here.  */
   std::string type;
   Inventory::QuantityT amount;
-  DetectResource (pos, RoConfig ()->resource_dist (), rnd, type, amount);
+  DetectResource (pos, cfg->resource_dist (), rnd, type, amount);
   prosp->set_resource (type);
   r->SetResourceLeft (amount);
 

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -287,9 +287,10 @@ TEST (PrizesTests, AllInItemConfig)
   for (const xaya::Chain c : {xaya::Chain::MAIN, xaya::Chain::TEST,
                               xaya::Chain::REGTEST})
     {
+      const RoConfig cfg(c);
       const Params params(c);
       for (const auto& p : params.ProspectingPrizes ())
-        ASSERT_NE (RoConfig ().ItemOrNull (p.name + " prize"), nullptr)
+        ASSERT_NE (cfg.ItemOrNull (p.name + " prize"), nullptr)
             << "Prize item not defined: " << p.name;
     }
 }

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -58,9 +58,7 @@ protected:
   CanProspectRegionTests ()
     : characters(db), regions(db, 1'042),
       pos(-10, 42), region(ctx.Map ().Regions ().GetRegionId (pos))
-  {
-    ctx.SetChain (xaya::Chain::REGTEST);
-  }
+  {}
 
 };
 
@@ -127,8 +125,6 @@ protected:
   FinishProspectingTests ()
     : characters(db), regions(db, 1'042)
   {
-    ctx.SetChain (xaya::Chain::REGTEST);
-
     const auto h = characters.CreateNew ("domob", Faction::RED);
     CHECK_EQ (h->GetId (), 1);
   }

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -209,14 +209,14 @@ NonStateRpcServer::getbuildingshape (const Json::Value& centre, const int rot,
     ReturnError (ErrorCode::INVALID_ARGUMENT,
                  "rot is outside the valid range [0, 5]");
 
-  if (RoConfig ().BuildingOrNull (type) == nullptr)
+  if (RoConfig (chain).BuildingOrNull (type) == nullptr)
     ReturnError (ErrorCode::INVALID_ARGUMENT, "unknown building type");
 
   proto::ShapeTransformation trafo;
   trafo.set_rotation_steps (rot);
 
   Json::Value res(Json::arrayValue);
-  for (const auto& t : GetBuildingShape (type, trafo, c))
+  for (const auto& t : GetBuildingShape (type, trafo, c, chain))
     res.append (CoordToJson (t));
 
   return res;

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -74,11 +74,14 @@ private:
   /** The basemap we use.  */
   const BaseMap& map;
 
+  /** The chain this is running on.  */
+  const xaya::Chain chain;
+
 public:
 
   explicit NonStateRpcServer (jsonrpc::AbstractServerConnector& conn,
-                              const BaseMap& m)
-    : NonStateRpcServerStub(conn), map(m)
+                              const BaseMap& m, const xaya::Chain c)
+    : NonStateRpcServerStub(conn), map(m), chain(c)
   {}
 
   Json::Value findpath (int l1range, const Json::Value& source,
@@ -116,7 +119,7 @@ public:
   explicit PXRpcServer (xaya::Game& g, PXLogic& l,
                         jsonrpc::AbstractServerConnector& conn)
     : PXRpcServerStub(conn), game(g), logic(l),
-      nonstate(nullConnector, logic.map)
+      nonstate(nullConnector, logic.map, game.GetChain ())
   {}
 
   void stop () override;

--- a/src/resourcedist_tests.cpp
+++ b/src/resourcedist_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -115,7 +115,7 @@ protected:
   Inventory::QuantityT amount;
 
   DetectResourceTests ()
-    : rd(RoConfig ()->resource_dist ())
+    : rd(RoConfig (xaya::Chain::REGTEST)->resource_dist ())
   {}
 
   /**

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -124,7 +124,8 @@ protected:
   bool
   IsSupported (const Building& b) const override
   {
-    return cfg.Building (b.GetType ()).offered_services ().refining ();
+    return ctx.RoConfig ().Building (b.GetType ())
+        .offered_services ().refining ();
   }
 
   Amount
@@ -153,7 +154,7 @@ RefiningOperation::RefiningOperation (Account& a, BuildingsTable::Handle b,
   : ServiceOperation(a, std::move (b), refs),
     type(t), amount(am)
 {
-  const auto* itemData = cfg.ItemOrNull (type);
+  const auto* itemData = ctx.RoConfig ().ItemOrNull (type);
   if (itemData == nullptr)
     {
       LOG (WARNING) << "Can't refine invalid item type " << type;
@@ -274,7 +275,8 @@ protected:
   bool
   IsSupported (const Building& b) const override
   {
-    return cfg.Building (b.GetType ()).offered_services ().armour_repair ();
+    return ctx.RoConfig ().Building (b.GetType ())
+        .offered_services ().armour_repair ();
   }
 
   bool IsValid () const override;
@@ -441,7 +443,7 @@ protected:
   bool
   IsSupported (const Building& b) const override
   {
-    return cfg.Building (b.GetType ())
+    return ctx.RoConfig ().Building (b.GetType ())
         .offered_services ().reverse_engineering ();
   }
 
@@ -471,7 +473,7 @@ RevEngOperation::RevEngOperation (Account& a, BuildingsTable::Handle b,
   : ServiceOperation(a, std::move (b), refs),
     type(t), num(n)
 {
-  const auto* itemData = cfg.ItemOrNull (type);
+  const auto* itemData = ctx.RoConfig ().ItemOrNull (type);
   if (itemData == nullptr)
     {
       LOG (WARNING) << "Can't reveng invalid item type " << type;
@@ -596,7 +598,8 @@ protected:
   bool
   IsSupported (const Building& b) const override
   {
-    return cfg.Building (b.GetType ()).offered_services ().blueprint_copy ();
+    return ctx.RoConfig ().Building (b.GetType ())
+        .offered_services ().blueprint_copy ();
   }
 
   Amount
@@ -626,7 +629,7 @@ BlueprintCopyOperation::BlueprintCopyOperation (
   : ServiceOperation(a, std::move (b), refs),
     original(o), num(n)
 {
-  const auto* origData = cfg.ItemOrNull (original);
+  const auto* origData = ctx.RoConfig ().ItemOrNull (original);
   if (origData == nullptr || !origData->has_is_blueprint ())
     {
       LOG (WARNING) << "Can't copy item type " << original;
@@ -641,7 +644,7 @@ BlueprintCopyOperation::BlueprintCopyOperation (
 
   const auto& baseType = origData->is_blueprint ().for_item ();
   copy = baseType + " bpc";
-  complexity = cfg.Item (baseType).complexity ();
+  complexity = ctx.RoConfig ().Item (baseType).complexity ();
   CHECK_GT (complexity, 0)
       << "Invalid complexity " << complexity << " for type " << baseType;
 }
@@ -774,7 +777,7 @@ ConstructionOperation::ConstructionOperation (
   : ServiceOperation(a, std::move (b), refs),
     blueprint(bp), num(n)
 {
-  const auto* bpData = cfg.ItemOrNull (blueprint);
+  const auto* bpData = ctx.RoConfig ().ItemOrNull (blueprint);
   if (bpData == nullptr || !bpData->has_is_blueprint ())
     {
       LOG (WARNING) << "Can't construct from item type " << blueprint;
@@ -784,7 +787,7 @@ ConstructionOperation::ConstructionOperation (
 
   fromOriginal = bpData->is_blueprint ().original ();
   output = bpData->is_blueprint ().for_item ();
-  outputData = &(cfg.Item (output));
+  outputData = &(ctx.RoConfig ().Item (output));
   CHECK_GT (outputData->complexity (), 0)
       << "Invalid complexity " << outputData->complexity ()
       << " for type " << output;
@@ -793,7 +796,8 @@ ConstructionOperation::ConstructionOperation (
 bool
 ConstructionOperation::IsSupported (const Building& b) const
 {
-  const auto& offered = cfg.Building (b.GetType ()).offered_services ();
+  const auto& offered
+      = ctx.RoConfig ().Building (b.GetType ()).offered_services ();
 
   if (outputData->has_vehicle ())
     return offered.vehicle_construction ();
@@ -913,7 +917,7 @@ ServiceOperation::ServiceOperation (Account& a, BuildingsTable::Handle b,
                                     const ContextRefs& refs)
   : accounts(refs.accounts), ongoings(refs.ongoings),
     acc(a), building(std::move (b)),
-    ctx(refs.ctx), cfg(ctx.Chain ()),
+    ctx(refs.ctx),
     invTable(refs.invTable), itemCounts(refs.cnt)
 {}
 

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -86,9 +86,6 @@ protected:
   /** Context for parameters and such.  */
   const Context& ctx;
 
-  /** RoConfig instance.  */
-  const RoConfig cfg;
-
   /** Database handle for upating building inventories (e.g. for refining).  */
   BuildingInventoriesTable& invTable;
 

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -28,6 +28,7 @@
 #include "database/inventory.hpp"
 #include "database/itemcounts.hpp"
 #include "database/ongoing.hpp"
+#include "proto/roconfig.hpp"
 
 #include <xayautil/random.hpp>
 
@@ -84,6 +85,9 @@ protected:
 
   /** Context for parameters and such.  */
   const Context& ctx;
+
+  /** RoConfig instance.  */
+  const RoConfig cfg;
 
   /** Database handle for upating building inventories (e.g. for refining).  */
   BuildingInventoriesTable& invTable;

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -655,10 +655,6 @@ protected:
 
   RevEngTests ()
   {
-    /* Regtest has better chances for reverse engineering (starting at 100%),
-       so that is more suitable for testing.  */
-    ctx.SetChain (xaya::Chain::REGTEST);
-
     inv.Get (ANCIENT_BUILDING, "domob")
         ->GetInventory ().AddFungibleCount ("test artefact", 3);
   }

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -141,7 +141,7 @@ SpawnCharacter (const std::string& owner, const Faction f,
       break;
     }
 
-  DeriveCharacterStats (*c);
+  DeriveCharacterStats (*c, ctx);
 
   return c;
 }

--- a/src/spawn_tests.cpp
+++ b/src/spawn_tests.cpp
@@ -50,7 +50,7 @@ protected:
   CharacterTable tbl;
 
   SpawnTests ()
-    : dyn(db), tbl(db)
+    : dyn(db, ctx), tbl(db)
   {}
 
   /**

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -40,6 +40,7 @@ ContextForTesting::SetChain (const xaya::Chain c)
   LOG (INFO) << "Setting context chain to " << xaya::ChainToString (c);
   chain = c;
   params = std::make_unique<pxd::Params> (chain);
+  cfg = std::make_unique<pxd::RoConfig> (chain);
 }
 
 void

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -57,7 +57,7 @@ private:
 public:
 
   ContextForTesting ()
-    : Context(xaya::Chain::MAIN, map, 0, NO_TIMESTAMP)
+    : Context(xaya::Chain::REGTEST, map, 0, NO_TIMESTAMP)
   {
     /* Note that map will be constructed only after the superclass
        constructor, which stores a reference to it.  That is fine, though,


### PR DESCRIPTION
This implements the bulk of #108:  We pass the chain through to `RoConfig` (and in most places just access the `RoConfig` through `Context`), and also actually split the proto data into the main configuration and extra stuff that gets merged for regtest.

For now, the merged stuff is just the test items and buildings (so they are not actually defined on mainnet/testnet, not just "not available").  In the future, we can now use this to move stuff from `Params` to the roconfig proto.