### PR TITLE
Dynamic obstacle map (with buildings) for findpath

### DIFF
--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -25,8 +25,9 @@ Tests the findpath RPC command.
 
 class FindPathTest (PXTest):
 
-  def call (self, source, target, l1range, wpdist):
+  def call (self, source, target, l1range, wpdist, faction="r"):
     return self.rpc.game.findpath (source=source, target=target,
+                                   faction=faction,
                                    l1range=l1range, wpdist=wpdist)
 
   def run (self):
@@ -43,23 +44,32 @@ class FindPathTest (PXTest):
 
     # Verify exceptions for invalid arguments.
     self.expectError (-1, "source is not a valid coordinate",
-                      findpath, source={}, target=a, l1range=10, wpdist=1)
+                      findpath, source={}, target=a, faction="r",
+                      l1range=10, wpdist=1)
     self.expectError (-1, "target is not a valid coordinate",
-                      findpath, source=a, target={}, l1range=10, wpdist=1)
+                      findpath, source=a, target={}, faction="r",
+                      l1range=10, wpdist=1)
     self.expectError (-1, "l1range is out of bounds",
-                      findpath, source=a, target=a, l1range=-1, wpdist=1)
+                      findpath, source=a, target=a, faction="r",
+                      l1range=-1, wpdist=1)
     self.expectError (-1, "wpdist is out of bounds",
-                      findpath, source=a, target=a, l1range=1, wpdist=0)
+                      findpath, source=a, target=a, faction="r",
+                      l1range=1, wpdist=0)
+    for f in ["a", "invalid"]:
+      self.expectError (-1, "faction is invalid",
+                        findpath, source=a, target=a, faction=f,
+                        l1range=1, wpdist=0)
 
     # Paths that yield no connection.
     self.expectError (1, "no connection",
-                      findpath, source=passable, target=obstacle,
+                      findpath, source=passable, target=obstacle, faction="r",
                       l1range=10, wpdist=1)
     self.expectError (1, "no connection",
-                      findpath, source=a, target=b, l1range=1, wpdist=1)
+                      findpath, source=a, target=b, faction="r",
+                      l1range=1, wpdist=1)
     outOfMap = {"x": 10000, "y": 0}
     self.expectError (1, "no connection",
-                      findpath, source=outOfMap, target=outOfMap,
+                      findpath, source=outOfMap, target=outOfMap, faction="r",
                       l1range=10, wpdist=1)
 
     # Basic path that is fine with wpdist=1 (every coordinate).

--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -16,11 +16,40 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pxtest import PXTest
-
 """
 Tests the findpath RPC command.
 """
+
+from pxtest import PXTest, offsetCoord
+
+import threading
+import time
+
+
+# A thread that does an async call to findpath (plus setting buildings
+# first with setpathbuildings for the call).
+class AsyncFindPath (threading.Thread):
+
+  def __init__ (self, gameNode, buildings, *args, **kwargs):
+    super ().__init__ ()
+    self.rpc = gameNode.createRpc ()
+    self.args = args
+    self.kwargs = kwargs
+
+    self.result = None
+    self.rpc.setpathbuildings (buildings=buildings)
+    self.start ()
+
+    # Wait a bit so that the findpath call has (likely) started already
+    # and "locked in" its copy of the buildings.
+    time.sleep (0.01)
+
+  def run (self):
+    self.result = self.rpc.findpath (*self.args, **self.kwargs)
+
+  def finish (self):
+    self.join ()
+    return self.result
 
 
 class FindPathTest (PXTest):
@@ -31,7 +60,10 @@ class FindPathTest (PXTest):
                                    l1range=l1range, wpdist=wpdist)
 
   def run (self):
+    self.collectPremine ()
+
     findpath = self.rpc.game.findpath
+    setpathbuildings = self.rpc.game.setpathbuildings
 
     # Pair of coordinates that are next to each other, but where one
     # is an obstacle.
@@ -99,6 +131,82 @@ class FindPathTest (PXTest):
         "dist": 0,
         "wp": [a],
       })
