### PR TITLE
Self-destruct ability

### DIFF
--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -110,6 +110,21 @@ message Attack
 }
 
 /**
+ * Stats for the self-destruct ability of an entity (when the entity is
+ * destroyed, AoE damage is dealt to enemies in range).
+ */
+message SelfDestruct
+{
+
+  /** The AoE range of the attack.  */
+  optional uint32 area = 1;
+
+  /** The damage done.  */
+  optional Attack.Damage damage = 2;
+
+}
+
+/**
  * Stats for a boost to combat stats that is in effect when a character
  * has low armour HP (i.e. "final breath" attack).
  */
@@ -181,5 +196,8 @@ message CombatData
 
   /** Any low-HP boosts for the fighter.  */
   repeated LowHpBoost low_hp_boosts = 2;
+
+  /** Any self-destruct attacks this fighter has.  */
+  repeated SelfDestruct self_destructs = 3;
 
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -164,6 +164,9 @@ message FitmentData
   /** Low-HP-boost this fitment provides (if any).  */
   optional LowHpBoost low_hp_boost = 11;
 
+  /** Self-destruct ability of this fitment (if any).  */
+  optional SelfDestruct self_destruct = 12;
+
 }
 
 /**

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -82,6 +82,26 @@ fungible_items:
 
 fungible_items:
   {
+    key: "selfdestruct"
+    value:
+      {
+        space: 1
+        complexity: 4
+        with_blueprint: true
+        fitment:
+          {
+            slot: "high"
+            self_destruct:
+              {
+                area: 10
+                damage: { min: 10 max: 30 }
+              }
+          }
+      }
+  }
+
+fungible_items:
+  {
     key: "expander"
     value:
       {

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -213,21 +213,27 @@ private:
    */
   std::map<TargetKey, CombatModifier> modifiers;
 
-  /** The list of kills being built up.  */
-  std::set<TargetKey> dead;
+  /**
+   * The list of dead targets.  We use this to avoid giving out fame for
+   * kills of already-dead targets in later rounds of self-destruct.  The list
+   * being built up during a round of damage is a temporary, that gets put
+   * here only after the round.
+   */
+  std::set<TargetKey> alreadyDead;
 
   /**
    * Performs a random roll to determine the damage a particular attack does.
    * The min/max damage is modified according to the stats modifier.
    */
-  unsigned RollAttackDamage (const proto::Attack& attack,
+  unsigned RollAttackDamage (const proto::Attack::Damage& attack,
                              const StatModifier& mod);
 
   /**
-   * Applies a fixed given amount of damage to a given attack target.
+   * Applies a fixed given amount of damage to a given attack target.  Adds
+   * the target into newDead if it is now dead.
    */
   void ApplyDamage (unsigned dmg, const CombatEntity& attacker,
-                    CombatEntity& target);
+                    CombatEntity& target, std::set<TargetKey>& newDead);
 
   /**
    * Applies combat effects (non-damage) to a target.
@@ -238,7 +244,14 @@ private:
    * Deals damage for one fighter with a target to the respective target
    * (or any AoE targets).
    */
-  void DealDamage (FighterTable::Handle f);
+  void DealDamage (FighterTable::Handle f, std::set<TargetKey>& newDead);
+
+  /**
+   * Processes all damage the given fighter does due to self-destruct
+   * abilities when killed.
+   */
+  void ProcessSelfDestructs (FighterTable::Handle f,
+                             std::set<TargetKey>& newDead);
 
 public:
 
@@ -260,17 +273,15 @@ public:
   const std::set<TargetKey>&
   GetDead () const
   {
-    return dead;
+    return alreadyDead;
   }
 
 };
 
 unsigned
