### PR TITLE
Fitments for mining and prospecting

### DIFF
--- a/proto/character.proto
+++ b/proto/character.proto
@@ -86,11 +86,17 @@ message Character
   /** The character's mining data, if it can mine.  */
   optional MiningData mining = 6;
 
+  /**
+   * The character's prospecting rate, if it can prospect.  This is
+   * the number of blocks it takes them to finish prospection.
+   */
+  optional uint32 prospecting_blocks = 7;
+
   /** Movement speed of the character.  */
-  optional uint32 speed = 7;
+  optional uint32 speed = 8;
 
   /** Total cargo space the character has.  */
-  optional uint64 cargo_space = 8;
+  optional uint64 cargo_space = 9;
 
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -115,13 +115,16 @@ message VehicleData
   /** Base mining speed for the vehicle.  */
   optional MiningData.Speed mining_rate = 5;
 
+  /** Base prospecting rate (if prospecting is possible).  */
+  optional uint32 prospecting_blocks = 6;
+
   /**
    * Number of equipment slots of each type.  The slot types are just strings
    * which have to be matched between here and the fitment configs.  The valid
    * values are "high", "mid" and "low".  Unfortunately we cannot use enum
    * values as they can't be keys in protocol buffer maps.
    */
-  map<string, uint32> equipment_slots = 6;
+  map<string, uint32> equipment_slots = 7;
 
 }
 
@@ -412,41 +415,38 @@ message Params
   /** The number of blocks for which a character stays on a damage list.  */
   optional uint32 damage_list_blocks = 5;
 
-  /** The duration of prospecting in blocks.  */
-  optional uint32 prospecting_blocks = 6;
-
   /**
    * The number of blocks after which a region can be reprospected (if there
    * are no other factors preventing it).
    */
-  optional uint32 prospection_expiry_blocks = 7;
+  optional uint32 prospection_expiry_blocks = 6;
 
   /** The number of HP that can be repaired per block.  */
-  optional uint32 armour_repair_hp_per_block = 8;
+  optional uint32 armour_repair_hp_per_block = 7;
 
   /** Cost (in 1/1000 vCHI) for repairing one HP of armour.  */
-  optional uint32 armour_repair_cost_millis = 9;
+  optional uint32 armour_repair_cost_millis = 8;
 
   /** Cost (in vCHI) for copying a blueprint, per complexity.  */
-  optional int64 bp_copy_cost = 10;
+  optional int64 bp_copy_cost = 9;
 
   /** Number of blocks for copying a blueprint, per complexity.  */
-  optional uint32 bp_copy_blocks = 11;
+  optional uint32 bp_copy_blocks = 10;
 
   /** Cost (in vCHI) for constructing an item, per complexity.  */
-  optional int64 construction_cost = 12;
+  optional int64 construction_cost = 11;
 
   /** Nubmer of blocks for constructing an item, per complexity.  */
-  optional uint32 construction_blocks = 13;
+  optional uint32 construction_blocks = 12;
 
   /** The address to which developer payments should be sent.  */
-  optional string dev_addr = 14;
+  optional string dev_addr = 13;
 
   /** Whether or not god mode is enabled.  */
-  optional bool god_mode = 15;
+  optional bool god_mode = 14;
 
   /** Spawn areas for the factions (with the "r", "g", "b" string as key).  */
-  map<string, SpawnArea> spawn_areas = 16;
+  map<string, SpawnArea> spawn_areas = 15;
 
   /**
    * Prospecting prizes.  They are just a list and not a map, because the

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -164,11 +164,20 @@ message FitmentData
   /** Modification to the vehicle's allowed fitment complexity.  */
   optional StatModifier complexity = 10;
 
+  /**
+   * Modification to the vehicle's prospecting blocks.  Since a larger number
+   * of blocks is worse, a fitment will likely have a negative modifier here.
+   */
+  optional StatModifier prospecting_blocks = 11;
+
+  /** MOdification to the vehicle's mining rate (min and max).  */
+  optional StatModifier mining_rate = 12;
+
   /** Low-HP-boost this fitment provides (if any).  */
-  optional LowHpBoost low_hp_boost = 11;
+  optional LowHpBoost low_hp_boost = 13;
 
   /** Self-destruct ability of this fitment (if any).  */