+
+    # Invalid building specs for setpathbuildings.
+    self.expectError (-32602, ".*Invalid method parameters.*",
+                      setpathbuildings, buildings={})
+    for specs in [
+      [42],
+      ["foo"],
+      [{}],
+      [{"rotationsteps": 0, "centre": {"x": 1, "y": 2}}],
+      [{"type": 42, "rotationsteps": 0, "centre": {"x": 1, "y": 2}}],
+      [{"type": "invalid", "rotationsteps": 0, "centre": {"x": 1, "y": 2}}],
+      [{"type": "checkmark", "centre": {"x": 1, "y": 2}}],
+      [{"type": "checkmark", "rotationsteps": "0", "centre": {"x": 1, "y": 2}}],
+      [{"type": "checkmark", "rotationsteps": -1, "centre": {"x": 1, "y": 2}}],
+      [{"type": "checkmark", "rotationsteps": 6, "centre": {"x": 1, "y": 2}}],
+      [{"type": "checkmark", "rotationsteps": 0}],
+      [{"type": "checkmark", "rotationsteps": 0, "centre": "(0, 0)"}],
+      [{"type": "checkmark", "rotationsteps": 0, "centre": {"x": 1}}],
+      [
+        {"type": "checkmark", "rotationsteps": 0, "centre": {"x": 1, "y": 0}},
+        {"type": "checkmark", "rotationsteps": 0, "centre": {"x": 1, "y": 0}},
+      ],
+    ]:
+      self.expectError (-1, "buildings is invalid",
+                        setpathbuildings, buildings=specs)
+
+    # This is a very long path, which takes a non-negligible amount of time
+    # to compute.  We use this later to ensure that multiple calls are
+    # actually done in parallel and not blocking each other.
+    longA = {"x": -2000, "y": 0}
+    longB = {"x": 2000, "y": 0}
+    kwargs = {
+      "source": longA,
+      "target": longB,
+      "faction": "r",
+      "l1range": 8000,
+      "wpdist": 8000,
+    }
+    before = time.clock_gettime (time.CLOCK_MONOTONIC)
+    baseLen = findpath (**kwargs)["dist"]
+    after = time.clock_gettime (time.CLOCK_MONOTONIC)
+    baseDuration = after - before
+    self.log.info ("Duration for single call: %.3f s" % baseDuration)
+
+    # Now place buildings in two steps on the map, which make the path from
+    # longA to longB further.  We use the output of getbuildings itself, to
+    # ensure that it can be passed directly back to setpathbuildings.
+    buildings = [[]]
+    self.build ("r_rt", None,
+                offsetCoord (longA, {"x": 1, "y": 0}, False), rot=0)
+    self.build ("r_rt", None,
+                offsetCoord (longA, {"x": 1, "y": -1}, False), rot=0)
+    self.build ("r_rt", None,
+                offsetCoord (longA, {"x": 0, "y": 1}, False), rot=0)
+    buildings.append (self.getRpc ("getbuildings"))
+    self.build ("r_rt", None,
+                offsetCoord (longA, {"x": 0, "y": -1}, False), rot=0)
+    self.build ("r_rt", None,
+                offsetCoord (longA, {"x": -1, "y": 1}, False), rot=0)
+    buildings.append (self.getRpc ("getbuildings"))
+
+    # We do three calls now in parallel, with different sets of buildings.
+    # All should be running concurrently and not block each other.  The total
+    # time should be shorter than sequential execution.
+    before = time.clock_gettime (time.CLOCK_MONOTONIC)
+    calls = []
+    for b in buildings:
+      calls.append (AsyncFindPath (self.gamenode, b, **kwargs))
+    [shortLen, midLen, longLen] = [c.finish ()["dist"] for c in calls]
+    after = time.clock_gettime (time.CLOCK_MONOTONIC)
+    threeDuration = after - before
+    self.log.info ("Duration for three calls: %.3f s" % threeDuration)
+    self.assertEqual (shortLen, baseLen)
+    assert midLen > shortLen
+    assert longLen > midLen
+    assert threeDuration < 2 * baseDuration
 
 
 if __name__ == "__main__":

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,7 @@ libtaurionheaders = \
   logic.hpp \
   mining.hpp \
   modifier.hpp \
