### PR TITLE
Safe and starter zones

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -Im4
 
-SUBDIRS = hexagonal mapdata proto database src gametest
+SUBDIRS = hexagonal proto mapdata database src gametest

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -Im4
 
-SUBDIRS = hexagonal proto mapdata database src gametest
+SUBDIRS = hexagonal proto database mapdata src gametest

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -36,6 +36,7 @@ REGTESTS = \
   prospecting_basic.py \
   prospecting_prizes.py \
   prospecting_resources.py \
+  safezones.py \
   services_bpcopy.py \
   services_construction.py \
   services_fees.py \

--- a/gametest/safezones.py
+++ b/gametest/safezones.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests basic behaviour of the starter "safe zones".
+"""
+
+from pxtest import PXTest, offsetCoord
+
+
+def relativePos (x, y):
+  """
+  Returns a coordinate offset by the given (x, y) relative to a test
+  starter zone's centre.  The zone's radius is 10.
+  """
+
+  centre = {"x": -2042, "y": 100}
+  return offsetCoord (centre, {"x": x, "y": y}, False)
+
+
+class SafeZonesTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("Creating test characters...")
+    self.initAccount ("red", "r")
+    self.initAccount ("green", "g")
+    self.generate (1)
+    self.createCharacters ("red")
+    self.createCharacters ("green")
+    self.generate (1)
+    self.changeCharacterVehicle ("red", "light attacker")
+    self.changeCharacterVehicle ("green", "light attacker")
+
+    self.mainLogger.info ("Testing findpath...")
+    def findpath (**kwargs):
+      path = self.rpc.game.findpath (l1range=1000, wpdist=1000, **kwargs)
+      return path["dist"]
+    self.expectError (1, "no connection",
+                      findpath, faction="g",
+                      source=relativePos (-15, 0),
+                      target=relativePos (-5, 0))
+    self.assertEqual (findpath (faction="r",
+                                source=relativePos (-15, 0),
+                                target=relativePos (-5, 0)),
+                      4000 + 6 * (1000 // 3))
+    assert findpath (faction="g", source=relativePos (-15, 0),
+                     target=relativePos (15, 0)) > 30000
+    assert findpath (faction="r", source=relativePos (-15, 11),
+                     target=relativePos (15, 11)) < 30000
+
+    self.mainLogger.info ("Testing movement...")
+    # The green one has to move around the starter zone and will take longer
+    # than a straight line (speed is 2).  The red one can take a "detour"
+    # through the area to be faster.
+    self.moveCharactersTo ({
+      "red": relativePos (-15, 11),
+      "green": relativePos (-15, 0),
+    })
+    chars = self.getCharacters ()
+    chars["red"].sendMove ({"wp": [relativePos (15, 11)]})
+    chars["green"].sendMove ({"wp": [relativePos (15, 0)]})
+    self.generate (9)
+    c = self.getCharacters ()["red"]
+    self.assertEqual (c.isMoving (), False)
+    self.assertEqual (c.getPosition (), relativePos (15, 11))
+    self.generate (2)
+    self.assertEqual (self.getCharacters ()["green"].isMoving (), True)
+
+    self.mainLogger.info ("Testing combat...")
+    self.moveCharactersTo ({
+      "red": relativePos (0, 14),
+      "green": relativePos (0, 11),
+    })
+    self.setCharactersHP ({
+      "red": {"ma": 100, "a": 100, "ms": 100, "s": 100},
+      "green": {"ma": 100, "a": 100, "ms": 100, "s": 100},
+    })
+    self.getCharacters ()["red"].sendMove ({"wp": [relativePos (0, 7)]})
+    self.generate (2)
+    c = self.getCharacters ()["red"]
+    assert c.data["combat"]["hp"]["current"]["shield"] < 100
+    assert "target" not in c.data["combat"]
+    self.assertEqual (c.getPosition (), relativePos (0, 7))
+
+    # Let the shield regenerate in the safe zone.
+    self.generate (100)
+    c = self.getCharacters ()["red"]
+    self.assertEqual (c.data["combat"]["hp"]["current"]["shield"], 100)
+
+    # Move out of the safe zone.  After the first block, we are still in
+    # and there should not be any combat.  After that, we are out and combat
+    # will resume.
+    c.sendMove ({"wp": [relativePos (0, 12)], "speed": 1000})
+    self.generate (1)
+    chars = self.getCharacters ()
+    c = chars["red"]
+    self.assertEqual (c.getPosition (), relativePos (0, 10))
+    self.assertEqual (c.data["combat"]["hp"]["current"]["shield"], 100)
+    assert "target" not in c.data["combat"]
+    c = chars["green"]
+    self.assertEqual (c.data["combat"]["hp"]["current"]["shield"], 100)
+    assert "target" not in c.data["combat"]
+
+    # After the first block moving out of the safe zone, both characters
+    # should have targeted each other (but not yet attacked).
+    self.generate (1)
+    chars = self.getCharacters ()
+    c = chars["red"]
+    self.assertEqual (c.data["combat"]["hp"]["current"]["shield"], 100)
+    assert "target" in c.data["combat"]
+    c = chars["green"]
+    self.assertEqual (c.data["combat"]["hp"]["current"]["shield"], 100)
+    assert "target" in c.data["combat"]
+
+    # After the second block, also both attacks should have dealt some damage.
+    self.generate (1)
+    chars = self.getCharacters ()
+    c = chars["red"]
+    assert c.data["combat"]["hp"]["current"]["shield"] < 100
+    assert "target" in c.data["combat"]
+    c = chars["green"]
+    assert c.data["combat"]["hp"]["current"]["shield"] < 100
+    assert "target" in c.data["combat"]
+
+
+if __name__ == "__main__":
+  SafeZonesTest ().main ()

--- a/mapdata/Makefile.am
+++ b/mapdata/Makefile.am
@@ -15,12 +15,14 @@ libmapdata_la_CXXFLAGS = \
   -I$(top_srcdir) \
   $(GLOG_CFLAGS)
 libmapdata_la_LIBADD = \
+  $(top_builddir)/database/libdatabase.la \
   $(top_builddir)/hexagonal/libhexagonal.la \
   $(top_builddir)/proto/libpxproto.la \
   $(GLOG_LIBS)
 libmapdata_la_SOURCES = \
   basemap.cpp \
   regionmap.cpp \
+  safezones.cpp \
   tiledata.cpp \
   \
   blobs.s
@@ -28,6 +30,7 @@ noinst_HEADERS = \
   basemap.hpp basemap.tpp \
   dyntiles.hpp dyntiles.tpp \
   regionmap.hpp \
+  safezones.hpp safezones.tpp \
   tiledata.hpp \
   \
   benchutils.hpp \
@@ -42,6 +45,7 @@ tests_CXXFLAGS = \
   $(GTEST_CFLAGS) $(GLOG_CFLAGS)
 tests_LDADD = \
   $(builddir)/libmapdata.la \
+  $(top_builddir)/database/libdatabase.la \
   $(top_builddir)/hexagonal/libhexagonal.la \
   $(top_builddir)/proto/libpxproto.la \
   $(GTEST_MAIN_LIBS) \
@@ -50,6 +54,7 @@ tests_SOURCES = \
   basemap_tests.cpp \
   dyntiles_tests.cpp \
   regionmap_tests.cpp \
+  safezones_tests.cpp \
   \
   dataio.cpp
 
@@ -58,6 +63,7 @@ benchmarks_CXXFLAGS = \
   $(GLOG_CFLAGS) $(BENCHMARK_CFLAGS)
 benchmarks_LDADD = \
   $(builddir)/libmapdata.la \
+  $(top_builddir)/database/libdatabase.la \
   $(top_builddir)/hexagonal/libbenchmain.la \
   $(top_builddir)/hexagonal/libhexagonal.la \
   $(top_builddir)/proto/libpxproto.la \

--- a/mapdata/Makefile.am
+++ b/mapdata/Makefile.am
@@ -16,6 +16,7 @@ libmapdata_la_CXXFLAGS = \
   $(GLOG_CFLAGS)
 libmapdata_la_LIBADD = \
   $(top_builddir)/hexagonal/libhexagonal.la \
+  $(top_builddir)/proto/libpxproto.la \
   $(GLOG_LIBS)
 libmapdata_la_SOURCES = \
   basemap.cpp \
@@ -42,6 +43,7 @@ tests_CXXFLAGS = \
 tests_LDADD = \
   $(builddir)/libmapdata.la \
   $(top_builddir)/hexagonal/libhexagonal.la \
+  $(top_builddir)/proto/libpxproto.la \
   $(GTEST_MAIN_LIBS) \
   $(GTEST_LIBS) $(GLOG_LIBS)
 tests_SOURCES = \
@@ -58,6 +60,7 @@ benchmarks_LDADD = \
   $(builddir)/libmapdata.la \
   $(top_builddir)/hexagonal/libbenchmain.la \
   $(top_builddir)/hexagonal/libhexagonal.la \
+  $(top_builddir)/proto/libpxproto.la \
   $(GLOG_LIBS) $(BENCHMARK_LIBS)
 benchmarks_SOURCES = \
   dyntiles_bench.cpp \

--- a/mapdata/Makefile.am
+++ b/mapdata/Makefile.am
@@ -71,6 +71,7 @@ benchmarks_LDADD = \
 benchmarks_SOURCES = \
   dyntiles_bench.cpp \
   regionmap_bench.cpp \
+  safezones_bench.cpp \
   \
   benchutils.cpp
 

--- a/mapdata/basemap.cpp
+++ b/mapdata/basemap.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,7 +21,8 @@
 namespace pxd
 {
 
-BaseMap::BaseMap ()
+BaseMap::BaseMap (const xaya::Chain c)
+  : cfg(c)
 {
   CHECK_EQ (&blob_obstacles_end - &blob_obstacles_start,
             tiledata::obstacles::bitDataSize);

--- a/mapdata/basemap.cpp
+++ b/mapdata/basemap.cpp
@@ -22,7 +22,7 @@ namespace pxd
 {
 
 BaseMap::BaseMap (const xaya::Chain c)
-  : cfg(c)
+  : cfg(c), sz(cfg)
 {
   CHECK_EQ (&blob_obstacles_end - &blob_obstacles_start,
             tiledata::obstacles::bitDataSize);

--- a/mapdata/basemap.hpp
+++ b/mapdata/basemap.hpp
@@ -20,6 +20,7 @@
 #define MAPDATA_BASEMAP_HPP
 
 #include "regionmap.hpp"
+#include "safezones.hpp"
 
 #include "hexagonal/coord.hpp"
 #include "hexagonal/pathfinder.hpp"
@@ -42,7 +43,10 @@ private:
   const RoConfig cfg;
 
   /** RegionMap instance that is exposed as part of the BaseMap.  */
-  RegionMap rm;
+  const RegionMap rm;
+
+  /** SafeZones instance used.  */
+  const pxd::SafeZones sz;
 
 public:
 
@@ -67,6 +71,12 @@ public:
   Regions () const
   {
     return rm;
+  }
+
+  const pxd::SafeZones&
+  SafeZones () const
+  {
+    return sz;
   }
 
   /**

--- a/mapdata/basemap.hpp
+++ b/mapdata/basemap.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@
 
 #include "hexagonal/coord.hpp"
 #include "hexagonal/pathfinder.hpp"
+#include "proto/roconfig.hpp"
 
 namespace pxd
 {
@@ -37,13 +38,17 @@ class BaseMap
 
 private:
 
+  /** RoConfig data.  */
+  const RoConfig cfg;
+
   /** RegionMap instance that is exposed as part of the BaseMap.  */
   RegionMap rm;
 
 public:
 
-  BaseMap ();
+  explicit BaseMap (const xaya::Chain c);
 
+  BaseMap () = delete;
   BaseMap (const BaseMap&) = delete;
   void operator= (const BaseMap&) = delete;
 

--- a/mapdata/basemap.tpp
+++ b/mapdata/basemap.tpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -76,7 +76,7 @@ inline PathFinder::DistanceT
 BaseMap::GetEdgeWeight (const HexCoord& from, const HexCoord& to) const
 {
   if (IsPassable (to))
-    return 1000;
+    return 1'000;
 
   return PathFinder::NO_CONNECTION;
 }

--- a/mapdata/basemap_tests.cpp
+++ b/mapdata/basemap_tests.cpp
@@ -42,6 +42,10 @@ protected:
 
   BaseMap map;
 
+  BaseMapTests ()
+    : map(xaya::Chain::REGTEST)
+  {}
+
 };
 
 TEST_F (BaseMapTests, IsOnMap)

--- a/mapdata/dyntiles.hpp
+++ b/mapdata/dyntiles.hpp
@@ -32,6 +32,13 @@ namespace dyntiles
 {
 
 /**
+ * Computes the index into our abstract data vector at which a certain
+ * coordinate will be found.  The abstract data vector is the assumed
+ * array of all tiles, stored row-by-row.
+ */
+inline size_t GetIndex (const HexCoord& c);
+
+/**
  * Size of each "bucket" of values.  We use one array
  * for each bucket, and have a larger array of arrays.  That way,
  * we can initialise each bucket only when needed (i.e. it is changed

--- a/mapdata/dyntiles.tpp
+++ b/mapdata/dyntiles.tpp
@@ -28,12 +28,7 @@ namespace pxd
 namespace dyntiles
 {
 
-/**
- * Computes the index into our abstract data vector at which a certain
- * coordinate will be found.  The abstract data vector is the assumed
- * array of all tiles, stored row-by-row.
- */
-inline size_t
+size_t
 GetIndex (const HexCoord& c)
 {
   const auto x = c.GetX ();

--- a/mapdata/safezones.cpp
+++ b/mapdata/safezones.cpp
@@ -1,0 +1,82 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "safezones.hpp"
+
+#include "hexagonal/ring.hpp"
+
+namespace pxd
+{
+
+SafeZones::SafeZones (const RoConfig& cfg)
+  : data(new uint8_t[ARRAY_SIZE])
+{
+  uint8_t* mutData = const_cast<uint8_t*> (data);
+  std::fill (mutData, mutData + ARRAY_SIZE, 0);
+
+  for (const auto& sz : cfg->safe_zones ())
+    {
+      const HexCoord centre(sz.centre ().x (), sz.centre ().y ());
+
+      Entry e;
+      if (sz.has_faction ())
+        {
+          const auto f = FactionFromString (sz.faction ());
+          switch (f)
+            {
+            case Faction::RED:
+            case Faction::GREEN:
+            case Faction::BLUE:
+              e = static_cast<Entry> (f);
+              break;
+            default:
+              LOG (FATAL)
+                  << "Invalid faction defined for starter zone: "
+                  << sz.faction ();
+              break;
+            }
+        }
+      else
+        e = Entry::NEUTRAL;
+
+      const uint8_t val = static_cast<uint8_t> (e);
+      CHECK_LE (val, 0x0F);
+
+      for (unsigned r = 0; r <= sz.radius (); ++r)
+        for (const auto& c : L1Ring (centre, r))
+          {
+            const auto old = GetEntry (c);
+            CHECK (old == Entry::NONE)
+                << "Overlapping safe zones at " << c
+                << ", previous value " << static_cast<int> (old);
+
+            size_t ind;
+            unsigned shift;
+            GetPosition (c, ind, shift);
+
+            mutData[ind] |= (val << shift);
+          }
+    }
+}
+
+SafeZones::~SafeZones ()
+{
+  delete[] data;
+}
+
+} // namespace pwd

--- a/mapdata/safezones.hpp
+++ b/mapdata/safezones.hpp
@@ -1,0 +1,111 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MAPDATA_SAFEZONES_HPP
+#define MAPDATA_SAFEZONES_HPP
+
+#include "tiledata.hpp"
+
+#include "database/faction.hpp"
+#include "hexagonal/coord.hpp"
+#include "proto/roconfig.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace pxd
+{
+
+/**
+ * Class that holds a pre-computed map of which tiles are safe zones or
+ * starting areas to allow quick access during path finding and combat.
+ */
+class SafeZones
+{
+
+private:
+
+  /**
+   * The entries stored in our map for each coordinate.  This encodes
+   * all data we need for safe and starter zones, and fits into 4 bits
+   * so that we can store two of each into a single byte in memory.
+   */
+  enum class Entry : uint8_t
+  {
+    NONE = 0,
+    RED = static_cast<unsigned> (Faction::RED),
+    GREEN = static_cast<unsigned> (Faction::GREEN),
+    BLUE = static_cast<unsigned> (Faction::BLUE),
+    NEUTRAL = 4,
+  };
+
+  /** Size of the total data array we need in bytes.  */
+  static constexpr size_t ARRAY_SIZE = (tiledata::numTiles + 1) / 2;
+
+  /**
+   * The array of entries.  Each byte here holds two entries, and in total
+   * they are organised in a row-by-row fashion like DynTiles.  We allocate
+   * it dynamically to avoid issues with stack overflow.
+   */
+  const uint8_t* const data;
+
+  /**
+   * Reads out the entry for the given coordinate.
+   */
+  inline Entry GetEntry (const HexCoord& c) const;
+
+  /**
+   * For a given coordinate, returns the byte-based index into the data array
+   * and the bit shift to apply to get to this coordinate's entry.
+   */
+  static inline void GetPosition (const HexCoord& c,
+                                  size_t& ind, unsigned& shift);
+
+public:
+
+  /**
+   * Constructs an instance based on the zone data from the given RoConfig.
+   * This fills in all the data caches.
+   */
+  explicit SafeZones (const RoConfig& cfg);
+
+  ~SafeZones ();
+
+  SafeZones () = delete;
+  SafeZones (const SafeZones&) = delete;
+  void operator= (const SafeZones&) = delete;
+
+  /**
+   * Returns true if the given coordinate is a no-combat zone.  This is the
+   * case for all factions' starter zones as well as the neutral safe zones.
+   */
+  inline bool IsNoCombat (const HexCoord& c) const;
+
+  /**
+   * Returns the faction for which this is a starter zone, or INVALID if
+   * it is no starter zone.
+   */
+  inline Faction StarterFor (const HexCoord& c) const;
+
+};
+
+} // namespace pwd
+
+#include "safezones.tpp"
+
+#endif // MAPDATA_SAFEZONES_HPP

--- a/mapdata/safezones.tpp
+++ b/mapdata/safezones.tpp
@@ -1,0 +1,82 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Inline code for safezones.hpp.  */
+
+#include "dyntiles.hpp"
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+void
+SafeZones::GetPosition (const HexCoord& c, size_t& ind, unsigned& shift)
+{
+  const size_t fullIndex = dyntiles::GetIndex (c);
+  ind = fullIndex / 2;
+  shift = (fullIndex % 2 == 0 ? 0 : 4);
+}
+
+SafeZones::Entry
+SafeZones::GetEntry (const HexCoord& c) const
+{
+  size_t ind;
+  unsigned shift;
+  GetPosition (c, ind, shift);
+
+  return static_cast<Entry> ((data[ind] >> shift) & 0x0F);
+}
+
+bool
+SafeZones::IsNoCombat (const HexCoord& c) const
+{
+  const Entry e = GetEntry (c);
+  switch (e)
+    {
+    case Entry::NONE:
+      return false;
+    case Entry::RED:
+    case Entry::GREEN:
+    case Entry::BLUE:
+    case Entry::NEUTRAL:
+      return true;
+    default:
+      LOG (FATAL) << "Invalid data entry: " << static_cast<int> (e);
+    }
+}
+
+Faction
+SafeZones::StarterFor (const HexCoord& c) const
+{
+  const Entry e = GetEntry (c);
+  switch (e)
+    {
+    case Entry::NONE:
+    case Entry::NEUTRAL:
+      return Faction::INVALID;
+    case Entry::RED:
+    case Entry::GREEN:
+    case Entry::BLUE:
+      return static_cast<Faction> (e);
+    default:
+      LOG (FATAL) << "Invalid data entry: " << static_cast<int> (e);
+    }
+}
+
+} // namespace pwd

--- a/mapdata/safezones_bench.cpp
+++ b/mapdata/safezones_bench.cpp
@@ -1,0 +1,110 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "safezones.hpp"
+
+#include "benchutils.hpp"
+
+#include "hexagonal/coord.hpp"
+#include "proto/roconfig.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <cstdlib>
+
+namespace pxd
+{
+namespace
+{
+
+/**
+ * Benchmarks construction of the SafeZones instance for the different types
+ * of RoConfig's we have.
+ */
+void
+SafeZonesConstructor (benchmark::State& state, const xaya::Chain chain)
+{
+  const RoConfig cfg(chain);
+  for (auto _ : state)
+    {
+      SafeZones sz(cfg);
+      /* Just the constructor alone does the cache construction and is
+         what we want to benchmark.  */
+    }
+}
+BENCHMARK_CAPTURE (SafeZonesConstructor, main, xaya::Chain::MAIN)
+  ->Unit (benchmark::kMillisecond);
+BENCHMARK_CAPTURE (SafeZonesConstructor, test, xaya::Chain::TEST)
+  ->Unit (benchmark::kMillisecond);
+BENCHMARK_CAPTURE (SafeZonesConstructor, regtest, xaya::Chain::REGTEST)
+  ->Unit (benchmark::kMillisecond);
+
+/**
+ * Benchmarks the IsNoCombat access.  Accepts one argument, which is the number
+ * of coordinates to check in one benchmark run.
+ */
+void
+SafeZonesIsNoCombat (benchmark::State& state)
+{
+  const RoConfig cfg(xaya::Chain::MAIN);
+  const SafeZones sz(cfg);
+  const size_t n = state.range (0);
+
+  std::srand (42);
+  for (auto _ : state)
+    {
+      state.PauseTiming ();
+      const auto coords = RandomCoords (n);
+      state.ResumeTiming ();
+      for (const auto& c : coords)
+        sz.IsNoCombat (c);
+    }
+}
+BENCHMARK (SafeZonesIsNoCombat)
+  ->Unit (benchmark::kMicrosecond)
+  ->Arg (1'000)
+  ->Arg (1'000'000);
+
+/**
+ * Benchmarks the StarterFor access.  Accepts one argument, which is the number
+ * of coordinates to check in one benchmark run.
+ */
+void
+SafeZonesStarterFor (benchmark::State& state)
+{
+  const RoConfig cfg(xaya::Chain::MAIN);
+  const SafeZones sz(cfg);
+  const size_t n = state.range (0);
+
+  std::srand (42);
+  for (auto _ : state)
+    {
+      state.PauseTiming ();
+      const auto coords = RandomCoords (n);
+      state.ResumeTiming ();
+      for (const auto& c : coords)
+        sz.StarterFor (c);
+    }
+}
+BENCHMARK (SafeZonesStarterFor)
+  ->Unit (benchmark::kMicrosecond)
+  ->Arg (1'000)
+  ->Arg (1'000'000);
+
+} // anonymous namespace
+} // namespace pxd

--- a/mapdata/safezones_tests.cpp
+++ b/mapdata/safezones_tests.cpp
@@ -1,0 +1,126 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "safezones.hpp"
+
+#include "tiledata.hpp"
+
+#include "hexagonal/coord.hpp"
+#include "proto/config.pb.h"
+#include "proto/roconfig.hpp"
+
+#include <xayagame/gamelogic.hpp>
+
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+
+namespace pxd
+{
+namespace
+{
+
+/** Coordinate in a neutral safe zone.  */
+const HexCoord NEUTRAL(2'042, 10);
+/** Coordinate in red's starter zone.  */
+const HexCoord RED_START(-2'042, 100);
+/** Coordinate in no safe zone.  */
+const HexCoord NORMAL(2'042, 11);
+
+class SafeZonesTests : public testing::Test
+{
+
+protected:
+
+  const RoConfig cfg;
+  const SafeZones sz;
+
+  SafeZonesTests ()
+    : cfg(xaya::Chain::REGTEST), sz(cfg)
+  {}
+
+};
+
+TEST_F (SafeZonesTests, IsNoCombat)
+{
+  EXPECT_TRUE (sz.IsNoCombat (NEUTRAL));
+  EXPECT_TRUE (sz.IsNoCombat (RED_START));
+  EXPECT_FALSE (sz.IsNoCombat (NORMAL));
+}
+
+TEST_F (SafeZonesTests, StarterFor)
+{
+  EXPECT_EQ (sz.StarterFor (NEUTRAL), Faction::INVALID);
+  EXPECT_EQ (sz.StarterFor (NORMAL), Faction::INVALID);
+  EXPECT_EQ (sz.StarterFor (RED_START), Faction::RED);
+}
+
+/**
+ * Exhaustively check each coordinate against the StarterZones and the
+ * direct roconfig proto data.
+ */
+TEST_F (SafeZonesTests, Exhaustive)
+{
+  using namespace tiledata;
+  for (HexCoord::IntT y = minY; y <= maxY; ++y)
+    {
+      const auto yInd = y - minY;
+      for (HexCoord::IntT x = minX[yInd]; x <= maxX[yInd]; ++x)
+        {
+          const HexCoord c(x, y);
+
+          const proto::SafeZone* zone = nullptr;
+          for (const auto& pb : cfg->safe_zones ())
+            {
+              const HexCoord centre(pb.centre ().x (), pb.centre ().y ());
+              const unsigned dist = HexCoord::DistanceL1 (c, centre);
+              if (dist > pb.radius ())
+                continue;
+
+              ASSERT_EQ (zone, nullptr) << "Overlapping zones at " << c;
+              zone = &pb;
+            }
+
+          ASSERT_EQ (sz.IsNoCombat (c), zone != nullptr);
+
+          std::string zoneFaction;
+          if (zone != nullptr && zone->has_faction ())
+            zoneFaction = zone->faction ();
+
+          const auto f = sz.StarterFor (c);
+          switch (f)
+            {
+            case Faction::RED:
+            case Faction::GREEN:
+            case Faction::BLUE:
+              ASSERT_EQ (zoneFaction, FactionToString (f));
+              break;
+            case Faction::INVALID:
+              ASSERT_EQ (zoneFaction, "");
+              break;
+            default:
+              FAIL ()
+                  << "Unexpected result from StarterFor: "
+                  << static_cast<int> (f);
+              break;
+            }
+        }
+    }
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/mapdata/tiledata.hpp
+++ b/mapdata/tiledata.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -53,7 +53,7 @@ extern const size_t offsetForY[];
  * std::array.  It is only checked against the actual data from the raw
  * map files using static_assert.
  */
-constexpr size_t numTiles = 66080641;
+constexpr size_t numTiles = 66'080'641;
 
 namespace obstacles
 {
@@ -109,6 +109,6 @@ extern const int16_t blob_region_xcoord_end;
 extern const unsigned char blob_region_ids_start;
 extern const unsigned char blob_region_ids_end;
 
-}
+} // extern C
 
 #endif // MAPDATA_TILEDATA_HPP

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -5,6 +5,7 @@ ROCONFIG_TEXT_PROTOS = \
   roconfig/initialbuildings.pb.text \
   roconfig/params.pb.text \
   roconfig/resourcedist.pb.text \
+  roconfig/safezones.pb.text \
   \
   roconfig/items/fitments.pb.text \
   roconfig/items/materials.pb.text \
@@ -23,6 +24,7 @@ ROCONFIG_TEXT_PROTOS = \
 
 ROCONFIG_TEXT_PROTOS_REGTEST = \
   roconfig/test_params.pb.text \
+  roconfig/test_safezones.pb.text \
   roconfig/buildings/test.pb.text \
   roconfig/items/test.pb.text
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -404,6 +404,27 @@ message InitialBuilding
 
 }
 
+/**
+ * Data for a safe zone.  They represent both the general no-combat zones
+ * as well as the faction-specific starter areas.
+ */
+message SafeZone
+{
+
+  /** Centre of the zone.  */
+  optional HexCoord centre = 1;
+
+  /** L1 radius of the zone.  */
+  optional uint32 radius = 2;
+
+  /**
+   * If this is a faction starter zone, the faction as string ("r", "g" or "b").
+   * If this is a general no-combat zone, then the field is unset.
+   */
+  optional string faction = 3;
+
+}
+
 /* ************************************************************************** */
 
 /**
@@ -536,8 +557,11 @@ message ConfigData
   /** Initial buildings (ancient buildings and starter zones).  */
   repeated InitialBuilding initial_buildings = 4;
 
+  /** Safe and starter zones.  */
+  repeated SafeZone safe_zones = 5;
+
   /** Basic parameters.  */
-  optional Params params = 5;
+  optional Params params = 6;
 
   /**
    * The testnet-specific configuration data.  This is merged into the main

--- a/proto/roconfig/safezones.pb.text
+++ b/proto/roconfig/safezones.pb.text
@@ -1,0 +1,24 @@
+# The starter zones are located around the spawns.
+
+safe_zones:
+  {
+    centre: { x: 1993 y: -2636 }
+    radius: 300
+    faction: "r"
+  }
+
+safe_zones:
+  {
+    centre: { x: -3430 y: 1793 }
+    radius: 300
+    faction: "g"
+  }
+
+safe_zones:
+  {
+    centre: { x: 571 y: 2609 }
+    radius: 300
+    faction: "b"
+  }
+
+# TODO: Define the no-combat zones.

--- a/proto/roconfig/test_safezones.pb.text
+++ b/proto/roconfig/test_safezones.pb.text
@@ -1,0 +1,17 @@
+# For testing, we use these additional safe zones which will remain
+# unchanged even if we decide to move around or tweak the safe zones
+# in the main game.
+
+safe_zones:
+  {
+    centre: { x: 2042 y: 0 }
+    radius: 10
+    # Neutral zone (no faction)
+  }
+
+safe_zones:
+  {
+    centre: { x: -2042 y: 100 }
+    radius: 10
+    faction: "r"
+  }

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -290,6 +290,9 @@ private:
     /** RealCharonClient instance this is associated to.  */
     RealCharonClient& parent;
 
+    /** The chain we use to answer requests.  */
+    const xaya::Chain chain;
+
     /** BaseMap for the nonstate server.  */
     const BaseMap map;
 
@@ -416,7 +419,8 @@ const std::map<std::string, RealCharonClient::RpcServer::NonStateMethod>
 RealCharonClient::RpcServer::RpcServer (RealCharonClient& p,
                                         jsonrpc::AbstractServerConnector& conn)
   : jsonrpc::AbstractServer<RpcServer> (conn, jsonrpc::JSONRPC_SERVER_V2),
-    parent(p), nonstate(nullConnector, map, xaya::Chain::MAIN)
+    parent(p),
+    chain(xaya::Chain::MAIN), map(chain), nonstate(nullConnector, map, chain)
 {
   jsonrpc::Procedure stopProc("stop", jsonrpc::PARAMS_BY_POSITION, nullptr);
   bindAndAddNotification (stopProc, &RpcServer::stop);

--- a/src/combat.hpp
+++ b/src/combat.hpp
@@ -63,7 +63,7 @@ public:
 /**
  * Finds combat targets for each fighter entity.
  */
-void FindCombatTargets (Database& db, xaya::Random& rnd);
+void FindCombatTargets (Database& db, xaya::Random& rnd, const Context& ctx);
 
 /**
  * Deals damage from combat and returns the target IDs of all fighters
@@ -71,7 +71,7 @@ void FindCombatTargets (Database& db, xaya::Random& rnd);
  * applies non-damage effects like slowing.
  */
 std::set<TargetKey> DealCombatDamage (Database& db, DamageLists& dl,
-                                      xaya::Random& rnd);
+                                      xaya::Random& rnd, const Context& ctx);
 
 /**
  * Processes killed fighers from the given list, actually performing the

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -103,7 +103,7 @@ UpdateHP (Database& db, xaya::Random& rnd, const Context& ctx)
   DamageLists dl(db, 0);
   GroundLootTable loot(db);
 
-  const auto dead = DealCombatDamage (db, dl, rnd);
+  const auto dead = DealCombatDamage (db, dl, rnd, ctx);
   ProcessKills (db, dl, loot, dead, rnd, ctx);
   RegenerateHP (db);
 }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -23,9 +23,14 @@
 namespace pxd
 {
 
+Context::Context (const xaya::Chain c)
+  : map(nullptr), chain(c),
+    height(0), timestamp(NO_TIMESTAMP)
+{}
+
 Context::Context (const xaya::Chain c, const BaseMap& m,
                   const unsigned h, const int64_t ts)
-  : map(m), chain(c),
+  : map(&m), chain(c),
     params(new pxd::Params (chain)),
     cfg(new pxd::RoConfig (chain)),
     height(h), timestamp(ts)

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -42,7 +42,7 @@ class Context
 private:
 
   /** Reference to the used BaseMap instance.  */
-  const BaseMap& map;
+  const BaseMap* map;
 
   /** The chain we are on.  */
   xaya::Chain chain;
@@ -69,6 +69,12 @@ private:
    */
   int64_t timestamp;
 
+  /**
+   * Constructs an empty instance without setting any stuff yet.  This is
+   * used with ContextForTesting.
+   */
+  explicit Context (xaya::Chain c);
+
   friend class ContextForTesting;
 
 public:
@@ -93,7 +99,7 @@ public:
   const BaseMap&
   Map () const
   {
-    return map;
+    return *map;
   }
 
   const pxd::Params&

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -107,7 +107,7 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
      entering a building won't be attacked any more.  */
   ProcessEnterBuildings (db, dyn, ctx);
 
-  FindCombatTargets (db, rnd);
+  FindCombatTargets (db, rnd, ctx);
 
   /* At the very end of processing this block, clear temporary combat effects
      again.  They only need to be present from when they are applied during

--- a/src/logic.hpp
+++ b/src/logic.hpp
@@ -37,6 +37,7 @@
 #include <sqlite3.h>
 
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace pxd
@@ -87,8 +88,11 @@ class PXLogic : public xaya::SQLiteGame
 
 private:
 
-  /** The underlying base map data.  */
-  const BaseMap map;
+  /**
+   * The underlying base map data.  It is constructed on first access, when
+   * the chain we are connected to is known.
+   */
+  std::unique_ptr<const BaseMap> map;
 
   /**
    * Handles the actual logic for the game-state update.  This is extracted
@@ -159,11 +163,7 @@ public:
    * Gives access to the underlying BaseMap instance (so that it can be reused
    * for other parts of the game like pending processing).
    */
-  const BaseMap&
-  GetBaseMap ()
-  {
-    return map;
-  }
+  const BaseMap& GetBaseMap ();
 
   /**
    * Returns custom game-state data as JSON, with a callback that

--- a/src/movement_tests.cpp
+++ b/src/movement_tests.cpp
@@ -159,6 +159,32 @@ TEST_F (MovementEdgeWeightTests, DynamicObstacle)
              42);
 }
 
+TEST_F (MovementEdgeWeightTests, StarterZones)
+{
+  const HexCoord redStarter(-2'042, 110);
+  const HexCoord outside(-2'042, 111);
+  ASSERT_TRUE (ctx.Map ().IsPassable (redStarter));
+  ASSERT_TRUE (ctx.Map ().IsPassable (outside));
+  ASSERT_EQ (ctx.Map ().SafeZones ().StarterFor (redStarter), Faction::RED);
+  ASSERT_EQ (ctx.Map ().SafeZones ().StarterFor (outside), Faction::INVALID);
+
+  /* Moving out of the starter zone does nothing special.  */
+  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), dyn, Faction::RED,
+                                 redStarter, outside),
+             1'000);
+  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), dyn, Faction::GREEN,
+                                 redStarter, outside),
+             1'000);
+
+  /* Into the starter zone changes the weights.  */
+  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), dyn, Faction::RED,
+                                 outside, redStarter),
+             1'000 / 3);
+  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), dyn, Faction::GREEN,
+                                 outside, redStarter),
+             PathFinder::NO_CONNECTION);
+}
+
 /* ************************************************************************** */
 
 /**

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -188,14 +188,12 @@ TEST_F (FinishProspectingTests, Basic)
 
 TEST_F (FinishProspectingTests, Resources)
 {
-  BaseMap map;
-
   std::map<std::string, unsigned> regionsForResource;
   for (int i = -30; i < 30; ++i)
     for (int j = -30; j < 30; ++j)
       {
         const HexCoord pos(100 * i, 100 * j);
-        if (!map.IsOnMap (pos) || !map.IsPassable (pos))
+        if (!ctx.Map ().IsOnMap (pos) || !ctx.Map ().IsPassable (pos))
           continue;
 
         auto c = characters.CreateNew ("domob", Faction::RED);

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -144,7 +144,7 @@ public:
   explicit PXRpcServer (xaya::Game& g, PXLogic& l,
                         jsonrpc::AbstractServerConnector& conn)
     : PXRpcServerStub(conn), game(g), logic(l),
-      nonstate(nullConnector, logic.map, game.GetChain ())
+      nonstate(nullConnector, logic.GetBaseMap (), game.GetChain ())
   {}
 
   void stop () override;

--- a/src/resourcedist_tests.cpp
+++ b/src/resourcedist_tests.cpp
@@ -21,9 +21,7 @@
 #include "protoutils.hpp"
 #include "testutils.hpp"
 
-#include "mapdata/basemap.hpp"
 #include "mapdata/tiledata.hpp"
-#include "proto/roconfig.hpp"
 
 #include <xayautil/hash.hpp>
 #include <xayautil/uint256.hpp>
@@ -101,6 +99,7 @@ class DetectResourceTests : public testing::Test
 protected:
 
   TestRandom rnd;
+  ContextForTesting ctx;
 
   /**
    * The resource distribution data that we pass to DetectResource.  It is
@@ -115,7 +114,7 @@ protected:
   Inventory::QuantityT amount;
 
   DetectResourceTests ()
-    : rd(RoConfig (xaya::Chain::REGTEST)->resource_dist ())
+    : rd(ctx.RoConfig ()->resource_dist ())
   {}
 
   /**
@@ -309,8 +308,6 @@ TEST_F (DetectResourceTests, DISABLED_AllPassableTiles)
 
   using namespace tiledata;
 
-  BaseMap map;
-
   unsigned all = 0;
   unsigned passable = 0;
   unsigned nothing = 0;
@@ -321,13 +318,13 @@ TEST_F (DetectResourceTests, DISABLED_AllPassableTiles)
       for (HexCoord::IntT x = minX[yInd]; x <= maxX[yInd]; ++x)
         {
           const HexCoord pos(x, y);
-          CHECK (map.IsOnMap (pos));
+          CHECK (ctx.Map ().IsOnMap (pos));
 
           ++all;
           if (all % 1'000'000 == 0)
             LOG (INFO) << "Tile " << all << " / " << numTiles << "...";
 
-          if (!map.IsPassable (pos))
+          if (!ctx.Map ().IsPassable (pos))
             continue;
           ++passable;
 

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -39,6 +39,8 @@ ContextForTesting::SetChain (const xaya::Chain c)
 {
   LOG (INFO) << "Setting context chain to " << xaya::ChainToString (c);
   chain = c;
+  mapInstance = std::make_unique<BaseMap> (chain);
+  map = mapInstance.get ();
   params = std::make_unique<pxd::Params> (chain);
   cfg = std::make_unique<pxd::RoConfig> (chain);
 }

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -52,16 +52,14 @@ class ContextForTesting : public Context
 private:
 
   /** The BaseMap instance used.  */
-  BaseMap map;
+  std::unique_ptr<const BaseMap> mapInstance;
 
 public:
 
   ContextForTesting ()
-    : Context(xaya::Chain::REGTEST, map, 0, NO_TIMESTAMP)
+    : Context(xaya::Chain::REGTEST)
   {
-    /* Note that map will be constructed only after the superclass
-       constructor, which stores a reference to it.  That is fine, though,
-       as it won't be accessed then.  */
+    SetChain (chain);
   }
 
   void SetChain (xaya::Chain c);

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -49,11 +49,6 @@ public:
 class ContextForTesting : public Context
 {
 
-private:
-
-  /** The BaseMap instance used.  */
-  std::unique_ptr<const BaseMap> mapInstance;
-
 public:
 
   ContextForTesting ()


### PR DESCRIPTION
This implements the game logic for safe and starter zones (see #117).  Safe zones are neutral, but characters inside them do not participate in combat (they do not do any target selection / attacks / effects by themselves, are not available as targets for others, and won't be affected by any self-destruct or AoE damage and effects).  Starter zones are associated to a faction; they act as safe zones as well, but in addition are obstacles for all other factions and allow faster movement (by 3x) for the same faction.

This change already contains three starter zones around the spawn locations (with L1 radius 300 each) as well as test zones, but no "mainnet" safe zones.