-DamageProcessor::RollAttackDamage (const proto::Attack& attack,
+DamageProcessor::RollAttackDamage (const proto::Attack::Damage& dmg,
                                    const StatModifier& mod)
 {
-  CHECK (attack.has_damage ());
-  const auto& dmg = attack.damage ();
   const auto minDmg = mod (dmg.min ());
   const auto maxDmg = mod (dmg.max ());
 
@@ -281,12 +292,20 @@ DamageProcessor::RollAttackDamage (const proto::Attack& attack,
 
 void
 DamageProcessor::ApplyDamage (unsigned dmg, const CombatEntity& attacker,
-                              CombatEntity& target)
+                              CombatEntity& target,
+                              std::set<TargetKey>& newDead)
 {
   const auto targetId = target.GetIdAsTarget ();
   if (dmg == 0)
     {
       VLOG (1) << "No damage done to target:\n" << targetId.DebugString ();
+      return;
+    }
+  const TargetKey targetKey(targetId);
+  if (alreadyDead.count (targetKey) > 0)
+    {
+      VLOG (1)
+          << "Target is already dead from before:\n" << targetId.DebugString ();
       return;
     }
   VLOG (1)
@@ -314,8 +333,8 @@ DamageProcessor::ApplyDamage (unsigned dmg, const CombatEntity& attacker,
       /* Regenerated partial HP are ignored (i.e. you die even with 999/1000
          partial HP).  Just make sure that the partial HP are not full yet
          due to some bug.  */
-      CHECK_LT (hp.shield_mhp (), 1000);
-      CHECK (dead.insert (targetId).second)
+      CHECK_LT (hp.shield_mhp (), 1'000);
+      CHECK (newDead.insert (targetKey).second)
           << "Target is already dead:\n" << targetId.DebugString ();
     }
 }
@@ -338,7 +357,8 @@ DamageProcessor::ApplyEffects (const proto::Attack& attack,
 }
 
 void
-DamageProcessor::DealDamage (FighterTable::Handle f)
+DamageProcessor::DealDamage (FighterTable::Handle f,
+                             std::set<TargetKey>& newDead)
 {
   const auto& cd = f->GetCombatData ();
   const auto& pos = f->GetCombatPosition ();
@@ -361,7 +381,7 @@ DamageProcessor::DealDamage (FighterTable::Handle f)
 
       unsigned dmg = 0;
       if (attack.has_damage ())
-        dmg = RollAttackDamage (attack, mod.damage);
+        dmg = RollAttackDamage (attack.damage (), mod.damage);
 
       if (attack.has_area ())
         {
@@ -376,16 +396,45 @@ DamageProcessor::DealDamage (FighterTable::Handle f)
             [&] (const HexCoord& c, const proto::TargetId& id)
             {
               auto t = fighters.GetForTarget (id);
-              ApplyDamage (dmg, *f, *t);
+              ApplyDamage (dmg, *f, *t, newDead);
               ApplyEffects (attack, *t);
             });
         }
       else
         {
           auto t = fighters.GetForTarget (f->GetTarget ());
-          ApplyDamage (dmg, *f, *t);
+          ApplyDamage (dmg, *f, *t, newDead);
           ApplyEffects (attack, *t);
         }
+    }
+}
+
+void
+DamageProcessor::ProcessSelfDestructs (FighterTable::Handle f,
+                                       std::set<TargetKey>& newDead)
+{
+  /* The killed fighter should have zero HP left, and thus also should get
+     all low-HP boosts now.  */
+  CHECK_EQ (f->GetHP ().armour (), 0);
+  CHECK_EQ (f->GetHP ().shield (), 0);
+  CombatModifier mod;
+  ComputeLowHpBoosts (*f, mod);
+
+  const auto& pos = f->GetCombatPosition ();
+  for (const auto& sd : f->GetCombatData ().self_destructs ())
+    {
+      const auto dmg = RollAttackDamage (sd.damage (), mod.damage);
+      VLOG (1)
+          << "Dealing " << dmg
+          << " of damage for self-destruct of "
+          << f->GetIdAsTarget ().DebugString ();
+
+      targets.ProcessL1Targets (pos, mod.range (sd.area ()), f->GetFaction (),
+        [&] (const HexCoord& c, const proto::TargetId& id)
+        {
+          auto t = fighters.GetForTarget (id);
+          ApplyDamage (dmg, *f, *t, newDead);
+        });
     }
 }
 
@@ -400,10 +449,33 @@ DamageProcessor::Process ()
       CHECK (modifiers.emplace (f->GetIdAsTarget (), std::move (mod)).second);
     });
 