-  movement.hpp \
+  movement.hpp movement.tpp \
   moveprocessor.hpp \
   ongoings.hpp \
   params.hpp \

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -407,6 +407,7 @@ public:
 const std::map<std::string, RealCharonClient::RpcServer::NonStateMethod>
     RealCharonClient::RpcServer::NONSTATE_METHODS =
   {
+    {"setpathbuildings", &NonStateRpcServer::setpathbuildingsI},
     {"findpath", &NonStateRpcServer::findpathI},
     {"getregionat", &NonStateRpcServer::getregionatI},
     {"getbuildingshape", &NonStateRpcServer::getbuildingshapeI},

--- a/src/dynobstacles.cpp
+++ b/src/dynobstacles.cpp
@@ -50,7 +50,7 @@ DynObstacles::DynObstacles (Database& db, const Context& ctx)
   }
 }
 
-void
+bool
 DynObstacles::AddBuilding (const std::string& type,
                            const proto::ShapeTransformation& trafo,
                            const HexCoord& pos)
@@ -58,15 +58,19 @@ DynObstacles::AddBuilding (const std::string& type,
   for (const auto& c : GetBuildingShape (type, trafo, pos, chain))
     {
       auto ref = buildings.Access (c);
-      CHECK (!ref);
+      if (ref)
+        return false;
       ref = true;
     }
+  return true;
 }
 
 void
 DynObstacles::AddBuilding (const Building& b)
 {
-  AddBuilding (b.GetType (), b.GetProto ().shape_trafo (), b.GetCentre ());
+  CHECK (AddBuilding (b.GetType (), b.GetProto ().shape_trafo (),
+                      b.GetCentre ()))
+      << "Error adding building " << b.GetId ();
 }
 
 } // namespace pxd