-  optional SelfDestruct self_destruct = 12;
+  optional SelfDestruct self_destruct = 14;
 
 }
 

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -82,6 +82,38 @@ fungible_items:
 
 fungible_items:
   {
+    key: "scanner"
+    value:
+      {
+        space: 5
+        complexity: 4
+        with_blueprint: true
+        fitment:
+          {
+            slot: "high"
+            prospecting_blocks: { percent: -20 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "pick"
+    value:
+      {
+        space: 5
+        complexity: 4
+        with_blueprint: true
+        fitment:
+          {
+            slot: "high"
+            mining_rate: { percent: 20 }
+          }
+      }
+  }
+
+fungible_items:
+  {
     key: "selfdestruct"
     value:
       {

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -1,3 +1,6 @@
+################################################################################
+# Resources and ores
+
 fungible_items:
   {
     key: "foo"
@@ -31,6 +34,9 @@ fungible_items:
           }
       }
   }
+
+################################################################################
+# Fitments and artefacts
 
 # These ones are dummy "weapons" that can be equipped and constructed
 # from dummy blueprints for testing purposes.
@@ -75,6 +81,9 @@ fungible_items:
       }
   }
 
+################################################################################
+# Vehicles
+
 # A test vehicle with some well-defined stats that can be used
 # also e.g. in tests for fitments.
 fungible_items:
@@ -108,6 +117,7 @@ fungible_items:
                   }
               }
             mining_rate: { min: 10 max: 100 }
+            prospecting_blocks: 10
             equipment_slots: { key: "high" value: 3 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 1 }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -45,8 +45,8 @@ fungible_items:
     key: "bow"
     value:
       {
-        space: 1,
-        complexity: 100,
+        space: 1
+        complexity: 100
         with_blueprint: true
         construction_resources: { key: "foo" value: 2 }
         construction_resources: { key: "bar" value: 1 }
@@ -58,11 +58,29 @@ fungible_items:
     key: "sword"
     value:
       {
-        space: 1,
-        complexity: 1,
+        space: 1
+        complexity: 1
         with_blueprint: true
         construction_resources: { key: "zerospace" value: 10 }
         fitment: { slot: "high" }
+      }
+  }
+
+# Strong reduction of prospecting time (more than any real item)
+# so that we can test the lower cap at one block.
+fungible_items:
+  {
+    key: "super scanner",
+    value:
+      {
+        space: 1
+        complexity: 1
+        with_blueprint: true
+        fitment:
+          {
+            slot: "high"
+            prospecting_blocks: { percent: -99 }
+          }
       }
   }
 
@@ -71,7 +89,7 @@ fungible_items:
     key: "test artefact"
     value:
       {
-        space: 0,
+        space: 0
         reveng:
           {
             cost: 10

--- a/proto/roconfig/items/vehicles.pb.text
+++ b/proto/roconfig/items/vehicles.pb.text
@@ -26,6 +26,7 @@ fungible_items:
                   }
               }
             mining_rate: { min: 0 max: 5 }
+            prospecting_blocks: 10
           }
       }
   }
@@ -55,6 +56,7 @@ fungible_items:
                   }
               }
             mining_rate: { min: 0 max: 5 }
+            prospecting_blocks: 10
           }
       }
   }
@@ -84,6 +86,7 @@ fungible_items:
                   }
               }
             mining_rate: { min: 0 max: 5 }
+            prospecting_blocks: 10
           }
       }
   }

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -7,7 +7,6 @@ params:
     blocked_step_retries: 10
 
     damage_list_blocks: 100
-    prospecting_blocks: 10
     prospection_expiry_blocks: 5000
 
     armour_repair_hp_per_block: 100

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -102,11 +102,24 @@ void
 InitCharacterStats (Character& c, const proto::VehicleData& data)
 {
   auto& pb = c.MutableProto ();
+
   pb.set_cargo_space (data.cargo_space ());
   pb.set_speed (data.speed ());
   *pb.mutable_combat_data () = data.combat_data ();
   c.MutableRegenData () = data.regen_data ();
-  *pb.mutable_mining ()->mutable_rate () = data.mining_rate ();
+
+  if (data.has_mining_rate ())
+    *pb.mutable_mining ()->mutable_rate () = data.mining_rate ();
+  else
+    pb.clear_mining ();
+
+  if (data.has_prospecting_blocks ())
+    {
+      pb.set_prospecting_blocks (data.prospecting_blocks ());
+      CHECK_GT (pb.prospecting_blocks (), 0);
+    }
+  else
+    pb.clear_prospecting_blocks ();
 }
 
 /**

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -132,6 +132,7 @@ ApplyFitments (Character& c, const Context& ctx)
   /* Boosts from stat modifiers are not compounding.  Thus we total up
      each modifier first and only apply them at the end.  */
   StatModifier cargo, speed;
