### PR TITLE
Define initial buildings in roconfig

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -2,6 +2,7 @@ noinst_PROGRAMS = roconfig_gen
 noinst_LTLIBRARIES = libpxproto.la
 
 ROCONFIG_TEXT_PROTOS = \
+  roconfig/initialbuildings.pb.text \
   roconfig/params.pb.text \
   roconfig/resourcedist.pb.text \
   \

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -18,6 +18,7 @@
 
 syntax = "proto2";
 
+import "proto/building.proto";
 import "proto/character.proto";
 import "proto/combat.proto";
 import "proto/geometry.proto";
@@ -365,6 +366,26 @@ message ResourceDistribution
 /* ************************************************************************** */
 
 /**
+ * Data for a building that is initially on the map.  All of them are
+ * ancient and indestructible.
+ */
+message InitialBuilding
+{
+
+  /** Type of the building.  */
+  optional string type = 1;
+
+  /** Centre of the building.  */
+  optional HexCoord centre = 2;
+
+  /** Shape transformation of the building.  */
+  optional ShapeTransformation shape_trafo = 3;
+
+}
+
+/* ************************************************************************** */
+
+/**
  * Definition of a spawn area.
  */
 message SpawnArea
@@ -491,8 +512,11 @@ message ConfigData
   /** Distribution of resources for prospecting.  */
   optional ResourceDistribution resource_dist = 3;
 
+  /** Initial buildings (ancient buildings and starter zones).  */
+  repeated InitialBuilding initial_buildings = 4;
+
   /** Basic parameters.  */
-  optional Params params = 4;
+  optional Params params = 5;
 
   /**
    * The testnet-specific configuration data.  This is merged into the main

--- a/proto/roconfig/initialbuildings.pb.text
+++ b/proto/roconfig/initialbuildings.pb.text
@@ -1,0 +1,20 @@
+initial_buildings:
+  {
+    type: "obelisk1"
+    centre: { x: -125 y: 810 }
+    shape_trafo: { rotation_steps: 0 }
+  }
+
+initial_buildings:
+  {
+    type: "obelisk2"
+    centre: { x: -1301 y: 902 }
+    shape_trafo: { rotation_steps: 0 }
+  }
+
+initial_buildings:
+  {
+    type: "obelisk3"
+    centre: { x: -637 y: -291 }
+    shape_trafo: { rotation_steps: 0 }
+  }

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -337,6 +337,13 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
           return false;
         }
 
+  for (const auto& ib : cfg->initial_buildings ())
+    if (cfg.BuildingOrNull (ib.type ()) == nullptr)
+      {
+        LOG (WARNING) << "Invalid type for initial building: " << ib.type ();
+        return false;
+      }
+
   return true;
 }
 

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -102,20 +102,14 @@ InitialiseBuildings (Database& db, const xaya::Chain chain)
   LOG (INFO) << "Adding initial ancient buildings to the map...";
   BuildingsTable tbl(db);
 
-  auto h = tbl.CreateNew ("obelisk1", "", Faction::ANCIENT);
-  h->SetCentre (HexCoord (-125, 810));
-  UpdateBuildingStats (*h, chain);
-  h.reset ();
-
-  h = tbl.CreateNew ("obelisk2", "", Faction::ANCIENT);
-  h->SetCentre (HexCoord (-1'301, 902));
-  UpdateBuildingStats (*h, chain);
-  h.reset ();
-
-  h = tbl.CreateNew ("obelisk3", "", Faction::ANCIENT);
-  h->SetCentre (HexCoord (-637, -291));
-  UpdateBuildingStats (*h, chain);
-  h.reset ();
+  const RoConfig cfg(chain);
+  for (const auto& ib : cfg->initial_buildings ())
+    {
+      auto h = tbl.CreateNew (ib.type (), "", Faction::ANCIENT);
+      h->SetCentre (CoordFromProto (ib.centre ()));
+      *h->MutableProto ().mutable_shape_trafo () = ib.shape_trafo ();
+      UpdateBuildingStats (*h, chain);
+    }
 }
 
 void


### PR DESCRIPTION
Instead of hardcoding the initial buildings in C++ code, define them in the roconfig proto and place them in code from there.

This is a part of #123.