--- a/src/dynobstacles.cpp
+++ b/src/dynobstacles.cpp
@@ -25,8 +25,13 @@
 namespace pxd
 {
 
-DynObstacles::DynObstacles (Database& db, const Context& c)
-  : ctx(c), red(false), green(false), blue(false), buildings(false)
+DynObstacles::DynObstacles (const xaya::Chain c)
+  : chain(c), red(false), green(false), blue(false), buildings(false)
+{}
+
+DynObstacles::DynObstacles (Database& db, const Context& ctx)
+  : chain(ctx.Chain ()),
+    red(false), green(false), blue(false), buildings(false)
 {
   {
     CharacterTable tbl(db);
@@ -46,14 +51,22 @@ DynObstacles::DynObstacles (Database& db, const Context& c)
 }
 
 void
-DynObstacles::AddBuilding (const Building& b)
+DynObstacles::AddBuilding (const std::string& type,
+                           const proto::ShapeTransformation& trafo,
+                           const HexCoord& pos)
 {
-  for (const auto& c : GetBuildingShape (b, ctx))
+  for (const auto& c : GetBuildingShape (type, trafo, pos, chain))
     {
       auto ref = buildings.Access (c);
       CHECK (!ref);
       ref = true;
     }
+}
+
+void
+DynObstacles::AddBuilding (const Building& b)
+{
+  AddBuilding (b.GetType (), b.GetProto ().shape_trafo (), b.GetCentre ());
 }
 
 } // namespace pxd

--- a/src/dynobstacles.hpp
+++ b/src/dynobstacles.hpp
@@ -109,13 +109,14 @@ public:
 
   /**
    * Adds a building from the raw data (without requiring a Building instance).
+   * Returns false if adding failed, e.g. because the buildings overlap.
    */
-  void AddBuilding (const std::string& type,
+  bool AddBuilding (const std::string& type,
                     const proto::ShapeTransformation& trafo,
                     const HexCoord& pos);
 
   /**
-   * Adds a new building.
+   * Adds a new building.  CHECK-fails if something goes wrong.
    */
   void AddBuilding (const Building& b);
 

--- a/src/dynobstacles.hpp
+++ b/src/dynobstacles.hpp
@@ -27,6 +27,7 @@
 #include "hexagonal/coord.hpp"
 #include "mapdata/basemap.hpp"
 #include "mapdata/dyntiles.hpp"
+#include "proto/building.pb.h"
 
 namespace pxd
 {
@@ -42,8 +43,8 @@ class DynObstacles
 
 private:
 
-  /** Context (used for roconfig).  */
-  const Context& ctx;
+  /** Chain to extract the roconfig building shapes.  */
+  const xaya::Chain chain;
 
   /** Vehicles of the red faction on the map.  */
   DynTiles<bool> red;
@@ -67,6 +68,12 @@ private:
   }
 
 public:
+
+  /**
+   * Constructs an "empty" instance.  This is used by the non-state RPC
+   * server for "findpath".
+   */
+  DynObstacles (xaya::Chain c);
 
   /**
    * Constructs an initialised instance with all vehicles and buildings
@@ -99,6 +106,13 @@ public:
    * Removes a vehicle from the given position.
    */
   void RemoveVehicle (const HexCoord& c, Faction f);
+
+  /**
+   * Adds a building from the raw data (without requiring a Building instance).
+   */
+  void AddBuilding (const std::string& type,
+                    const proto::ShapeTransformation& trafo,
+                    const HexCoord& pos);
 
   /**
    * Adds a new building.

--- a/src/dynobstacles_tests.cpp
+++ b/src/dynobstacles_tests.cpp
@@ -106,6 +106,33 @@ TEST_F (DynObstaclesTests, Modifications)
   EXPECT_FALSE (dyn.IsPassable (HexCoord (1, 0), Faction::RED));
 }
 
+TEST_F (DynObstaclesTests, AddingBuildings)
+{
+  auto b1 = buildings.CreateNew ("checkmark", "", Faction::RED);
+  auto b2 = buildings.CreateNew ("checkmark", "", Faction::GREEN);
+  b2->SetCentre (HexCoord (10, 5));
+
+  {
+    DynObstacles dyn(db, ctx);
+    dyn.AddBuilding (*b1);
+    dyn.AddBuilding (*b2);
+    EXPECT_DEATH (dyn.AddBuilding (*b1), "Error adding building");
+  }
+
+  {
+    DynObstacles dyn(ctx.Chain ());
+    ASSERT_TRUE (dyn.AddBuilding (b1->GetType (),
+                                  b1->GetProto ().shape_trafo (),
+                                  b1->GetCentre ()));
+    ASSERT_TRUE (dyn.AddBuilding (b2->GetType (),
+                                  b2->GetProto ().shape_trafo (),
+                                  b2->GetCentre ()));
+    ASSERT_FALSE (dyn.AddBuilding (b1->GetType (),
+                                   b1->GetProto ().shape_trafo (),
+                                   b1->GetCentre ()));
+  }
+}
+
 TEST_F (DynObstaclesTests, IsFree)
 {
   auto b = buildings.CreateNew ("huesli", "", Faction::ANCIENT);

--- a/src/movement.hpp
+++ b/src/movement.hpp
@@ -35,6 +35,15 @@ namespace pxd
 {
 
 /**
+ * Computes the edge weight used for movement of a given faction character
+ * on the map.  This is shared between the RPC server's findpath method
+ * and the actual GSP movement processing logic.
+ */
+inline PathFinder::DistanceT MovementEdgeWeight (
+    const BaseMap& map, const DynObstacles& dyn, Faction f,
+    const HexCoord& from, const HexCoord& to);
+
+/**
  * Clears all movement for the given character (stops its movement entirely).
  */
 void StopCharacter (Character& c);
@@ -85,9 +94,8 @@ using EdgeWeightFcn
  * and additionally excluding movement to locations where a dynamic obstacle is.
  */
 PathFinder::DistanceT MovementEdgeWeight (
-    const HexCoord& from, const HexCoord& to,
-    const EdgeWeightFcn& baseEdges, const DynObstacles& dyn,
-    Faction f);
+    const EdgeWeightFcn& baseEdges, const DynObstacles& dyn, Faction f,
+    const HexCoord& from, const HexCoord& to);
 
 /**
  * Processes movement (if any) for the given character handle and edge weights.
@@ -98,5 +106,7 @@ void ProcessCharacterMovement (Character& c, const Context& ctx,
 } // namespace test
 
 } // namespace pxd
+
+#include "movement.tpp"
 
 #endif // PXD_MOVEMENT_HPP

--- a/src/movement.tpp
+++ b/src/movement.tpp
@@ -1,0 +1,67 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Template implementation code for movement.hpp.  */
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+namespace
+{
+
+/**
+ * Generalised function for the edge weight, which does not rely on a real
+ * BaseMap for the base edges.  This is useful (with non-BaseMap edges)
+ * for testing.
+ */
+template <typename Fcn>
+  inline PathFinder::DistanceT
+  InternalMovementEdgeWeight (const Fcn& baseEdges, const DynObstacles& dyn,
+                              const Faction f,
+                              const HexCoord& from, const HexCoord& to)
+{
+  /* With dynamic obstacles, we do not handle the situation well if from and
+     to are the same location.  In that case, the vehicle itself will be
+     seen as obstacle (which it should not).  */
+  CHECK_NE (from, to);
+
+  const auto res = baseEdges (from, to);
+
+  if (res == PathFinder::NO_CONNECTION || !dyn.IsPassable (to, f))
+    return PathFinder::NO_CONNECTION;
+
+  return res;
+}
+
+} // anonymous namespace
+
+PathFinder::DistanceT
+MovementEdgeWeight (const BaseMap& map, const DynObstacles& dyn,
+                    const Faction f, const HexCoord& from, const HexCoord& to)
+{
+  const auto base = [&map] (const HexCoord& from, const HexCoord& to)
+    {
+      return map.GetEdgeWeight (from, to);
+    };
+
+  return InternalMovementEdgeWeight (base, dyn, f, from, to);
+}
+
+} // namespace pxd

