### PR TITLE
Airdrop vCHI for each character

### DIFF
--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -29,6 +29,7 @@ class GodModeTest (PXTest):
     self.collectPremine ()
 
     self.initAccount ("domob", "r")
+    self.initAccount ("daniel", "r")
     self.initAccount ("andy", "b")
     self.createCharacters ("domob")
     self.generate (1)
@@ -152,11 +153,11 @@ class GodModeTest (PXTest):
     self.assertEqual (b.getFungibleInventory ("domob"), {"bar": 42})
 
     self.mainLogger.info ("Testing gift coins...")
-    self.giftCoins ({"domob": 20, "andy": 42})
-    self.giftCoins ({"domob": 30})
+    self.giftCoins ({"daniel": 20, "andy": 42})
+    self.giftCoins ({"daniel": 30})
     acc = self.getAccounts ()
     self.assertEqual (acc["andy"].getBalance (), 42)
-    self.assertEqual (acc["domob"].getBalance (), 50)
+    self.assertEqual (acc["daniel"].getBalance (), 50)
     
 
 if __name__ == "__main__":

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -43,6 +43,9 @@ namespace pxd
  */
 static constexpr unsigned MAX_SERVICE_FEE_PERCENT = 1'000;
 
+/** Airdrop of vCHI for each new character during testing.  */
+static constexpr Amount VCHI_AIRDROP = 1'000;
+
 /* ************************************************************************** */
 
 BaseMoveProcessor::BaseMoveProcessor (Database& d, DynObstacles& o,
@@ -137,7 +140,7 @@ BaseMoveProcessor::TryCharacterCreation (const std::string& name,
           return;
         }
 
-      PerformCharacterCreation (name, faction);
+      PerformCharacterCreation (*account, faction);
       paidToDev -= cost;
       VLOG (1) << "After character creation, paid to dev left: " << paidToDev;
     }
@@ -1105,10 +1108,15 @@ MoveProcessor::ProcessOne (const Json::Value& moveObj)
 }
 
 void
-MoveProcessor::PerformCharacterCreation (const std::string& name,
-                                         const Faction f)
+MoveProcessor::PerformCharacterCreation (Account& acc, const Faction f)
 {
-  SpawnCharacter (name, f, characters, dyn, rnd, ctx);
+  SpawnCharacter (acc.GetName (), f, characters, dyn, rnd, ctx);
+
+  /* FIXME: For the full game, remove this.  */
+  LOG (INFO)
+      << "Airdropping " << VCHI_AIRDROP << " to " << acc.GetName ()
+      << " for newly created character";
+  acc.AddBalance (VCHI_AIRDROP);
 }
 
 namespace

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -259,7 +259,7 @@ protected:
    * is valid and should be performed.
    */
   virtual void
-  PerformCharacterCreation (const std::string& name, Faction f)
+  PerformCharacterCreation (Account& acc, Faction f)
   {}
 
   /**
@@ -400,7 +400,7 @@ private:
 
 protected:
 
-  void PerformCharacterCreation (const std::string& name, Faction f) override;
+  void PerformCharacterCreation (Account& acc, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& mv) override;
   void PerformBuildingUpdate (Building& b, const Json::Value& mv) override;
   void PerformServiceOperation (ServiceOperation& op) override;

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -431,6 +431,21 @@ TEST_F (CharacterCreationTests, ValidCreation)
   EXPECT_FALSE (res.Step ());
 }
 
+TEST_F (CharacterCreationTests, VChiAirdrop)
+{
+  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("andy", Faction::BLUE);
+
+  ProcessWithDevPayment (R"([
+    {"name": "domob", "move": {"nc": [{}, {}]}},
+    {"name": "andy", "move": {"nc": [{}]}},
+    {"name": "andy", "move": {"nc": [{}]}}
+  ])", 2 * ctx.RoConfig ()->params ().character_cost () * COIN);
+
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 2'000);
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 2'000);
+}
+
 TEST_F (CharacterCreationTests, DevPayment)
 {
   accounts.CreateNew ("domob", Faction::RED);

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -426,10 +426,9 @@ PendingState::ToJson () const
 /* ************************************************************************** */
 
 void
-PendingStateUpdater::PerformCharacterCreation (const std::string& name,
-                                               const Faction f)
+PendingStateUpdater::PerformCharacterCreation (Account& acc, const Faction f)
 {
-  state.AddCharacterCreation (name, f);
+  state.AddCharacterCreation (acc.GetName (), f);
 }
 
 void

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -297,7 +297,7 @@ private:
 
 protected:
 
-  void PerformCharacterCreation (const std::string& name, Faction f) override;
+  void PerformCharacterCreation (Account& acc, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& upd) override;
   void PerformServiceOperation (ServiceOperation& op) override;
 


### PR DESCRIPTION
Whenever a character is created, add 1000 vCHI to the owner's account balance as well.  This is a temporary measure to allow testing in the next competition, before a proper vCHI distribution mechanism is designed and put in place.