+  std::set<TargetKey> newDead;
   fighters.ProcessWithTarget ([&] (FighterTable::Handle f)
     {
-      DealDamage (std::move (f));
+      DealDamage (std::move (f), newDead);
     });
+
+  /* After applying the base damage, we process all self-destruct actions
+     of kills.  This may lead to more damage and more kills, so we have
+     to process as many "rounds" of self-destructs as necessary before
+     no new kills are added.  */
+  while (!newDead.empty ())
+    {
+      /* The way we merge in the new elements here is not optimal, as one
+         could use a proper merge of sorted ranges instead.  But it is quite
+         straight-forward and easy to read, and most likely not performance
+         critical anyway.  */
+      for (const auto& n : newDead)
+        CHECK (alreadyDead.insert (n).second)
+            << "Target was already dead before:\n"
+            << n.ToProto ().DebugString ();
+
+      const auto toProcess = std::move (newDead);
+      CHECK (newDead.empty ());
+
+      for (const auto& d : toProcess)
+        ProcessSelfDestructs (fighters.GetForTarget (d.ToProto ()), newDead);
+    }
 }
 
 } // anonymous namespace

--- a/src/combat.hpp
+++ b/src/combat.hpp
@@ -30,10 +30,35 @@
 
 #include <xayautil/random.hpp>
 
-#include <vector>
+#include <set>
+#include <utility>
 
 namespace pxd
 {
+
+/**
+ * Representation of a Target that can be used as key in a map or as
+ * entry in a set.
+ */
+class TargetKey : public std::pair<proto::TargetId::Type, Database::IdT>
+{
+
+public:
+
+  TargetKey (const proto::TargetId::Type type, const Database::IdT id)
+  {
+    first = type;
+    second = id;
+  }
+
+  TargetKey (const proto::TargetId& id);
+
+  /**
+   * Converts the target back to proto format.
+   */
+  proto::TargetId ToProto () const;
+
+};
 
 /**
  * Finds combat targets for each fighter entity.
@@ -45,15 +70,15 @@ void FindCombatTargets (Database& db, xaya::Random& rnd);
  * that are now dead (and need to be handled accordingly).  This also
  * applies non-damage effects like slowing.
  */
-std::vector<proto::TargetId> DealCombatDamage (Database& db, DamageLists& dl,
-                                               xaya::Random& rnd);
+std::set<TargetKey> DealCombatDamage (Database& db, DamageLists& dl,
+                                      xaya::Random& rnd);
 
 /**
  * Processes killed fighers from the given list, actually performing the
  * necessary database changes for having them dead.
  */
 void ProcessKills (Database& db, DamageLists& dl, GroundLootTable& loot,
-                   const std::vector<proto::TargetId>& dead,
+                   const std::set<TargetKey>& dead,
                    xaya::Random& rnd, const Context& ctx);
 
 /**

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -33,6 +33,7 @@
 #include <xayautil/hash.hpp>
 #include <xayautil/random.hpp>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <glog/logging.h>
@@ -44,6 +45,8 @@ namespace pxd
 {
 namespace
 {
+
+using testing::ElementsAre;
 
 /* ************************************************************************** */
 
@@ -444,7 +447,7 @@ protected:
   /**
    * Finds combat targets and deals damage.
    */
-  std::vector<proto::TargetId>
+  std::set<TargetKey>
   FindTargetsAndDamage ()
   {
     FindCombatTargets (db, rnd);
@@ -730,15 +733,13 @@ TEST_F (DealDamageTests, Kills)
   SetHp (*c, 1, 1, 1, 1);
   c.reset ();
 
-  auto dead = FindTargetsAndDamage ();
-  ASSERT_EQ (dead.size (), 1);
-  EXPECT_EQ (dead[0].type (), proto::TargetId::TYPE_CHARACTER);
-  EXPECT_EQ (dead[0].id (), id1);
+  EXPECT_THAT (FindTargetsAndDamage (), ElementsAre (
+    TargetKey (proto::TargetId::TYPE_CHARACTER, id1)
+  ));
 
-  dead = FindTargetsAndDamage ();
-  ASSERT_EQ (dead.size (), 1);
-  EXPECT_EQ (dead[0].type (), proto::TargetId::TYPE_CHARACTER);
-  EXPECT_EQ (dead[0].id (), id2);
+  EXPECT_THAT (FindTargetsAndDamage (), ElementsAre (
+    TargetKey (proto::TargetId::TYPE_CHARACTER, id2)
+  ));
 }
 
 TEST_F (DealDamageTests, Effects)

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -124,6 +124,7 @@ ApplyFitments (Character& c, const Context& ctx)
   StatModifier range, damage;
 
   auto& pb = c.MutableProto ();
+  auto* cd = pb.mutable_combat_data ();
   for (const auto& f : pb.fitments ())
     {
       const auto fItemData = ctx.RoConfig ().Item (f);
@@ -132,10 +133,11 @@ ApplyFitments (Character& c, const Context& ctx)
       const auto& fitment = fItemData.fitment ();
 
       if (fitment.has_attack ())
-        *pb.mutable_combat_data ()->add_attacks () = fitment.attack ();
+        *cd->add_attacks () = fitment.attack ();
       if (fitment.has_low_hp_boost ())
-        *pb.mutable_combat_data ()->add_low_hp_boosts ()
-            = fitment.low_hp_boost ();
+        *cd->add_low_hp_boosts () = fitment.low_hp_boost ();
+      if (fitment.has_self_destruct ())
+        *cd->add_self_destructs () = fitment.self_destruct ();
 
       cargo += fitment.cargo_space ();
       speed += fitment.speed ();
@@ -155,7 +157,7 @@ ApplyFitments (Character& c, const Context& ctx)
   regen.set_shield_regeneration_mhp (
       shieldRegen (regen.shield_regeneration_mhp ()));
 
-  for (auto& a : *pb.mutable_combat_data ()->mutable_attacks ())
+  for (auto& a : *cd->mutable_attacks ())
     {
       /* Both the targeting range and size of AoE area (if applicable)
          are modified in the same way through the "range" modifier.  */
@@ -170,6 +172,15 @@ ApplyFitments (Character& c, const Context& ctx)
           dmg.set_min (damage (dmg.min ()));
           dmg.set_max (damage (dmg.max ()));
         }
+    }
+
+  for (auto& sd : *cd->mutable_self_destructs ())
+    {
+      sd.set_area (range (sd.area ()));
+
+      auto& dmg = *sd.mutable_damage ();
+      dmg.set_min (damage (dmg.min ()));
+      dmg.set_max (damage (dmg.max ()));
     }
 }
 

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -149,6 +149,25 @@ TEST_F (DeriveCharacterStatsTests, FitmentLowHpBoosts)
     }
 }
 
