### PR TITLE
Move basic parameters to roconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ libtool
 ltmain.sh
 m4
 missing
+py-compile
 stamp-h1
 test-driver
 

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -1,3 +1,6 @@
+AM_TESTS_ENVIRONMENT = \
+  PYTHONPATH=$(PYTHONPATH):$(top_srcdir)
+
 TEST_LIBRARY = \
   pxtest.py
 

--- a/gametest/accounts.py
+++ b/gametest/accounts.py
@@ -21,7 +21,7 @@
 Tests creation / initialisation of accounts.
 """
 
-from pxtest import PXTest, CHARACTER_COST
+from pxtest import PXTest
 
 
 class AccountsTest (PXTest):

--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -22,7 +22,7 @@ Runs tests about the basic handling of characters (creating them, transferring
 them and retrieving them through RPC).
 """
 
-from pxtest import PXTest, CHARACTER_COST
+from pxtest import PXTest
 
 
 class CharactersTest (PXTest):
@@ -45,11 +45,13 @@ class CharactersTest (PXTest):
   def run (self):
     self.collectPremine ()
 
+    cost = self.roConfig ().params.character_cost
+
     self.mainLogger.info ("Creating first character...")
     self.moveWithPayment ("adam", {
       "a": {"init": {"faction": "r"}},
       "nc": [{}],
-    }, CHARACTER_COST)
+    }, cost)
     self.generate (1)
     self.expectPartial ({
       "adam": {"owner": "adam", "faction": "r"},
@@ -116,7 +118,7 @@ class CharactersTest (PXTest):
 
     self.mainLogger.info ("Multiple creations in one transaction...")
     self.initAccount ("domob", "b")
-    self.moveWithPayment ("domob", {"nc": [{}, {}, {}]}, 2.5 * CHARACTER_COST)
+    self.moveWithPayment ("domob", {"nc": [{}, {}, {}]}, 2.5 * cost)
     self.generate (1)
     self.expectPartial ({
       "adam": {"owner": "adam"},

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -24,7 +24,6 @@ import os.path
 
 
 GAMEID = "tn"
-DEVADDR = "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p"
 
 
 def offsetCoord (c, offs, inverse):
@@ -304,7 +303,8 @@ class PXTest (XayaGameTest):
     given payment to the developer address.
     """
 
-    return self.sendMove (name, move, {"sendCoins": {DEVADDR: devAmount}})
+    addr = self.roConfig ().params.dev_addr
+    return self.sendMove (name, move, {"sendCoins": {addr: devAmount}})
 
   def roConfig (self):
     """

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -16,6 +16,8 @@
 
 from xayagametest.testcase import XayaGameTest
 
+from proto import config_pb2
+
 import collections
 import os
 import os.path
@@ -23,7 +25,6 @@ import os.path
 
 GAMEID = "tn"
 DEVADDR = "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p"
-CHARACTER_COST = 1
 
 
 def offsetCoord (c, offs, inverse):
@@ -259,12 +260,24 @@ class PXTest (XayaGameTest):
   Integration test for the Tauron game daemon.
   """
 
+  cfg = None
+
   def __init__ (self):
-    top_builddir = os.getenv ("top_builddir")
-    if top_builddir is None:
-      top_builddir = ".."
-    binary = os.path.join (top_builddir, "src", "tauriond")
+    binary = self.getBuildPath ("src", "tauriond")
     super (PXTest, self).__init__ (GAMEID, binary)
+
+  def getBuildPath (self, *parts):
+    """
+    Returns the builddir (to get the GSP binary and roconfig file).
+    It retrieves what should be the top builddir and then adds on the parts
+    with os.path.join.
+    """
+
+    top = os.getenv ("top_builddir")
+    if top is None:
+      top = ".."
+
+    return os.path.join (top, *parts)
 
   def splitPremine (self):
     """
@@ -293,6 +306,21 @@ class PXTest (XayaGameTest):
 
     return self.sendMove (name, move, {"sendCoins": {DEVADDR: devAmount}})
 
+  def roConfig (self):
+    """
+    Returns the roconfig protocol buffer.
+    """
+
+    if self.cfg is None:
+      self.cfg = config_pb2.ConfigData ()
+      with open (self.getBuildPath ("proto", "roconfig.pb"), "rb") as f:
+        self.cfg.ParseFromString (f.read ())
+      self.cfg.MergeFrom (self.cfg.regtest_merge)
+      self.cfg.ClearField ("regtest_merge")
+
+    assert self.cfg is not None
+    return self.cfg
+
   def initAccount (self, name, faction):
     """
     Utility method to initialise an account.
@@ -315,8 +343,8 @@ class PXTest (XayaGameTest):
     Utility method to create multiple characters for a given owner.
     """
 
-    return self.moveWithPayment (owner, {"nc": [{}] * num},
-                                 num * CHARACTER_COST)
+    cost = self.roConfig ().params.character_cost
+    return self.moveWithPayment (owner, {"nc": [{}] * num}, num * cost)
 
   def getCharacters (self):
     """

--- a/proto/.gitignore
+++ b/proto/.gitignore
@@ -7,3 +7,4 @@ tests
 *.trs
 *.pb.h
 *.pb.cc
+*_pb2.py

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -39,15 +39,17 @@ EXTRA_DIST = \
   roconfig_gen_head.cpp roconfig_gen_mid.cpp roconfig_gen_tail.cpp
 
 BUILT_SOURCES = \
-  $(PROTOS:.proto=.pb.h) \
+  $(PROTOS:.proto=.pb.h) $(PROTOS:.proto=_pb2.py) \
   roconfig_gen.cpp \
   roconfig.pb.text roconfig.pb
 CLEANFILES = \
-  $(PROTOS:.proto=.pb.h) $(PROTOS:.proto=.pb.cc) \
+  $(PROTOS:.proto=.pb.h) $(PROTOS:.proto=.pb.cc) $(PROTOS:.proto=_pb2.py) \
   roconfig_gen.cpp roconfig.pb.text roconfig.pb
 
-libpxproto_la_CXXFLAGS = $(XAYAGAME_CFLAGS) $(PROTOBUF_CFLAGS)
-libpxproto_la_LBADD = $(XAYAGAME_LIBS) $(PROTOBUF_LIBS)
+libpxproto_la_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(XAYAGAME_CFLAGS) $(PROTOBUF_CFLAGS)
+libpxproto_la_LIBADD = $(XAYAGAME_LIBS) $(PROTOBUF_LIBS)
 libpxproto_la_SOURCES = \
   roconfig.cpp \
   \
@@ -58,12 +60,18 @@ noinst_HEADERS = \
   \
   $(PROTOS:.proto=.pb.h)
 
-roconfig_gen_CXXFLAGS = $(GLOG_CFLAGS) $(GFLAGS_CFLAGS) $(PROTOBUF_CFLAGS)
+roconfig_gen_CXXFLAGS = \
+  -I$(top_srcdir) \
+  $(GLOG_CFLAGS) $(GFLAGS_CFLAGS) $(PROTOBUF_CFLAGS)
 roconfig_gen_LDADD = $(GLOG_LIBS) $(GFLAGS_LIBS) $(PROTOBUF_LIBS)
 roconfig_gen_SOURCES = \
   roconfig_gen.cpp \
   \
   $(PROTOS:.proto=.pb.cc)
+
+noinst_PYTHON = \
+  __init__.py \
+  $(PROTOS:.proto=_pb2.py)
 
 check_PROGRAMS = tests
 TESTS = tests
@@ -79,8 +87,10 @@ tests_LDADD = \
 tests_SOURCES = \
   roconfig_tests.cpp
 
-%.pb.h %.pb.cc: $(srcdir)/%.proto
-	protoc -I$(srcdir) --cpp_out=. "$<"
+%.pb.h %.pb.cc: $(top_srcdir)/proto/%.proto
+	protoc -I$(top_srcdir) --cpp_out=$(top_builddir) "$<"
+%_pb2.py: $(top_srcdir)/proto/%.proto
+	protoc -I$(top_srcdir) --python_out=$(top_builddir) "$<"
 
 roconfig_gen.cpp: roconfig_gen_head.cpp $(ROCONFIG_TEXT_PROTOS) roconfig_gen_mid.cpp $(ROCONFIG_TEXT_PROTOS_REGTEST) roconfig_gen_tail.cpp
 	cat $^ >$@

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -19,6 +19,7 @@ ROCONFIG_TEXT_PROTOS = \
   roconfig/buildings/turrets.pb.text
 
 ROCONFIG_TEXT_PROTOS_REGTEST = \
+  roconfig/test_params.pb.text \
   roconfig/buildings/test.pb.text \
   roconfig/items/test.pb.text
 

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -16,7 +16,9 @@ ROCONFIG_TEXT_PROTOS = \
   roconfig/buildings/obelisk1.pb.text \
   roconfig/buildings/obelisk2.pb.text \
   roconfig/buildings/obelisk3.pb.text \
-  roconfig/buildings/turrets.pb.text
+  roconfig/buildings/turrets.pb.text \
+  \
+  roconfig/testnet.pb.text
 
 ROCONFIG_TEXT_PROTOS_REGTEST = \
   roconfig/test_params.pb.text \

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -2,6 +2,7 @@ noinst_PROGRAMS = roconfig_gen
 noinst_LTLIBRARIES = libpxproto.la
 
 ROCONFIG_TEXT_PROTOS = \
+  roconfig/params.pb.text \
   roconfig/resourcedist.pb.text \
   \
   roconfig/items/fitments.pb.text \

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -18,8 +18,8 @@
 
 syntax = "proto2";
 
-import "combat.proto";
-import "inventory.proto";
+import "proto/combat.proto";
+import "proto/inventory.proto";
 
 package pxd.proto;
 

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -18,8 +18,8 @@
 
 syntax = "proto2";
 
-import "combat.proto";
-import "movement.proto";
+import "proto/combat.proto";
+import "proto/movement.proto";
 
 package pxd.proto;
 

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto2";
 
-import "modifier.proto";
+import "proto/modifier.proto";
 
 package pxd.proto;
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -347,6 +347,17 @@ message Params
   /** The maximum number of characters per account.  */
   optional uint32 character_limit = 2;
 
+  /** The maximum L1 distance between waypoints.  */
+  optional uint32 max_waypoint_l1_dist = 3;
+
+  /**
+   * Number of retries of a blocked movement step before the movement
+   * is cancelled completely.  Note that this is really the number of *retries*,
+   * meaning that movement is only cancelled after N+1 blocked turns if N is
+   * the value here.
+   */
+  optional uint32 blocked_step_retries = 4;
+
 }
 
 /* ************************************************************************** */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -335,6 +335,17 @@ message ResourceDistribution
 
 }
 
+/**
+ * Basic parameters of the game.
+ */
+message Params
+{
+
+  /** The amount of CHI to be paid for a character.  */
+  optional int64 character_cost = 1;
+
+}
+
 /* ************************************************************************** */
 
 /**
@@ -356,6 +367,9 @@ message ConfigData
 
   /** Distribution of resources for prospecting.  */
   optional ResourceDistribution resource_dist = 3;
+
+  /** Basic parameters.  */
+  optional Params params = 4;
 
   /**
    * The regtest-specific configuration data.  This is merged into the main

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -370,6 +370,24 @@ message Params
    */
   optional uint32 prospection_expiry_blocks = 7;
 
+  /** The number of HP that can be repaired per block.  */
+  optional uint32 armour_repair_hp_per_block = 8;
+
+  /** Cost (in 1/1000 vCHI) for repairing one HP of armour.  */
+  optional uint32 armour_repair_cost_millis = 9;
+
+  /** Cost (in vCHI) for copying a blueprint, per complexity.  */
+  optional int64 bp_copy_cost = 10;
+
+  /** Number of blocks for copying a blueprint, per complexity.  */
+  optional uint32 bp_copy_blocks = 11;
+
+  /** Cost (in vCHI) for constructing an item, per complexity.  */
+  optional int64 construction_cost = 12;
+
+  /** Nubmer of blocks for constructing an item, per complexity.  */
+  optional uint32 construction_blocks = 13;
+
 }
 
 /* ************************************************************************** */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -18,10 +18,10 @@
 
 syntax = "proto2";
 
-import "character.proto";
-import "combat.proto";
-import "geometry.proto";
-import "modifier.proto";
+import "proto/character.proto";
+import "proto/combat.proto";
+import "proto/geometry.proto";
+import "proto/modifier.proto";
 
 package pxd.proto;
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -344,6 +344,9 @@ message Params
   /** The amount of CHI to be paid for a character.  */
   optional int64 character_cost = 1;
 
+  /** The maximum number of characters per account.  */
+  optional uint32 character_limit = 2;
+
 }
 
 /* ************************************************************************** */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -364,6 +364,12 @@ message Params
   /** The duration of prospecting in blocks.  */
   optional uint32 prospecting_blocks = 6;
 
+  /**
+   * The number of blocks after which a region can be reprospected (if there
+   * are no other factors preventing it).
+   */
+  optional uint32 prospection_expiry_blocks = 7;
+
 }
 
 /* ************************************************************************** */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -335,6 +335,22 @@ message ResourceDistribution
 
 }
 
+/* ************************************************************************** */
+
+/**
+ * Definition of a spawn area.
+ */
+message SpawnArea
+{
+
+  /** The centre of the area.  */
+  optional HexCoord centre = 1;
+
+  /** The L1 radius around the centre.  */
+  optional uint32 radius = 2;
+
+}
+
 /**
  * Basic parameters of the game.
  */
@@ -387,6 +403,9 @@ message Params
 
   /** Nubmer of blocks for constructing an item, per complexity.  */
   optional uint32 construction_blocks = 13;
+
+  /** Spawn areas for the factions (with the "r", "g", "b" string as key).  */
+  map<string, SpawnArea> spawn_areas = 14;
 
 }
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -404,8 +404,11 @@ message Params
   /** Nubmer of blocks for constructing an item, per complexity.  */
   optional uint32 construction_blocks = 13;
 
+  /** Whether or not god mode is enabled.  */
+  optional bool god_mode = 14;
+
   /** Spawn areas for the factions (with the "r", "g", "b" string as key).  */
-  map<string, SpawnArea> spawn_areas = 14;
+  map<string, SpawnArea> spawn_areas = 15;
 
 }
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -358,6 +358,12 @@ message Params
    */
   optional uint32 blocked_step_retries = 4;
 
+  /** The number of blocks for which a character stays on a damage list.  */
+  optional uint32 damage_list_blocks = 5;
+
+  /** The duration of prospecting in blocks.  */
+  optional uint32 prospecting_blocks = 6;
+
 }
 
 /* ************************************************************************** */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -404,11 +404,14 @@ message Params
   /** Nubmer of blocks for constructing an item, per complexity.  */
   optional uint32 construction_blocks = 13;
 
+  /** The address to which developer payments should be sent.  */
+  optional string dev_addr = 14;
+
   /** Whether or not god mode is enabled.  */
-  optional bool god_mode = 14;
+  optional bool god_mode = 15;
 
   /** Spawn areas for the factions (with the "r", "g", "b" string as key).  */
-  map<string, SpawnArea> spawn_areas = 15;
+  map<string, SpawnArea> spawn_areas = 16;
 
 }
 
@@ -438,9 +441,15 @@ message ConfigData
   optional Params params = 4;
 
   /**
-   * The regtest-specific configuration data.  This is merged into the main
-   * instance by the RoConfig-helper class when running on regtest.
+   * The testnet-specific configuration data.  This is merged into the main
+   * configuration when running on testnet or regtest.
    */
-  optional ConfigData regtest_merge = 100;
+  optional ConfigData testnet_merge = 100;
+
+  /**
+   * The regtest-specific configuration data.  This is merged into the testnet
+   * data by the RoConfig-helper class when running on regtest.
+   */
+  optional ConfigData regtest_merge = 101;
 
 }

--- a/proto/movement.proto
+++ b/proto/movement.proto
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 
 syntax = "proto2";
 
-import "geometry.proto";
+import "proto/geometry.proto";
 
 package pxd.proto;
 

--- a/proto/roconfig.hpp
+++ b/proto/roconfig.hpp
@@ -51,6 +51,9 @@ private:
    */
   static Data* mainnet;
 
+  /** The singleton instance for testnet.  */
+  static Data* testnet;
+
   /** The singleton instance for regtest.  */
   static Data* regtest;
 

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -1,4 +1,5 @@
 params:
   {
     character_cost: 1
+    character_limit: 20
   }

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -17,6 +17,10 @@ params:
     construction_cost: 100
     construction_blocks: 10
 
+    # The address configured here (for mainnet) is the premine address of Xaya
+    # controlled by the Xaya team.  See also Xaya Core's src/chainparams.cpp.
+    dev_addr: "DHy2615XKevE23LVRVZVxGeqxadRGyiFW4"
+
     god_mode: false
 
     spawn_areas:

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -17,6 +17,8 @@ params:
     construction_cost: 100
     construction_blocks: 10
 
+    god_mode: false
+
     spawn_areas:
       {
         key: "r"

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -1,0 +1,4 @@
+params:
+  {
+    character_cost: 1
+  }

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -6,4 +6,5 @@ params:
     blocked_step_retries: 10
     damage_list_blocks: 100
     prospecting_blocks: 10
+    prospection_expiry_blocks: 5000
   }

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -2,4 +2,6 @@ params:
   {
     character_cost: 1
     character_limit: 20
+    max_waypoint_l1_dist: 100
+    blocked_step_retries: 10
   }

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -4,4 +4,6 @@ params:
     character_limit: 20
     max_waypoint_l1_dist: 100
     blocked_step_retries: 10
+    damage_list_blocks: 100
+    prospecting_blocks: 10
   }

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -7,4 +7,10 @@ params:
     damage_list_blocks: 100
     prospecting_blocks: 10
     prospection_expiry_blocks: 5000
+    armour_repair_hp_per_block: 100
+    armour_repair_cost_millis: 100  # 1 vCHI per 10 HP repair
+    bp_copy_cost: 100
+    bp_copy_blocks: 10
+    construction_cost: 100
+    construction_blocks: 10
   }

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -2,15 +2,46 @@ params:
   {
     character_cost: 1
     character_limit: 20
+
     max_waypoint_l1_dist: 100
     blocked_step_retries: 10
+
     damage_list_blocks: 100
     prospecting_blocks: 10
     prospection_expiry_blocks: 5000
+
     armour_repair_hp_per_block: 100
     armour_repair_cost_millis: 100  # 1 vCHI per 10 HP repair
     bp_copy_cost: 100
     bp_copy_blocks: 10
     construction_cost: 100
     construction_blocks: 10
+
+    spawn_areas:
+      {
+        key: "r"
+        value:
+          {
+            centre: { x: 1993 y: -2636 }
+            radius: 50
+          }
+      }
+    spawn_areas:
+      {
+        key: "g"
+        value:
+          {
+            centre: { x: -3430 y: 1793 }
+            radius: 50
+          }
+      }
+    spawn_areas:
+      {
+        key: "b"
+        value:
+          {
+            centre: { x: 571 y: 2609 }
+            radius: 50
+          }
+      }
   }

--- a/proto/roconfig/test_params.pb.text
+++ b/proto/roconfig/test_params.pb.text
@@ -4,4 +4,5 @@
 params:
   {
     prospection_expiry_blocks: 100
+    god_mode: true
   }

--- a/proto/roconfig/test_params.pb.text
+++ b/proto/roconfig/test_params.pb.text
@@ -1,0 +1,7 @@
+# This gets merged in with the mainnet configuration, so we only need
+# to specify parameters that actually differ.
+
+params:
+  {
+    prospection_expiry_blocks: 100
+  }

--- a/proto/roconfig/test_params.pb.text
+++ b/proto/roconfig/test_params.pb.text
@@ -4,5 +4,6 @@
 params:
   {
     prospection_expiry_blocks: 100
+    dev_addr: "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p"
     god_mode: true
   }

--- a/proto/roconfig/testnet.pb.text
+++ b/proto/roconfig/testnet.pb.text
@@ -1,0 +1,7 @@
+testnet_merge:
+  {
+    params:
+      {
+        dev_addr: "dSFDAWxovUio63hgtfYd3nz3ir61sJRsXn"
+      }
+  }

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -61,6 +61,9 @@ TEST (RoConfigTests, ChainDependence)
 
   EXPECT_EQ (main->params ().prospection_expiry_blocks (), 5'000);
   EXPECT_EQ (regtest->params ().prospection_expiry_blocks (), 100);
+
+  EXPECT_FALSE (main->params ().god_mode ());
+  EXPECT_TRUE (regtest->params ().god_mode ());
 }
 
 TEST (RoConfigTests, Building)

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -47,11 +47,14 @@ TEST (RoConfigTests, ProtoIsSingleton)
 TEST (RoConfigTests, ChainDependence)
 {
   const RoConfig main(xaya::Chain::MAIN);
+  const RoConfig test(xaya::Chain::TEST);
   const RoConfig regtest(xaya::Chain::REGTEST);
 
   EXPECT_NE (main.ItemOrNull ("raw a"), nullptr);
+  EXPECT_NE (test.ItemOrNull ("raw a"), nullptr);
   EXPECT_NE (regtest.ItemOrNull ("raw a"), nullptr);
   EXPECT_EQ (main.ItemOrNull ("bow"), nullptr);
+  EXPECT_EQ (test.ItemOrNull ("bow"), nullptr);
   EXPECT_NE (regtest.ItemOrNull ("bow"), nullptr);
 
   EXPECT_NE (main.BuildingOrNull ("ancient1"), nullptr);
@@ -60,9 +63,16 @@ TEST (RoConfigTests, ChainDependence)
   EXPECT_NE (regtest.BuildingOrNull ("huesli"), nullptr);
 
   EXPECT_EQ (main->params ().prospection_expiry_blocks (), 5'000);
+  EXPECT_EQ (test->params ().prospection_expiry_blocks (), 5'000);
   EXPECT_EQ (regtest->params ().prospection_expiry_blocks (), 100);
 
+  EXPECT_EQ (main->params ().dev_addr (), "DHy2615XKevE23LVRVZVxGeqxadRGyiFW4");
+  EXPECT_EQ (test->params ().dev_addr (), "dSFDAWxovUio63hgtfYd3nz3ir61sJRsXn");
+  EXPECT_EQ (regtest->params ().dev_addr (),
+             "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p");
+
   EXPECT_FALSE (main->params ().god_mode ());
+  EXPECT_FALSE (test->params ().god_mode ());
   EXPECT_TRUE (regtest->params ().god_mode ());
 }
 
@@ -197,6 +207,12 @@ protected:
 bool
 RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
 {
+  if (cfg->has_testnet_merge () || cfg->has_regtest_merge ())
+    {
+      LOG (WARNING) << "Merge data still present";
+      return false;
+    }
+
   for (const auto& entry : cfg->fungible_items ())
     {
       const auto& i = entry.second;

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -58,6 +58,9 @@ TEST (RoConfigTests, ChainDependence)
   EXPECT_NE (regtest.BuildingOrNull ("ancient1"), nullptr);
   EXPECT_EQ (main.BuildingOrNull ("huesli"), nullptr);
   EXPECT_NE (regtest.BuildingOrNull ("huesli"), nullptr);
+
+  EXPECT_EQ (main->params ().prospection_expiry_blocks (), 5'000);
+  EXPECT_EQ (regtest->params ().prospection_expiry_blocks (), 100);
 }
 
 TEST (RoConfigTests, Building)

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -71,7 +71,8 @@ void
 PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
                       const Context& ctx, const Json::Value& blockData)
 {
-  fame.GetDamageLists ().RemoveOld (ctx.Params ().DamageListBlocks ());
+  fame.GetDamageLists ().RemoveOld (
+      ctx.RoConfig ()->params ().damage_list_blocks ());
 
   AllHpUpdates (db, fame, rnd, ctx);
   ProcessAllOngoings (db, rnd, ctx);

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -285,7 +285,7 @@ ValidateCharacterLimit (Database& db, const Context& ctx)
     {
       auto a = accounts.GetFromResult (res);
       CHECK_LE (characters.CountForOwner (a->GetName ()),
-                ctx.Params ().CharacterLimit ())
+                ctx.RoConfig ()->params ().character_limit ())
           << "Account " << a->GetName () << " has too many characters";
     }
 }

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -1011,7 +1011,7 @@ TEST_F (ValidateStateTests, CharacterLimit)
 {
   accounts.CreateNew ("domob", Faction::RED);
   accounts.CreateNew ("andy", Faction::GREEN);
-  for (unsigned i = 0; i < ctx.Params ().CharacterLimit (); ++i)
+  for (unsigned i = 0; i < ctx.RoConfig ()->params ().character_limit (); ++i)
     {
       characters.CreateNew ("domob", Faction::RED);
       characters.CreateNew ("andy", Faction::GREEN);

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -122,7 +122,8 @@ template <typename Fcn>
       VLOG (1)
           << "Incremented blocked turns counter to " << volMv.blocked_turns ();
 
-      if (volMv.blocked_turns () > ctx.Params ().BlockedStepRetries ())
+      if (volMv.blocked_turns ()
+            > ctx.RoConfig ()->params ().blocked_step_retries ())
         {
           VLOG (1)
               << "Too many blocked turns, stopping character " << c.GetId ();
@@ -218,8 +219,9 @@ template <typename Fcn>
     }
 
   PathFinder finder(wp);
-  const auto dist = finder.Compute (edges, pos,
-                                    ctx.Params ().MaximumWaypointL1Distance ());
+  const auto dist
+      = finder.Compute (edges, pos,
+                        ctx.RoConfig ()->params ().max_waypoint_l1_dist ());
   VLOG (1) << "Shortest path has length " << dist;
 
   if (dist == PathFinder::NO_CONNECTION)

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -128,7 +128,8 @@ BaseMoveProcessor::TryCharacterCreation (const std::string& name,
           return;
         }
 
-      if (characters.CountForOwner (name) >= ctx.Params ().CharacterLimit ())
+      if (characters.CountForOwner (name)
+            >= ctx.RoConfig ()->params ().character_limit ())
         {
           LOG (WARNING)
               << "Account " << name << " has the maximum number of characters"
@@ -1144,7 +1145,8 @@ MoveProcessor::MaybeTransferCharacter (Character& c, const Json::Value& upd)
     return;
   const std::string sendTo = sendToVal.asString ();
 
-  if (characters.CountForOwner (sendTo) >= ctx.Params ().CharacterLimit ())
+  if (characters.CountForOwner (sendTo)
+        >= ctx.RoConfig ()->params ().character_limit ())
     {
       LOG (WARNING)
           << "Account " << sendTo << " already has the maximum number of"

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1968,7 +1968,7 @@ MoveProcessor::HandleGodMode (const Json::Value& cmd)
   if (!cmd.isObject ())
     return;
 
-  if (!ctx.Params ().GodModeEnabled ())
+  if (!ctx.RoConfig ()->params ().god_mode ())
     {
       LOG (WARNING) << "God mode command ignored: " << cmd;
       return;

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -116,7 +116,8 @@ BaseMoveProcessor::TryCharacterCreation (const std::string& name,
         }
 
       VLOG (1) << "Trying to create character, amount paid left: " << paidToDev;
-      if (paidToDev < ctx.Params ().CharacterCost ())
+      const Amount cost = ctx.RoConfig ()->params ().character_cost () * COIN;
+      if (paidToDev < cost)
         {
           /* In this case, we can return rather than continue with the next
              iteration.  If all money paid is "used up" already, then it won't
@@ -136,7 +137,7 @@ BaseMoveProcessor::TryCharacterCreation (const std::string& name,
         }
 
       PerformCharacterCreation (name, faction);
-      paidToDev -= ctx.Params ().CharacterCost ();
+      paidToDev -= cost;
       VLOG (1) << "After character creation, paid to dev left: " << paidToDev;
     }
 }

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -75,9 +75,9 @@ BaseMoveProcessor::ExtractMoveBasics (const Json::Value& moveObj,
 
   paidToDev = 0;
   const auto& outVal = moveObj["out"];
-  if (outVal.isObject () && outVal.isMember (ctx.Params ().DeveloperAddress ()))
-    CHECK (AmountFromJson (outVal[ctx.Params ().DeveloperAddress ()],
-                           paidToDev));
+  const auto& devAddr = ctx.RoConfig ()->params ().dev_addr ();
+  if (outVal.isObject () && outVal.isMember (devAddr))
+    CHECK (AmountFromJson (outVal[devAddr], paidToDev));
 
   return true;
 }

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1244,7 +1244,8 @@ MoveProcessor::MaybeStartProspecting (Character& c, const Json::Value& upd)
 
   auto op = ongoings.CreateNew (ctx.Height ());
   c.MutableProto ().set_ongoing (op->GetId ());
-  op->SetHeight (ctx.Height () + ctx.Params ().ProspectingBlocks ());
+  op->SetHeight (
+      ctx.Height () + ctx.RoConfig ()->params ().prospecting_blocks ());
   op->SetCharacterId (c.GetId ());
   op->MutableProto ().mutable_prospection ();
 }

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -205,7 +205,7 @@ TEST_F (AccountUpdateTests, InitialisationAndCharacterCreation)
         "nc": [{}]
       }
     }
-  ])", ctx.Params ().CharacterCost ());
+  ])", ctx.RoConfig ()->params ().character_cost () * COIN);
 
   CharacterTable characters(db);
   auto c = characters.GetById (1);
@@ -388,7 +388,7 @@ TEST_F (CharacterCreationTests, InvalidCommands)
     {"name": "domob", "move": {}},
     {"name": "domob", "move": {"nc": 42}},
     {"name": "domob", "move": {"nc": [{"faction": "r"}]}}
-  ])", ctx.Params ().CharacterCost ());
+  ])", ctx.RoConfig ()->params ().character_cost () * COIN);
 
   auto res = tbl.QueryAll ();
   EXPECT_FALSE (res.Step ());
@@ -398,7 +398,7 @@ TEST_F (CharacterCreationTests, AccountNotInitialised)
 {
   ProcessWithDevPayment (R"([
     {"name": "domob", "move": {"nc": [{}]}}
-  ])", ctx.Params ().CharacterCost ());
+  ])", ctx.RoConfig ()->params ().character_cost () * COIN);
 
   auto res = tbl.QueryAll ();
   EXPECT_FALSE (res.Step ());
@@ -413,7 +413,7 @@ TEST_F (CharacterCreationTests, ValidCreation)
     {"name": "domob", "move": {"nc": []}},
     {"name": "domob", "move": {"nc": [{}]}},
     {"name": "andy", "move": {"nc": [{}]}}
-  ])", ctx.Params ().CharacterCost ());
+  ])", ctx.RoConfig ()->params ().character_cost () * COIN);
 
   auto res = tbl.QueryAll ();
 
@@ -440,10 +440,10 @@ TEST_F (CharacterCreationTests, DevPayment)
   ])");
   ProcessWithDevPayment (R"([
     {"name": "domob", "move": {"nc": [{}]}}
-  ])", ctx.Params ().CharacterCost () - 1);
+  ])", ctx.RoConfig ()->params ().character_cost () * COIN - 1);
   ProcessWithDevPayment (R"([
     {"name": "andy", "move": {"nc": [{}]}}
-  ])", ctx.Params ().CharacterCost () + 1);
+  ])", ctx.RoConfig ()->params ().character_cost () * COIN + 1);
 
   auto res = tbl.QueryAll ();
   ASSERT_TRUE (res.Step ());
@@ -465,7 +465,7 @@ TEST_F (CharacterCreationTests, Multiple)
           "nc": [{}, {}, {}]
         }
     }
-  ])", 2 * ctx.Params ().CharacterCost ());
+  ])", 2 * ctx.RoConfig ()->params ().character_cost () * COIN);
 
   auto res = tbl.QueryAll ();
 
@@ -496,7 +496,7 @@ TEST_F (CharacterCreationTests, CharacterLimit)
           "nc": [{}, {}]
         }
     }
-  ])", 2 * ctx.Params ().CharacterCost ());
+  ])", 2 * ctx.RoConfig ()->params ().character_cost () * COIN);
 
   EXPECT_EQ (tbl.CountForOwner ("domob"), ctx.Params ().CharacterLimit ());
 }
@@ -585,7 +585,7 @@ TEST_F (CharacterUpdateTests, CreationAndUpdate)
         "nc": [{}],
         "c": {"1": {"send": "daniel"}, "2": {"send": "andy"}}
       }
-  }])", ctx.Params ().CharacterCost ());
+  }])", ctx.RoConfig ()->params ().character_cost () * COIN);
 
   /* Transfer and creation should work fine together for two different
      characters (but in the same move).  The character created in the same
@@ -608,7 +608,7 @@ TEST_F (CharacterUpdateTests, AccountNotInitialised)
       {
         "c": {"10": {"send": "domob"}}
       }
-  }])", ctx.Params ().CharacterCost ());
+  }])", ctx.RoConfig ()->params ().character_cost () * COIN);
 
   ExpectCharacterOwners ({{10, "unknown account"}});
 }

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -84,7 +84,8 @@ protected:
   {
     Json::Value val = ParseJson (str);
     for (auto& entry : val)
-      entry["out"][ctx.Params ().DeveloperAddress ()] = AmountToJson (amount);
+      entry["out"][ctx.RoConfig ()->params ().dev_addr ()]
+          = AmountToJson (amount);
 
     DynObstacles dyn(db, ctx);
     MoveProcessor mvProc(db, dyn, rnd, ctx);
@@ -112,7 +113,7 @@ TEST_F (MoveProcessorTests, InvalidDataFromXaya)
 
   EXPECT_DEATH (Process (R"([{
     "name": "domob", "move": {},
-    "out": {")" + ctx.Params ().DeveloperAddress () + R"(": false}
+    "out": {")" + ctx.RoConfig ()->params ().dev_addr () + R"(": false}
   }])"), "JSON value for amount is not double");
 }
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -482,11 +482,13 @@ TEST_F (CharacterCreationTests, Multiple)
 
 TEST_F (CharacterCreationTests, CharacterLimit)
 {
+  const unsigned limit = ctx.RoConfig ()->params ().character_limit ();
+
   accounts.CreateNew ("domob", Faction::RED);
-  for (unsigned i = 0; i < ctx.Params ().CharacterLimit () - 1; ++i)
+  for (unsigned i = 0; i < limit - 1; ++i)
     tbl.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (i, 0));
 
-  EXPECT_EQ (tbl.CountForOwner ("domob"), ctx.Params ().CharacterLimit () - 1);
+  EXPECT_EQ (tbl.CountForOwner ("domob"), limit - 1);
 
   ProcessWithDevPayment (R"([
     {
@@ -498,7 +500,7 @@ TEST_F (CharacterCreationTests, CharacterLimit)
     }
   ])", 2 * ctx.RoConfig ()->params ().character_cost () * COIN);
 
-  EXPECT_EQ (tbl.CountForOwner ("domob"), ctx.Params ().CharacterLimit ());
+  EXPECT_EQ (tbl.CountForOwner ("domob"), limit);
 }
 
 /* ************************************************************************** */
@@ -686,7 +688,7 @@ TEST_F (CharacterUpdateTests, ValidTransfer)
 TEST_F (CharacterUpdateTests, InvalidTransfer)
 {
   accounts.CreateNew ("at limit", Faction::RED);
-  for (unsigned i = 0; i < ctx.Params ().CharacterLimit (); ++i)
+  for (unsigned i = 0; i < ctx.RoConfig ()->params ().character_limit (); ++i)
     tbl.CreateNew ("at limit", Faction::RED)->SetPosition (HexCoord (i, 0));
 
   accounts.CreateNew ("wrong faction", Faction::GREEN);

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -175,10 +175,4 @@ Params::RevEngSuccessChance (const unsigned existingBp) const
   return base;
 }
 
-bool
-Params::GodModeEnabled () const
-{
-  return chain == xaya::Chain::REGTEST;
-}
-
 } // namespace pxd

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -42,12 +42,6 @@ Params::DeveloperAddress () const
     }
 }
 
-unsigned
-Params::CharacterLimit () const
-{
-  return 20;
-}
-
 HexCoord::IntT
 Params::MaximumWaypointL1Distance () const
 {

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -43,18 +43,6 @@ Params::DeveloperAddress () const
 }
 
 unsigned
-Params::DamageListBlocks () const
-{
-  return 100;
-}
-
-unsigned
-Params::ProspectingBlocks () const
-{
-  return 10;
-}
-
-unsigned
 Params::ProspectionExpiryBlocks () const
 {
   switch (chain)

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -42,18 +42,6 @@ Params::DeveloperAddress () const
     }
 }
 
-HexCoord::IntT
-Params::MaximumWaypointL1Distance () const
-{
-  return 100;
-}
-
-unsigned
-Params::BlockedStepRetries () const
-{
-  return 10;
-}
-
 unsigned
 Params::DamageListBlocks () const
 {

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -136,19 +136,6 @@ Params::IsLowPrizeZone (const HexCoord& pos) const
 }
 
 unsigned
-Params::ArmourRepairHpPerBlock () const
-{
-  return 100;
-}
-
-Amount
-Params::ArmourRepairCostMillis () const
-{
-  /* The cost is 1 vCHI for 10 HP repair.  */
-  return 100;
-}
-
-unsigned
 Params::RevEngSuccessChance (const unsigned existingBp) const
 {
   constexpr uint64_t fpMultiple = 1'000'000;
@@ -186,30 +173,6 @@ Params::RevEngSuccessChance (const unsigned existingBp) const
   base /= fpMultiple;
 
   return base;
-}
-
-Amount
-Params::BlueprintCopyCost (const unsigned complexity) const
-{
-  return 100 * complexity;
-}
-
-unsigned
-Params::BlueprintCopyBlocks (const unsigned complexity) const
-{
-  return 10 * complexity;
-}
-
-Amount
-Params::ConstructionCost (const unsigned complexity) const
-{
-  return 100 * complexity;
-}
-
-unsigned
-Params::ConstructionBlocks (const unsigned complexity) const
-{
-  return 10 * complexity;
 }
 
 HexCoord

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -175,27 +175,6 @@ Params::RevEngSuccessChance (const unsigned existingBp) const
   return base;
 }
 
-HexCoord
-Params::SpawnArea (const Faction f, HexCoord::IntT& radius) const
-{
-  radius = 50;
-
-  switch (f)
-    {
-    case Faction::RED:
-      return HexCoord (1993, -2636);
-
-    case Faction::GREEN:
-      return HexCoord (-3430, 1793);
-
-    case Faction::BLUE:
-      return HexCoord (571, 2609);
-
-    default:
-      LOG (FATAL) << "Invalid faction: " << static_cast<int> (f);
-    }
-}
-
 bool
 Params::GodModeEnabled () const
 {

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -42,12 +42,6 @@ Params::DeveloperAddress () const
     }
 }
 
-Amount
-Params::CharacterCost () const
-{
-  return 1 * COIN;
-}
-
 unsigned
 Params::CharacterLimit () const
 {

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -42,21 +42,6 @@ Params::DeveloperAddress () const
     }
 }
 
-unsigned
-Params::ProspectionExpiryBlocks () const
-{
-  switch (chain)
-    {
-    case xaya::Chain::MAIN:
-    case xaya::Chain::TEST:
-      return 5'000;
-    case xaya::Chain::REGTEST:
-      return 100;
-    default:
-      LOG (FATAL) << "Invalid chain value: " << static_cast<int> (chain);
-    }
-}
-
 namespace
 {
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -23,25 +23,6 @@
 namespace pxd
 {
 
-std::string
-Params::DeveloperAddress () const
-{
-  /* The address returned here is the premine address controlled by the Xaya
-     team for the various chains.  See also Xaya Core's src/chainparams.cpp.  */
-
-  switch (chain)
-    {
-    case xaya::Chain::MAIN:
-      return "DHy2615XKevE23LVRVZVxGeqxadRGyiFW4";
-    case xaya::Chain::TEST:
-      return "dSFDAWxovUio63hgtfYd3nz3ir61sJRsXn";
-    case xaya::Chain::REGTEST:
-      return "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p";
-    default:
-      LOG (FATAL) << "Invalid chain value: " << static_cast<int> (chain);
-    }
-}
-
 namespace
 {
 

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -84,19 +84,6 @@ public:
   std::string DeveloperAddress () const;
 
   /**
-   * Returns the maximum L1 distance between waypoints for movement.
-   */
-  HexCoord::IntT MaximumWaypointL1Distance () const;
-
-  /**
-   * Number of retries of a blocked movement step before the movement
-   * is cancelled completely.  Note that this is really the numbef of *retries*,
-   * meaning that movement is only cancelled after N+1 blocked turns if N is
-   * the value returned from this function.
-   */
-  unsigned BlockedStepRetries () const;
-
-  /**
    * Returns the number of blocks for which a character stays on a damage list.
    */
   unsigned DamageListBlocks () const;

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -84,11 +84,6 @@ public:
   std::string DeveloperAddress () const;
 
   /**
-   * Returns the amount of CHI to be paid for creation of a character.
-   */
-  Amount CharacterCost () const;
-
-  /**
    * Returns the maximum number of characters allowed per account.
    */
   unsigned CharacterLimit () const;

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -101,11 +101,6 @@ public:
   unsigned RevEngSuccessChance (unsigned existingBp) const;
 
   /**
-   * Returns the spawn centre and radius for the given faction.
-   */
-  HexCoord SpawnArea (Faction f, HexCoord::IntT& radius) const;
-
-  /**
    * Returns true if god-mode commands are allowed (on regtest).
    */
   bool GodModeEnabled () const;

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -84,11 +84,6 @@ public:
   std::string DeveloperAddress () const;
 
   /**
-   * Returns the maximum number of characters allowed per account.
-   */
-  unsigned CharacterLimit () const;
-
-  /**
    * Returns the maximum L1 distance between waypoints for movement.
    */
   HexCoord::IntT MaximumWaypointL1Distance () const;

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -95,42 +95,10 @@ public:
   bool IsLowPrizeZone (const HexCoord& pos) const;
 
   /**
-   * Returns the maximum armour HP that can be repaired per block.
-   */
-  unsigned ArmourRepairHpPerBlock () const;
-
-  /**
-   * Returns the cost (in 1/1000 vCHI) for repairing one HP of armour.
-   */
-  Amount ArmourRepairCostMillis () const;
-
-  /**
    * Returns the chance for reverse-engineering success (as N in 1/N) based
    * on the already existing number of blueprints.
    */
   unsigned RevEngSuccessChance (unsigned existingBp) const;
-
-  /**
-   * Returns the cost for copying a blueprint of the given complexity.
-   */
-  Amount BlueprintCopyCost (unsigned complexity) const;
-
-  /**
-   * Returns the number of blocks for copying a blueprint of the given
-   * complexity.
-   */
-  unsigned BlueprintCopyBlocks (unsigned complexity) const;
-
-  /**
-   * Returns the cost in vCHI for constructing a given item complexity.
-   */
-  Amount ConstructionCost (unsigned complexity) const;
-
-  /**
-   * Returns the number of blocks for constructing an item of the
-   * given complexity.
-   */
-  unsigned ConstructionBlocks (unsigned complexity) const;
 
   /**
    * Returns the spawn centre and radius for the given faction.

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -33,9 +33,10 @@ namespace pxd
 {
 
 /**
- * The basic parameters that determine the game rules.  Once constructed, an
- * instance of this class is immutable and can be used to retrieve the
- * parameters for a particular situation (e.g. chain).
+ * Some "parameters" for the game rules.  Instances of this class
+ * extend the very basic parameters in roconfig with more complex
+ * things, like "parameters" that are simple functions (but still
+ * just arbitrarily-chosen game configuration).
  */
 class Params
 {

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -100,11 +100,6 @@ public:
    */
   unsigned RevEngSuccessChance (unsigned existingBp) const;
 
-  /**
-   * Returns true if god-mode commands are allowed (on regtest).
-   */
-  bool GodModeEnabled () const;
-
 };
 
 } // namespace pxd

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -79,11 +79,6 @@ public:
   void operator= (const Params&) = delete;
 
   /**
-   * Returns the address to which CHI for the developers should be paid.
-   */
-  std::string DeveloperAddress () const;
-
-  /**
    * Returns the ordered list of available prizes for prospecting in the
    * demo competition.
    */

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -84,12 +84,6 @@ public:
   std::string DeveloperAddress () const;
 
   /**
-   * Returns the number of blocks after which a region can be reprospected
-   * (if there are no other factors preventing it).
-   */
-  unsigned ProspectionExpiryBlocks () const;
-
-  /**
    * Returns the ordered list of available prizes for prospecting in the
    * demo competition.
    */

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -84,16 +84,6 @@ public:
   std::string DeveloperAddress () const;
 
   /**
-   * Returns the number of blocks for which a character stays on a damage list.
-   */
-  unsigned DamageListBlocks () const;
-
-  /**
-   * Returns the duration of prospecting in blocks.
-   */
-  unsigned ProspectingBlocks () const;
-
-  /**
    * Returns the number of blocks after which a region can be reprospected
    * (if there are no other factors preventing it).
    */

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -678,7 +678,7 @@ protected:
     moveObj["move"] = ParseJson (mvStr);
 
     if (paidToDev != 0)
-      moveObj["out"][ctx.Params ().DeveloperAddress ()]
+      moveObj["out"][ctx.RoConfig ()->params ().dev_addr ()]
           = AmountToJson (paidToDev);
 
     DynObstacles dyn(db, ctx);

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -716,7 +716,7 @@ TEST_F (PendingStateUpdaterTests, InvalidCreation)
   accounts.CreateNew ("domob", Faction::RED);
 
   accounts.CreateNew ("at limit", Faction::BLUE);
-  for (unsigned i = 0; i < ctx.Params ().CharacterLimit (); ++i)
+  for (unsigned i = 0; i < ctx.RoConfig ()->params ().character_limit (); ++i)
     characters.CreateNew ("at limit", Faction::BLUE)
         ->SetPosition (HexCoord (i, 1));
 

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -657,6 +657,13 @@ protected:
 
   ContextForTesting ctx;
 
+  /** Cost of one character.  */
+  const Amount characterCost;
+
+  PendingStateUpdaterTests ()
+    : characterCost(ctx.RoConfig ()->params ().character_cost () * COIN)
+  {}
+
   /**
    * Processes a move for the given name and with the given move data, parsed
    * from JSON string.  If paidToDev is non-zero, then add an "out" entry
@@ -693,7 +700,7 @@ protected:
 
 TEST_F (PendingStateUpdaterTests, AccountNotInitialised)
 {
-  ProcessWithDevPayment ("domob", ctx.Params ().CharacterCost (), R"({
+  ProcessWithDevPayment ("domob", characterCost, R"({
     "nc": [{}]
   })");
 
@@ -713,7 +720,7 @@ TEST_F (PendingStateUpdaterTests, InvalidCreation)
     characters.CreateNew ("at limit", Faction::BLUE)
         ->SetPosition (HexCoord (i, 1));
 
-  ProcessWithDevPayment ("domob", ctx.Params ().CharacterCost (), R"(
+  ProcessWithDevPayment ("domob", characterCost, R"(
     {
       "nc": [{"faction": "r"}]
     }
@@ -723,7 +730,7 @@ TEST_F (PendingStateUpdaterTests, InvalidCreation)
       "nc": [{}]
     }
   )");
-  ProcessWithDevPayment ("at limit", ctx.Params ().CharacterCost (), R"(
+  ProcessWithDevPayment ("at limit", characterCost, R"(
     {
       "nc": [{}]
     }
@@ -741,10 +748,10 @@ TEST_F (PendingStateUpdaterTests, ValidCreations)
   accounts.CreateNew ("domob", Faction::RED);
   accounts.CreateNew ("andy", Faction::GREEN);
 
-  ProcessWithDevPayment ("domob", 2 * ctx.Params ().CharacterCost (), R"({
+  ProcessWithDevPayment ("domob", 2 * characterCost, R"({
     "nc": [{}, {}, {}]
   })");
-  ProcessWithDevPayment ("andy", ctx.Params ().CharacterCost (), R"({
+  ProcessWithDevPayment ("andy", characterCost, R"({
     "nc": [{}]
   })");
 
@@ -1258,7 +1265,7 @@ TEST_F (PendingStateUpdaterTests, CreationAndUpdateTogether)
 
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
 
-  ProcessWithDevPayment ("domob", ctx.Params ().CharacterCost (), R"({
+  ProcessWithDevPayment ("domob", characterCost, R"({
     "nc": [{}],
     "c": {"1": {"wp": []}}
   })");

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -44,8 +44,9 @@ CanProspectRegion (const Character& c, const Region& r, const Context& ctx)
   if (!rpb.has_prospection ())
     return true;
 
-  if (ctx.Height () < rpb.prospection ().height ()
-                        + ctx.Params ().ProspectionExpiryBlocks ())
+  const unsigned expiry
+      = ctx.RoConfig ()->params ().prospection_expiry_blocks ();
+  if (ctx.Height () < rpb.prospection ().height () + expiry)
     {
       LOG (WARNING)
           << "Height " << ctx.Height ()

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -19,6 +19,7 @@
 #include "spawn.hpp"
 
 #include "fitments.hpp"
+#include "protoutils.hpp"
 
 #include "hexagonal/coord.hpp"
 #include "hexagonal/ring.hpp"
@@ -114,10 +115,11 @@ SpawnCharacter (const std::string& owner, const Faction f,
       << "Spawning new character for " << owner
       << " in faction " << FactionToString (f) << "...";
 
-  HexCoord::IntT radius;
-  const HexCoord spawnCentre = ctx.Params ().SpawnArea (f, radius);
-  const HexCoord pos = ChooseSpawnLocation (spawnCentre, radius, f,
-                                            rnd, dyn, ctx.Map ());
+  const auto& spawn
+      = ctx.RoConfig ()->params ().spawn_areas ().at (FactionToString (f));
+  const HexCoord pos
+      = ChooseSpawnLocation (CoordFromProto (spawn.centre ()), spawn.radius (),
+                             f, rnd, dyn, ctx.Map ());
 
   auto c = tbl.CreateNew (owner, f);
   c->SetPosition (pos);


### PR DESCRIPTION
This migrates all of the "basic" parameters (which are just simple values) from `Params` to the roconfig proto.  This will make it easier to maintain them in the future, and will also allow e.g. the frontend to read them directly from the protocol buffer data.  This is the bulk of the remaining stuff for #108.

The only things that remain in `Params` after this are prospecting prizes (which will be handled in a separate PR) and more complex things that are actually "functions" defining some game configuration rather than just "constants".