--- a/src/movement_tests.cpp
+++ b/src/movement_tests.cpp
@@ -138,11 +138,11 @@ protected:
 TEST_F (MovementEdgeWeightTests, BaseEdgesPassedThrough)
 {
   const auto baseEdges = EdgesWithObstacle (42);
-  EXPECT_EQ (MovementEdgeWeight (HexCoord (0, 0), HexCoord (1, 0),
-                                 baseEdges, dyn, Faction::RED),
+  EXPECT_EQ (MovementEdgeWeight (baseEdges, dyn, Faction::RED,
+                                 HexCoord (0, 0), HexCoord (1, 0)),
              42);
-  EXPECT_EQ (MovementEdgeWeight (HexCoord (0, 0), HexCoord (-1, 0),
-                                 baseEdges, dyn, Faction::RED),
+  EXPECT_EQ (MovementEdgeWeight (baseEdges, dyn, Faction::RED,
+                                 HexCoord (0, 0), HexCoord (-1, 0)),
              PathFinder::NO_CONNECTION);
 }
 
@@ -151,11 +151,11 @@ TEST_F (MovementEdgeWeightTests, DynamicObstacle)
   const auto baseEdges = EdgeWeights (42);
   dyn.AddVehicle (HexCoord (0, 0), Faction::RED);
 
-  EXPECT_EQ (MovementEdgeWeight (HexCoord (1, 0), HexCoord (0, 0),
-                                 baseEdges, dyn, Faction::RED),
+  EXPECT_EQ (MovementEdgeWeight (baseEdges, dyn, Faction::RED,
+                                 HexCoord (1, 0), HexCoord (0, 0)),
              PathFinder::NO_CONNECTION);
-  EXPECT_EQ (MovementEdgeWeight (HexCoord (1, 0), HexCoord (0, 0),
-                                 baseEdges, dyn, Faction::GREEN),
+  EXPECT_EQ (MovementEdgeWeight (baseEdges, dyn, Faction::GREEN,
+                                 HexCoord (1, 0), HexCoord (0, 0)),
              42);
 }
 

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -97,16 +97,17 @@ private:
   std::mutex mutDynObstacles;
 
   /**
-   * Initialises the dynamic obstacle map with a fresh instance.  This does
-   * not do any locking (callers must ensure synchronisation of dyn).
+   * Constructs a fresh dynamic obstacles instance without any extra
+   * buildings added yet.
    */
-  void InitDynObstacles ();
+  std::shared_ptr<DynObstacles> InitDynObstacles () const;
 
 public:
 
   explicit NonStateRpcServer (jsonrpc::AbstractServerConnector& conn,
                               const BaseMap& m, const xaya::Chain c);
 
+  bool setpathbuildings (const Json::Value& buildings) override;
   Json::Value findpath (const std::string& faction,
                         int l1range, const Json::Value& source,
                         const Json::Value& target, int wpdist) override;
@@ -165,6 +166,12 @@ public:
 
   Json::Value getserviceinfo (const std::string& name,
                               const Json::Value& op) override;
+
+  bool
+  setpathbuildings (const Json::Value& buildings) override
+  {
+    return nonstate.setpathbuildings (buildings);
+  }
 
   Json::Value
   findpath (const std::string& faction,

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -107,7 +107,8 @@ public:
   explicit NonStateRpcServer (jsonrpc::AbstractServerConnector& conn,
                               const BaseMap& m, const xaya::Chain c);
 
-  Json::Value findpath (int l1range, const Json::Value& source,
+  Json::Value findpath (const std::string& faction,
+                        int l1range, const Json::Value& source,
                         const Json::Value& target, int wpdist) override;
   Json::Value getregionat (const Json::Value& coord) override;
   Json::Value getbuildingshape (const Json::Value& centre, int rot,
@@ -166,10 +167,11 @@ public:
                               const Json::Value& op) override;
 
   Json::Value
-  findpath (int l1range, const Json::Value& source,
+  findpath (const std::string& faction,
+            int l1range, const Json::Value& source,
             const Json::Value& target, int wpdist) override
   {
-    return nonstate.findpath (l1range, source, target, wpdist);
+    return nonstate.findpath (faction, l1range, source, target, wpdist);
   }
 
   Json::Value

--- a/src/rpc-stubs/nonstate.json
+++ b/src/rpc-stubs/nonstate.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "setpathbuildings",
+    "params":
+      {
+        "buildings": []
+      },
+    "returns": true
+  },
+  {
     "name": "findpath",
     "params":
       {

--- a/src/rpc-stubs/nonstate.json
+++ b/src/rpc-stubs/nonstate.json
@@ -5,6 +5,7 @@
       {
         "source": {},
         "target": {},
+        "faction": "",
         "l1range": 100,
         "wpdist": 10
       },

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -88,6 +88,7 @@
       {
         "source": {},
         "target": {},
+        "faction": "",
         "l1range": 100,
         "wpdist": 10
       },

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -83,6 +83,14 @@
   },
 
   {
+    "name": "setpathbuildings",
+    "params":
+      {
+        "buildings": []
+      },
+    "returns": true
+  },
+  {
     "name": "findpath",
     "params":
       {


### PR DESCRIPTION
This adds a dynamic obstacle map for `findpath` calls (see #90).  This is still decoupled from the main game state, though, and the buildings on it have to be set explicitly using a new `setpathbuildings` RPC method before.  This allows path-finding to still be local for light-clients with Charon.

The new method `setpathbuildings` expects a single argument, which is the list of buildings that should be treated as obstacles (replacing the entire previous obstacle map on each call).  From when the method returns until the next call, the new map will be active.  Its format is like this (in particular, the result of `getbuildings` can be passed as-is if desired):

    setpathbuildings (buildings=[
      {"type": "checkmark", "rotationsteps": 2, "centre": {"x": 10, "y": -5}},
      {"type": "checkmark", "rotationsteps": 0, "centre": {"x": -10, "y": 42}},
      ...
    ]

In addition, the `findpath` method now expects a new argument `faction` (set to `"r"`, `"g"` or `"b"`), which corresponds to the faction of the vehicle for which the path should be found.  This is irrelevant for now; but it will be needed for #117 later on and fits in very well with this change code-wise.