+TEST_F (DeriveCharacterStatsTests, FitmentSelfDestructs)
+{
+  auto c = Derive ("chariot",
+    {
+      "selfdestruct",
+      "selfdestruct",
+      "rangeext",
+      "dmgext",
+    });
+  const auto& sd = c->GetProto ().combat_data ().self_destructs ();
+  ASSERT_EQ (sd.size (), 2);
+  for (const auto& s : sd)
+    {
+      EXPECT_EQ (s.area (), 11);
+      EXPECT_EQ (s.damage ().min (), 11);
+      EXPECT_EQ (s.damage ().max (), 33);
+    }
+}
+
 TEST_F (DeriveCharacterStatsTests, CargoSpeed)
 {
   auto c = Derive ("chariot", {"turbo"});


### PR DESCRIPTION
This adds a new fitment, `selfdestruct`, which implements a self-destruct ability.  When this is active on some character, then they do a certain amount of AoE damage when killed.  This may then in turn trigger more self-destructs by others, until no new kills are recorded.

Since self-destructing characters are on zero HP, all low-HP boosts (if any) will apply to the self-destruct AoE range and damage.

If A kills B, B self-destructs to kill C, and C's self-destruct would in theory hit back at B (e.g. same range), then A gets fame for B, B gets fame for C (and maybe A) but C does not game fame for B as B is already gone when C self-destructs "in a later processing round".