### PR TITLE
Some real vehicle data

### DIFF
--- a/gametest/buildings_basic.py
+++ b/gametest/buildings_basic.py
@@ -33,8 +33,8 @@ class BuildingsBasicTest (PXTest):
     self.initAccount ("domob", "r")
     self.createCharacters ("domob")
     self.generate (1)
-    self.moveCharactersTo ({"domob": {"x": -10, "y": 0}})
-    self.getCharacters ()["domob"].sendMove ({"wp": [{"x": 10, "y": 0}]})
+    self.moveCharactersTo ({"domob": {"x": -20, "y": 0}})
+    self.getCharacters ()["domob"].sendMove ({"wp": [{"x": 20, "y": 0}]})
     self.generate (3)
     reorgBlock = self.rpc.xaya.getbestblockhash ()
 
@@ -80,7 +80,7 @@ class BuildingsBasicTest (PXTest):
     self.assertEqual ([b.data for b in self.getBuildings ().values ()],
                       [b.data for b in self.ancientBuildings.values ()])
     self.assertEqual (self.getCharacters ()["domob"].getPosition (),
-                      {"x": 10, "y": 0})
+                      {"x": 20, "y": 0})
 
     self.rpc.xaya.reconsiderblock (blk)
     self.expectGameState (originalState)

--- a/gametest/buildings_combat.py
+++ b/gametest/buildings_combat.py
@@ -59,6 +59,7 @@ class BuildingsCombatTest (PXTest):
     self.generate (1)
     self.createCharacters ("attacker")
     self.generate (2)
+    self.changeCharacterVehicle ("attacker", "light attacker")
     reorgBlk = self.rpc.xaya.getbestblockhash ()
     self.moveCharactersTo ({"attacker": {"x": 1, "y": 0}})
 

--- a/gametest/buildings_enterexit.py
+++ b/gametest/buildings_enterexit.py
@@ -38,6 +38,7 @@ class BuildingsEnterExitTest (PXTest):
     self.initAccount ("domob", "r")
     self.createCharacters ("domob")
     self.generate (1)