+  StatModifier prospecting, mining;
   StatModifier maxArmour, maxShield;
   StatModifier shieldRegen;
   StatModifier range, damage;
@@ -154,6 +155,8 @@ ApplyFitments (Character& c, const Context& ctx)
 
       cargo += fitment.cargo_space ();
       speed += fitment.speed ();
+      prospecting += fitment.prospecting_blocks ();
+      mining += fitment.mining_rate ();
       maxArmour += fitment.max_armour ();
       maxShield += fitment.max_shield ();
       shieldRegen += fitment.shield_regen ();
@@ -163,6 +166,23 @@ ApplyFitments (Character& c, const Context& ctx)
 
   pb.set_cargo_space (cargo (pb.cargo_space ()));
   pb.set_speed (speed (pb.speed ()));
+
+  if (pb.has_prospecting_blocks ())
+    {
+      int blocks = pb.prospecting_blocks ();
+      CHECK_GT (blocks, 0);
+      blocks = prospecting (blocks);
+      blocks = std::max (1, blocks);
+      CHECK_GT (blocks, 0);
+      pb.set_prospecting_blocks (blocks);
+    }
+
+  if (pb.has_mining ())
+    {
+      auto* rate = pb.mutable_mining ()->mutable_rate ();
+      rate->set_min (mining (rate->min ()));
+      rate->set_max (mining (rate->max ()));
+    }
 
   auto& regen = c.MutableRegenData ();
   regen.mutable_max_hp ()->set_armour (maxArmour (regen.max_hp ().armour ()));

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -116,6 +116,12 @@ TEST_F (DeriveCharacterStatsTests, BaseVehicleStats)
   EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 10);
 }
 
+TEST_F (DeriveCharacterStatsTests, ProspectingRate)
+{
+  EXPECT_EQ (Derive ("chariot", {})->GetProto ().prospecting_blocks (), 10);
+  EXPECT_FALSE (Derive ("basetank", {})->GetProto ().has_prospecting_blocks ());
+}
+
 TEST_F (DeriveCharacterStatsTests, HpAreReset)
 {
   auto c = Derive ("chariot", {});

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -183,6 +183,21 @@ TEST_F (DeriveCharacterStatsTests, CargoSpeed)
   EXPECT_EQ (c->GetProto ().cargo_space (), 1'100);
 }
 
+TEST_F (DeriveCharacterStatsTests, ProspectingMining)
+{
+  auto c = Derive ("chariot", {"scanner", "pick"});
+  EXPECT_EQ (c->GetProto ().prospecting_blocks (), 8);
+  EXPECT_EQ (c->GetProto ().mining ().rate ().min (), 12);
+  EXPECT_EQ (c->GetProto ().mining ().rate ().max (), 120);
+
+  c = Derive ("chariot", {"super scanner", "super scanner"});
+  EXPECT_EQ (c->GetProto ().prospecting_blocks (), 1);
+
+  c = Derive ("basetank", {"scanner", "pick"});
+  EXPECT_FALSE (c->GetProto ().has_prospecting_blocks ());
+  EXPECT_FALSE (c->GetProto ().has_mining ());
+}
+
 TEST_F (DeriveCharacterStatsTests, MaxHpRegen)
 {
   auto c = Derive ("chariot", {"plating", "shield"});

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -294,6 +294,10 @@ template <>
   if (!mining.isNull ())
     res["mining"] = mining;
 
+  const auto& pb = c.GetProto ();
+  if (pb.has_prospecting_blocks ())
+    res["prospectingblocks"] = IntToJson (pb.prospecting_blocks ());
+
   return res;
 }
 

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -484,6 +484,29 @@ TEST_F (CharacterJsonTests, Mining)
   })");
 }
 