+    self.changeCharacterVehicle ("domob", "light attacker")
     self.moveCharactersTo ({"domob": {"x": 20, "y": 0}})
     self.getCharacters ()["domob"].sendMove ({
       "wp": [{"x": 3, "y": 0}],
@@ -64,6 +65,7 @@ class BuildingsEnterExitTest (PXTest):
     self.initAccount ("andy", "g")
     self.createCharacters ("andy")
     self.generate (1)
+    self.changeCharacterVehicle ("andy", "light attacker")
     self.moveCharactersTo ({
       "domob": {"x": 5, "y": 0},
       "andy": {"x": 5, "y": 0},

--- a/gametest/character_limit.py
+++ b/gametest/character_limit.py
@@ -66,6 +66,8 @@ class CharacterLimitTest (PXTest):
     self.mainLogger.info ("Killing some characters...")
     self.initAccount ("attacker", "g")
     self.createCharacters ("attacker")
+    self.generate (1)
+    self.changeCharacterVehicle ("attacker", "light attacker")
     self.setCharactersHP ({
       "domob 2": {"a": 1, "s": 0},
       "domob 5": {"a": 1, "s": 0},

--- a/gametest/combat_damage.py
+++ b/gametest/combat_damage.py
@@ -50,6 +50,7 @@ class CombatDamageTest (PXTest):
     self.initAccount ("attacker", "r")
     self.createCharacters ("attacker", 2)
     self.generate (1)
+    self.changeCharacterVehicle ("attacker", "light attacker")
 
     # We use a known good position as offset for our test.
     self.offset = {"x": -1100, "y": 1042}

--- a/gametest/combat_targets.py
+++ b/gametest/combat_targets.py
@@ -60,6 +60,9 @@ class CombatTargetTest (PXTest):
     self.initAccount ("green", "g")
     self.createCharacters ("green", 2)
     self.generate (1)
+    self.changeCharacterVehicle ("red", "light attacker")
+    self.changeCharacterVehicle ("green", "light attacker")
+    self.changeCharacterVehicle ("green 2", "light attacker")
 
     # We use the starting coordinate of green 1 as offset for coordinates,
     # so that the test is independent of the actual starting positions
@@ -95,7 +98,7 @@ class CombatTargetTest (PXTest):
     self.mainLogger.info ("Testing target selection when moving into range...")
     c = self.getCharacters ()["red"]
     self.moveCharactersTo ({
-      "red": offsetCoord ({"x": 12, "y": 0}, self.offset, False),
+      "red": offsetCoord ({"x": 13, "y": 0}, self.offset, False),
     })
     assert self.getTargetCharacter ("green") is None
     # Note that we can move a directly to the offset coordinate (where also

--- a/gametest/damage_lists.py
+++ b/gametest/damage_lists.py
@@ -59,6 +59,9 @@ class DamageListsTest (PXTest):
     self.initAccount ("attacker", "r")
     self.createCharacters ("attacker", 2)
     self.generate (1)
+    self.changeCharacterVehicle ("target", "light attacker")
+    self.changeCharacterVehicle ("attacker", "light attacker")
+    self.changeCharacterVehicle ("attacker 2", "light attacker")
 
     # We use a known good position as offset and move the characters
     # nearby so they are attacking each other.

--- a/gametest/fame.py
+++ b/gametest/fame.py
@@ -34,6 +34,8 @@ class FameTest (PXTest):
     self.initAccount ("bar", "g")
     self.createCharacters ("bar")
     self.generate (1)
+    self.changeCharacterVehicle ("foo", "light attacker")
+    self.changeCharacterVehicle ("bar", "light attacker")
     self.moveCharactersTo ({
       "foo": {"x": 0, "y": 0},
       "bar": {"x": 0, "y": 0},
@@ -60,6 +62,10 @@ class FameTest (PXTest):
     self.initAccount ("blue", "b")
     self.createCharacters ("blue")
     self.generate (1)
+    self.changeCharacterVehicle ("red", "light attacker")
+    self.changeCharacterVehicle ("red 2", "light attacker")
+    self.changeCharacterVehicle ("green", "light attacker")
+    self.changeCharacterVehicle ("blue", "light attacker")
     self.moveCharactersTo ({
       "blue": {"x": 0, "y": 0},
       "red": {"x": 5, "y": 0},
@@ -102,6 +108,8 @@ class FameTest (PXTest):
         suff = " %d" % (i + 1)
       mv["army" + suff] = {"x": 101, "y": i - armySize // 2}
       mv["other army" + suff] = {"x": -101, "y": i - armySize // 2}
+      self.changeCharacterVehicle ("army" + suff, "light attacker")
+      self.changeCharacterVehicle ("other army" + suff, "light attacker")
     self.moveCharactersTo (mv)
     self.setCharactersHP ({
       "target": {"a": 1, "s": 0},

--- a/gametest/loot.py
+++ b/gametest/loot.py
@@ -107,6 +107,7 @@ class LootTest (PXTest):
     self.dropLoot ({"x": 0, "y": 0}, {"foo": 10})
     self.createCharacters ("cargo", 1)
     self.generate (1)
+    self.changeCharacterVehicle ("cargo", "light attacker")
     self.moveCharactersTo ({"cargo": {"x": 0, "y": 0}})
     self.getCharacters ()["cargo"].sendMove ({"pu": {"f": {"foo": 100}}})
     self.generate (1)
@@ -150,6 +151,7 @@ class LootTest (PXTest):
     self.initAccount ("green", "g")
     self.createCharacters ("green")
     self.generate (1)
+    self.changeCharacterVehicle ("green", "light attacker")
     self.moveCharactersTo ({
       "red": {"x": 100, "y": 100},
       "green": {"x": 100, "y": 100},

--- a/gametest/mining.py
+++ b/gametest/mining.py
@@ -40,6 +40,8 @@ class MiningTest (PXTest):
     self.initAccount ("domob", "r")
     self.createCharacters ("domob", 2)
     self.generate (1)
+    self.changeCharacterVehicle ("domob", "light attacker")
+    self.changeCharacterVehicle ("domob 2", "light attacker")
     self.moveCharactersTo ({
       "domob": self.pos[0],
       "domob 2": self.pos[1],

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -98,6 +98,7 @@ class MovementTest (PXTest):
     self.initAccount ("domob", "g")
     self.createCharacters ("domob")
     self.generate (1)
+    self.changeCharacterVehicle ("domob", "light attacker")
 
     # Start off from a known good location to make sure all is fine and
     # not flaky depending on the randomised spawn position.
@@ -106,18 +107,18 @@ class MovementTest (PXTest):
 
     self.mainLogger.info ("Setting basic path for character...")
     wp = [
-      {"x": 6, "y": 0},
-      {"x": 2, "y": 2},
-      {"x": 2, "y": 2},
+      {"x": 9, "y": 0},
+      {"x": 3, "y": 3},
+      {"x": 3, "y": 3},
       {"x": 0, "y": 0},
-      {"x": -6, "y": -4},
-      {"x": -6, "y": -4},
+      {"x": -9, "y": -6},
+      {"x": -9, "y": -6},
     ]
     self.setWaypoints ("domob", wp)
     self.generate (1)
     pos, mv = self.getMovement ("domob")
     self.assertEqual (mv["partialstep"], 0)
-    self.assertEqual (pos, {"x": 2, "y": 0})
+    self.assertEqual (pos, {"x": 3, "y": 0})
     self.reorgBlock = self.rpc.xaya.getbestblockhash ()
 
     self.mainLogger.info ("Finishing the movement...")
@@ -171,7 +172,7 @@ class MovementTest (PXTest):
     c.sendMove ({"speed": 10000})
     self.generate (10)
     pos, mv = self.getMovement ("domob")
-    self.assertEqual (pos, {"x": 30, "y": 0})
+    self.assertEqual (pos, {"x": 40, "y": 0})
     self.assertEqual (mv["chosenspeed"], 10000)
 
     # Sending another movement in-between without speed will revert it to
@@ -180,7 +181,7 @@ class MovementTest (PXTest):
     c.sendMove ({"wp": wp, "speed": 1000})
     self.generate (10)
     pos, _ = self.getMovement ("domob")
-    self.assertEqual (pos, {"x": 40, "y": 0})
+    self.assertEqual (pos, {"x": 50, "y": 0})
     self.setWaypoints ("domob", [{"x": 0, "y": 0}])
     self.generate (10)
     pos, mv = self.getMovement ("domob")
@@ -200,7 +201,7 @@ class MovementTest (PXTest):
     self.setWaypoints ("domob", [{"x": 0, "y": 0}])
     self.generate (10)
     pos, mv = self.getMovement ("domob")
-    self.assertEqual (pos, {"x": 80, "y": 0})
+    self.assertEqual (pos, {"x": 70, "y": 0})
     assert "chosenspeed" not in mv
 
     # Stop the character to avoid confusing later tests.

--- a/gametest/prospecting_basic.py
+++ b/gametest/prospecting_basic.py
@@ -48,6 +48,8 @@ class BasicProspectingTest (PXTest):
     self.initAccount ("attacker 2", "g")
     self.createCharacters ("attacker 2")
     self.generate (1)
+    self.changeCharacterVehicle ("attacker 1", "light attacker")
+    self.changeCharacterVehicle ("attacker 2", "light attacker")
 
     # Set up known positions of the characters.  We use a known good position
     # as origin and move all attackers there.  The target will be moved to a
@@ -193,11 +195,11 @@ class BasicProspectingTest (PXTest):
     self.generate (100)
     self.createCharacters ("target", 1)
     self.generate (1)
-    self.moveCharactersTo ({
-      "target": self.offset,
-    })
     self.setCharactersHP ({
       "target": {"a": 1000, "s": 0},
+    })
+    self.moveCharactersTo ({
+      "target": self.offset,
     })
     r = self.getRegionAt (self.offset)
     c = self.getCharacters ()["target"]

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -114,6 +114,39 @@ fungible_items:
 ################################################################################
 # Vehicles
 
+# A test vehicle with some well-defined stats suitable for testing
+# basic combat in the integration tests.
+fungible_items:
+  {
+    key: "light attacker"
+    value:
+      {
+        space: 50
+        complexity: 100
+        vehicle:
+          {
+            cargo_space: 20
+            speed: 3000
+            regen_data:
+              {
+                max_hp: { armour: 100 shield: 30 }
+                shield_regeneration_mhp: 500
+              }
+            combat_data:
+              {
+                attacks:
+                  {
+                    range: 10
+                    damage: { min: 1 max: 10 }
+                  }
+              }
+            mining_rate: { min: 1 max: 1 }
+            prospecting_blocks: 10
+            size: LIGHT
+          }
+      }
+  }
+
 # A test vehicle with some well-defined stats that can be used
 # also e.g. in tests for fitments.
 fungible_items:

--- a/proto/roconfig/items/vehicles.pb.text
+++ b/proto/roconfig/items/vehicles.pb.text
@@ -1,31 +1,23 @@
 ################################################################################
-# Starter vehicles.
+# Starter vehicles
 
 fungible_items:
   {
     key: "rv st"
     value:
       {
-        space: 100
+        space: 4030000
         complexity: 1
         vehicle:
           {
-            cargo_space: 20
-            speed: 2100
+            cargo_space: 1008000
+            speed: 3000
             regen_data:
               {
-                max_hp: { armour: 75 shield: 30 }
-                shield_regeneration_mhp: 500
+                max_hp: { armour: 20 shield: 10 }
+                shield_regeneration_mhp: 1000
               }
-            combat_data:
-              {
-                attacks:
-                  {
-                    area: 7
-                    damage: { min: 1 max: 20 }
-                  }
-              }
-            mining_rate: { min: 0 max: 5 }
+            mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 10
             size: STARTER
           }
@@ -37,26 +29,18 @@ fungible_items:
     key: "gv st"
     value:
       {
-        space: 100
+        space: 4030000
         complexity: 1
         vehicle:
           {
-            cargo_space: 30
-            speed: 2000
+            cargo_space: 1008000
+            speed: 3000
             regen_data:
               {
-                max_hp: { armour: 150 shield: 30 }
-                shield_regeneration_mhp: 200
+                max_hp: { armour: 20 shield: 10 }
+                shield_regeneration_mhp: 1000
               }
-            combat_data:
-              {
-                attacks:
-                  {
-                    range: 10
-                    damage: { min: 1 max: 20 }
-                  }
-              }
-            mining_rate: { min: 0 max: 5 }
+            mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 10
             size: STARTER
           }
@@ -68,26 +52,18 @@ fungible_items:
     key: "bv st"
     value:
       {
-        space: 100
+        space: 4030000
         complexity: 1
         vehicle:
           {
-            cargo_space: 20
-            speed: 2200
+            cargo_space: 1008000
+            speed: 3000
             regen_data:
               {
-                max_hp: { armour: 50 shield: 30 }
+                max_hp: { armour: 20 shield: 10 }
                 shield_regeneration_mhp: 1000
               }
-            combat_data:
-              {
-                attacks:
-                  {
-                    range: 10
-                    damage: { min: 1 max: 12 }
-                  }
-              }
-            mining_rate: { min: 0 max: 5 }
+            mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 10
             size: STARTER
           }

--- a/proto/roconfig/items/vehicles.pb.text
+++ b/proto/roconfig/items/vehicles.pb.text
@@ -69,3 +69,93 @@ fungible_items:
           }
       }
   }
+
+################################################################################
+# Small vehicles
+
+fungible_items:
+  {
+    key: "rv s"
+    value:
+      {
+        space: 14450000
+        complexity: 10
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 52500 }
+        construction_resources: { key: "mat b" value: 22500 }
+        vehicle:
+          {
+            cargo_space: 3613125
+            speed: 3000
+            regen_data:
+              {
+                max_hp: { armour: 20 shield: 50 }
+                shield_regeneration_mhp: 2000
+              }
+            mining_rate: { min: 0 max: 4000000 }
+            prospecting_blocks: 9
+            size: LIGHT
+            equipment_slots: { key: "high" value: 1 }
+            equipment_slots: { key: "mid" value: 1 }
+            equipment_slots: { key: "low" value: 2 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "gv s"
+    value:
+      {
+        space: 14450000
+        complexity: 10
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 52500 }
+        construction_resources: { key: "mat b" value: 22500 }
+        vehicle:
+          {
+            cargo_space: 3613125
+            speed: 3000
+            regen_data:
+              {
+                max_hp: { armour: 20 shield: 50 }
+                shield_regeneration_mhp: 2000
+              }
+            mining_rate: { min: 0 max: 4000000 }
+            prospecting_blocks: 9
+            size: LIGHT
+            equipment_slots: { key: "high" value: 1 }
+            equipment_slots: { key: "mid" value: 2 }
+            equipment_slots: { key: "low" value: 1 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "bv s"
+    value:
+      {
+        space: 14450000
+        complexity: 10
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 52500 }
+        construction_resources: { key: "mat b" value: 22500 }
+        vehicle:
+          {
+            cargo_space: 3613125
+            speed: 3000
+            regen_data:
+              {
+                max_hp: { armour: 20 shield: 50 }
+                shield_regeneration_mhp: 2000
+              }
+            mining_rate: { min: 0 max: 4000000 }
+            prospecting_blocks: 9
+            size: LIGHT
+            equipment_slots: { key: "high" value: 1 }
+            equipment_slots: { key: "mid" value: 1 }
+            equipment_slots: { key: "low" value: 2 }
+          }
+      }
+  }

--- a/src/spawn_tests.cpp
+++ b/src/spawn_tests.cpp
@@ -100,28 +100,11 @@ TEST_F (SpawnTests, DataInitialised)
   ASSERT_EQ (c->GetOwner (), "domob");
 
   EXPECT_TRUE (c->GetProto ().has_combat_data ());
-  EXPECT_FALSE (c->GetProto ().combat_data ().attacks ().empty ());
+  EXPECT_GT (c->GetProto ().cargo_space (), 0);
+  EXPECT_GT (c->GetHP ().armour (), 0);
+  EXPECT_GT (c->GetHP ().shield (), 0);
   EXPECT_TRUE (MessageDifferencer::Equals (c->GetHP (),
                                            c->GetRegenData ().max_hp ()));
-}
-
-TEST_F (SpawnTests, PerFactionStats)
-{
-  const auto idRed = Spawn ("red", Faction::RED)->GetId ();
-  const auto idGreen = Spawn ("green", Faction::GREEN)->GetId ();
-  const auto idBlue = Spawn ("blue", Faction::BLUE)->GetId ();
-
-  auto c = tbl.GetById (idRed);
-  ASSERT_EQ (c->GetFaction (), Faction::RED);
-  EXPECT_EQ (c->GetProto ().speed (), 2'100);
-
-  c = tbl.GetById (idGreen);
-  ASSERT_EQ (c->GetFaction (), Faction::GREEN);
-  EXPECT_EQ (c->GetProto ().speed (), 2'000);
-
-  c = tbl.GetById (idBlue);
-  ASSERT_EQ (c->GetFaction (), Faction::BLUE);
-  EXPECT_EQ (c->GetProto ().speed (), 2'200);
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
This updates the stats of the starter vehicles to the real game design.  Since this e.g. removes all attacks they have, it also breaks a couple of tests, which are changed to use specific test vehicles instead.

It also adds in stats for the "light" vehicles of all factions, which serves as an example for how to add the other vehicles (including blueprint / construction materials, which are not applicable to starter vehicles).