+TEST_F (CharacterJsonTests, ProspectingRate)
+{
+  tbl.CreateNew ("without prospecting", Faction::RED);
+
+  auto c = tbl.CreateNew ("with prospecting", Faction::RED);
+  c->MutableProto ().set_prospecting_blocks (42);
+  c.reset ();
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "owner": "without prospecting",
+          "prospectingblocks": null
+        },
+        {
+          "owner": "with prospecting",
+          "prospectingblocks": 42
+        }
+      ]
+  })");
+}
+
 TEST_F (CharacterJsonTests, DamageLists)
 {
   const auto id1 = tbl.CreateNew ("domob", Faction::RED)->GetId ();

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -565,6 +565,7 @@ TEST_F (PXLogicTests, ProspectingBeforeMovement)
   auto& pb = c->MutableProto ();
   pb.mutable_combat_data ();
   *pb.mutable_movement ()->add_waypoints () = CoordToProto (pos2);
+  pb.set_prospecting_blocks (10);
   c.reset ();
 
   UpdateState (R"([
@@ -593,12 +594,14 @@ TEST_F (PXLogicTests, ProspectingUserKilled)
   auto c = CreateCharacter ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos);
+  c->MutableProto ().set_prospecting_blocks (10);
   AddUnityAttack (*c, 1);
   c.reset ();
 
   c = CreateCharacter ("andy", Faction::GREEN);
   ASSERT_EQ (c->GetId (), 2);
   c->SetPosition (pos);
+  c->MutableProto ().set_prospecting_blocks (10);
   c->MutableProto ().mutable_combat_data ();
   auto& regen = c->MutableRegenData ();
   regen.mutable_max_hp ()->set_shield (100);
@@ -657,6 +660,7 @@ TEST_F (PXLogicTests, FinishingProspecting)
   auto c = CreateCharacter ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (pos);
+  c->MutableProto ().set_prospecting_blocks (10);
   c->MutableProto ().mutable_combat_data ();
   c->MutableProto ().set_speed (1000);
   c.reset ();
@@ -713,6 +717,7 @@ TEST_F (PXLogicTests, MiningRightAfterProspecting)
   c->MutableProto ().mutable_combat_data ();
   c->MutableProto ().mutable_mining ()->mutable_rate ()->set_min (1);
   c->MutableProto ().mutable_mining ()->mutable_rate ()->set_max (1);
+  c->MutableProto ().set_prospecting_blocks (10);
   c->MutableProto ().set_cargo_space (100);
   c.reset ();
 
@@ -812,6 +817,7 @@ TEST_F (PXLogicTests, MiningWhenReprospected)
   c->MutableProto ().mutable_mining ()->mutable_rate ()->set_min (1);
   c->MutableProto ().mutable_mining ()->mutable_rate ()->set_max (1);
   c->MutableProto ().mutable_mining ()->set_active (true);
+  c->MutableProto ().set_prospecting_blocks (10);
   c->MutableProto ().set_cargo_space (1000);
   c.reset ();
 

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -639,6 +639,12 @@ BaseMoveProcessor::ParseCharacterProspecting (const Character& c,
       return false;
     }
 
+  if (!c.GetProto ().has_prospecting_blocks ())
+    {
+      LOG (WARNING) << "Character " << c.GetId () << " cannot prospect";
+      return false;
+    }
+
   if (c.IsBusy ())
     {
       LOG (WARNING)
@@ -1251,10 +1257,12 @@ MoveProcessor::MaybeStartProspecting (Character& c, const Json::Value& upd)
 
   StopCharacter (c);
 
+  const unsigned blocks = c.GetProto ().prospecting_blocks ();
+  CHECK_GT (blocks, 0);
+
   auto op = ongoings.CreateNew (ctx.Height ());
   c.MutableProto ().set_ongoing (op->GetId ());
-  op->SetHeight (
-      ctx.Height () + ctx.RoConfig ()->params ().prospecting_blocks ());
+  op->SetHeight (ctx.Height () + blocks);
   op->SetCharacterId (c.GetId ());
   op->MutableProto ().mutable_prospection ();
 }

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -1015,18 +1015,26 @@ TEST_F (PendingStateUpdaterTests, Prospecting)
   auto h = characters.CreateNew ("domob", Faction::RED);
   ASSERT_EQ (h->GetId (), 1);
   h->SetPosition (pos);
+  h->MutableProto ().set_prospecting_blocks (10);
   h.reset ();
 
   h = characters.CreateNew ("domob", Faction::GREEN);
   ASSERT_EQ (h->GetId (), 2);
   h->MutableProto ().set_ongoing (42);
+  h->MutableProto ().set_prospecting_blocks (10);
+  h.reset ();
+
+  h = characters.CreateNew ("domob", Faction::BLUE);
+  ASSERT_EQ (h->GetId (), 3);
+  h->MutableProto ().clear_prospecting_blocks ();
   h.reset ();
 
   Process ("domob", R"({
     "c":
       {
         "1": {"prospect": {}},
-        "2": {"prospect": {}}
+        "2": {"prospect": {}},
+        "3": {"prospect": {}}
       }
   })");
 


### PR DESCRIPTION
This changes the way prospecting is configured - instead of the duration of 10 blocks being fixed in the roconfig params, it is now a property of each vehicle type.  With this, we can also define fitments (`scanner` and `pick`) that improve speed for prospecting and mining.