### PR TITLE
Light fitments data

### DIFF
--- a/gametest/combat_aoe.py
+++ b/gametest/combat_aoe.py
@@ -62,8 +62,8 @@ class CombatAoETest (PXTest):
     self.generate (1)
     self.changeCharacterVehicle ("attacker", "basetank")
 
-    # We set up four potential targets:  Two within the "bomb" range
-    # of 2 (a closer and b further).  Then one within the "missile" area
+    # We set up four potential targets:  Two within the "lf bomb" range
+    # of 3 (a closer and b further).  Then one within the "missile" area
     # around each of those (c for a and d for b).
     self.targetNames = ["a", "b", "c", "d"]
     for nm in self.targetNames:
@@ -71,21 +71,21 @@ class CombatAoETest (PXTest):
       self.createCharacters (nm)
     self.generate (1)
     self.moveCharactersTo ({
-      "a": {"x": 1, "y": 0},
-      "b": {"x": -2, "y": 0},
-      "c": {"x": 1, "y": 2},
-      "d": {"x": -2, "y": -2},
+      "a": {"x": 2, "y": 0},
+      "b": {"x": -3, "y": 0},
+      "c": {"x": 2, "y": 2},
+      "d": {"x": -3, "y": -2},
     })
 
     self.mainLogger.info ("Testing AoE centred on attacker...")
-    self.changeCharacterVehicle ("attacker", "basetank", ["bomb"])
+    self.changeCharacterVehicle ("attacker", "basetank", ["lf bomb"])
     self.resetHP ()
     self.moveCharactersTo ({"attacker": {"x": 0, "y": 0}})
     self.generate (2)
     self.expectDamaged (["a", "b"])
 
     self.mainLogger.info ("Testing AoE centred on target...")
-    self.changeCharacterVehicle ("attacker", "basetank", ["missile"])
+    self.changeCharacterVehicle ("attacker", "basetank", ["lf missile"])
     self.resetHP ()
     self.moveCharactersTo ({"attacker": {"x": 0, "y": 0}})
     self.generate (2)

--- a/gametest/combat_effects.py
+++ b/gametest/combat_effects.py
@@ -38,7 +38,7 @@ class CombatEffectsTest (PXTest):
     self.generate (1)
 
     self.mainLogger.info ("Setting up basic situation...")
-    self.changeCharacterVehicle ("attacker", "basetank", ["retarder"])
+    self.changeCharacterVehicle ("attacker", "basetank", ["lf retarder"])
     self.changeCharacterVehicle ("target", "basetank", [])
     self.changeCharacterVehicle ("friendly", "basetank", [])
     self.moveCharactersTo ({
@@ -54,7 +54,7 @@ class CombatEffectsTest (PXTest):
     self.generate (100)
     c = self.getCharacters ()
     self.assertEqual (c["friendly"].getPosition (), {"x": 50, "y": 0})
-    self.assertEqual (c["target"].getPosition (), {"x": 46, "y": 0})
+    self.assertEqual (c["target"].getPosition (), {"x": 48, "y": 0})
 
 
 if __name__ == "__main__":

--- a/gametest/vehiclefitments.py
+++ b/gametest/vehiclefitments.py
@@ -38,8 +38,8 @@ class VehicleFitmentsTest (PXTest):
     self.generate (1)
     self.dropIntoBuilding (building, "domob", {
       "chariot": 1,
-      "plating": 1,
-      "bomb": 1,
+      "free plating": 1,
+      "lf bomb": 1,
     })
     self.createCharacters ("domob")
     self.generate (1)
@@ -61,11 +61,13 @@ class VehicleFitmentsTest (PXTest):
     self.assertEqual (len (c.data["combat"]["attacks"]), 2)
 
     self.mainLogger.info ("Adding fitments...")
-    self.getCharacters ()["domob"].sendMove ({"fit": ["plating", "bomb"]})
+    self.getCharacters ()["domob"].sendMove ({
+      "fit": ["free plating", "lf bomb"],
+    })
     self.generate (1)
     c = self.getCharacters ()["domob"]
     self.assertEqual (c.data["vehicle"], "chariot")
-    self.assertEqual (c.data["fitments"], ["plating", "bomb"])
+    self.assertEqual (c.data["fitments"], ["free plating", "lf bomb"])
     self.assertEqual (c.data["combat"]["hp"], {
       "current": {"armour": 1100, "shield": 100},
       "max": {"armour": 1100, "shield": 100},

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1,18 +1,41 @@
 fungible_items:
   {
-    key: "bomb"
+    key: "lf retarder"
     value:
       {
         space: 5
-        complexity: 4
+        complexity: 3
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                area: 3
+                effects: { speed: { percent: -15 } }
+              }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf longretard"
+    value:
+      {
+        space: 5
+        complexity: 3
         with_blueprint: true
         fitment:
           {
             slot: "high"
             attack:
               {
+                range: 4
                 area: 2
-                damage: { min: 2 max: 5 }
+                effects: { speed: { percent: -10 } }
               }
           }
       }
@@ -20,20 +43,40 @@ fungible_items:
 
 fungible_items:
   {
-    key: "missile"
+    key: "lf bomb"
     value:
       {
         space: 5
-        complexity: 4
+        complexity: 2
         with_blueprint: true
         fitment:
           {
             slot: "high"
             attack:
               {
-                range: 5
+                area: 3
+                damage: { min: 3 max: 9 }
+              }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf missile"
+    value:
+      {
+        space: 5
+        complexity: 2
+        with_blueprint: true
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 6
                 area: 2
-                damage: { min: 1 max: 3 }
+                damage: { min: 1 max: 5 }
               }
           }
       }
@@ -41,68 +84,11 @@ fungible_items:
 
 fungible_items:
   {
-    key: "retarder"
+    key: "lf pick"
     value:
       {
         space: 5
-        complexity: 4
-        with_blueprint: true
-        fitment:
-          {
-            slot: "high"
-            attack:
-              {
-                area: 5
-                effects: { speed: { percent: -25 } }
-              }
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "longretard"
-    value:
-      {
-        space: 5
-        complexity: 4
-        with_blueprint: true
-        fitment:
-          {
-            slot: "high"
-            attack:
-              {
-                range: 10
-                area: 2
-                effects: { speed: { percent: -25 } }
-              }
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "scanner"
-    value:
-      {
-        space: 5
-        complexity: 4
-        with_blueprint: true
-        fitment:
-          {
-            slot: "high"
-            prospecting_blocks: { percent: -20 }
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "pick"
-    value:
-      {
-        space: 5
-        complexity: 4
+        complexity: 2
         with_blueprint: true
         fitment:
           {
@@ -114,19 +100,36 @@ fungible_items:
 
 fungible_items:
   {
-    key: "selfdestruct"
+    key: "lf scanner"
     value:
       {
-        space: 1
-        complexity: 4
+        space: 5
+        complexity: 2
         with_blueprint: true
         fitment:
           {
             slot: "high"
-            self_destruct:
+            prospecting_blocks: { percent: -20 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf laser"
+    value:
+      {
+        space: 5
+        complexity: 7
+        with_blueprint: true
+        fitment:
+          {
+            slot: "high"
+            attack:
               {
-                area: 10
-                damage: { min: 10 max: 30 }
+                range: 5
+                area: 3
+                damage: { min: 3 max: 3 }
               }
           }
       }
@@ -134,27 +137,82 @@ fungible_items:
 
 fungible_items:
   {
-    key: "expander"
+    key: "lf selfdestruct"
     value:
       {
         space: 1
-        complexity: 4
+        complexity: 5
         with_blueprint: true
         fitment:
           {
-            slot: "low"
-            cargo_space: { percent: 10 }
+            slot: "high"
+            self_destruct:
+              {
+                area: 5
+                damage: { min: 30 max: 50 }
+              }
           }
       }
   }
 
 fungible_items:
   {
-    key: "turbo"
+    key: "lf shield"
     value:
       {
         space: 1
-        complexity: 4
+        complexity: 2
+        with_blueprint: true
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: LIGHT
+            max_shield: { percent: 10 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf replenisher"
+    value:
+      {
+        space: 1
+        complexity: 2
+        with_blueprint: true
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: LIGHT
+            shield_regen: { percent: 15 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf rangeext"
+    value:
+      {
+        space: 1
+        complexity: 2
+        with_blueprint: true
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: LIGHT
+            range: { percent: 10 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf turbo"
+    value:
+      {
+        space: 1
+        complexity: 2
         with_blueprint: true
         fitment:
           {
@@ -166,19 +224,71 @@ fungible_items:
 
 fungible_items:
   {
-    key: "lowhpboost"
+    key: "lf expander"
     value:
       {
         space: 1
-        complexity: 4
+        complexity: 2
         with_blueprint: true
         fitment:
           {
             slot: "low"
+            vehicle_size: LIGHT
+            cargo_space: { percent: 10 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf dmgext"
+    value:
+      {
+        space: 1
+        complexity: 2
+        with_blueprint: true
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: LIGHT
+            damage: { percent: 5 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf multiplier"
+    value:
+      {
+        space: 1
+        complexity: 2
+        with_blueprint: true
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: LIGHT
+            complexity: { percent: 20 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "lf lowhpboost"
+    value:
+      {
+        space: 1
+        complexity: 2
+        with_blueprint: true
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: LIGHT
             low_hp_boost:
               {
                 max_hp_percent: 10
-                damage: { percent: 50 }
+                damage: { percent: 20 }
                 range: { percent: 20 }
               }
           }
@@ -187,96 +297,17 @@ fungible_items:
 
 fungible_items:
   {
-    key: "plating"
+    key: "lf plating"
     value:
       {
         space: 1
-        complexity: 4
+        complexity: 2
         with_blueprint: true
         fitment:
           {
             slot: "low"
+            vehicle_size: LIGHT
             max_armour: { percent: 10 }
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "shield"
-    value:
-      {
-        space: 1
-        complexity: 4
-        with_blueprint: true
-        fitment:
-          {
-            slot: "mid"
-            max_shield: { percent: 10 }
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "replenisher"
-    value:
-      {
-        space: 1
-        complexity: 4
-        with_blueprint: true
-        fitment:
-          {
-            slot: "mid"
-            shield_regen: { percent: 10 }
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "rangeext"
-    value:
-      {
-        space: 1
-        complexity: 4
-        with_blueprint: true
-        fitment:
-          {
-            slot: "mid"
-            range: { percent: 10 }
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "dmgext"
-    value:
-      {
-        space: 1
-        complexity: 4
-        with_blueprint: true
-        fitment:
-          {
-            slot: "low"
-            damage: { percent: 10 }
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "multiplier"
-    value:
-      {
-        space: 1
-        complexity: 1
-        with_blueprint: true
-        fitment:
-          {
-            slot: "low"
-            complexity: { percent: 10 }
           }
       }
   }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -66,6 +66,28 @@ fungible_items:
       }
   }
 
+# Fitments of mid / low slots for testing slot restrictions.
+fungible_items:
+  {
+    key: "mid fitment"
+    value:
+      {
+        space: 1
+        complexity: 1
+        fitment: { slot: "mid" }
+      }
+  }
+fungible_items:
+  {
+    key: "low fitment"
+    value:
+      {
+        space: 1
+        complexity: 1
+        fitment: { slot: "low" }
+      }
+  }
+
 # A size-restricted fitment.
 fungible_items:
   {
@@ -75,6 +97,22 @@ fungible_items:
         space: 1
         complexity: 1
         fitment: { slot: "high" vehicle_size: MEDIUM }
+      }
+  }
+
+# Strong complexity multiplier for testing its effect.
+fungible_items:
+  {
+    key: "super multiplier"
+    value:
+      {
+        space: 1
+        complexity: 1
+        fitment:
+          {
+            slot: "low"
+            complexity: { percent: 200 }
+          }
       }
   }
 
@@ -92,6 +130,23 @@ fungible_items:
           {
             slot: "high"
             prospecting_blocks: { percent: -99 }
+          }
+      }
+  }
+
+# Armour increase (but without size or other restrictions like the normal
+# plating fitments).
+fungible_items:
+  {
+    key: "free plating"
+    value:
+      {
+        space: 1
+        complexity: 1
+        fitment:
+          {
+            slot: "low"
+            max_armour: { percent: 10 }
           }
       }
   }

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1201,41 +1201,38 @@ TEST_F (FitmentMoveTests, InvalidFitments)
 TEST_F (FitmentMoveTests, ValidUpdate)
 {
   SetVehicle ("chariot", {"bow"});
-  GetBuildingInv ()->GetInventory ().AddFungibleCount ("plating", 2);
+  GetBuildingInv ()->GetInventory ().AddFungibleCount ("super scanner", 2);
 
   Process (R"([
     {
       "name": "domob",
-      "move": {"c": {"1": {"fit": ["plating"]}}}
+      "move": {"c": {"1": {"fit": ["super scanner"]}}}
     }
   ])");
 
-  ExpectFitments ({"plating"});
+  ExpectFitments ({"super scanner"});
   auto inv = GetBuildingInv ();
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow"), 1);
-  EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("plating"), 1);
+  EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("super scanner"), 1);
   auto c = GetTest ();
-  EXPECT_EQ (c->GetRegenData ().max_hp ().armour (), 1'100);
-  EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 100);
-  EXPECT_EQ (c->GetHP ().armour (), 1'100);
-  EXPECT_EQ (c->GetHP ().shield (), 100);
+  EXPECT_EQ (c->GetProto ().prospecting_blocks (), 1);
 }
 
 TEST_F (FitmentMoveTests, ExistingFitmentsReused)
 {
-  SetVehicle ("chariot", {"expander", "expander"});
+  SetVehicle ("chariot", {"super scanner", "super scanner"});
   GetBuildingInv ()->GetInventory ().AddFungibleCount ("sword", 1);
 
   Process (R"([
     {
       "name": "domob",
-      "move": {"c": {"1": {"fit": ["sword", "expander"]}}}
+      "move": {"c": {"1": {"fit": ["sword", "super scanner"]}}}
     }
   ])");
 
-  ExpectFitments ({"sword", "expander"});
+  ExpectFitments ({"sword", "super scanner"});
   auto inv = GetBuildingInv ();
-  EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("expander"), 1);
+  EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("super scanner"), 1);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("sword"), 0);
 }
 

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -496,7 +496,7 @@ TEST_F (PendingStateTests, Fitments)
 
   c = characters.CreateNew ("domob", Faction::RED);
   state.AddCharacterFitments (*c, {"sword"});
-  state.AddCharacterFitments (*c, {"bow", "expander"});
+  state.AddCharacterFitments (*c, {"bow", "super scanner"});
 
   c.reset ();
   ExpectStateJson (R"(
@@ -510,7 +510,7 @@ TEST_F (PendingStateTests, Fitments)
             "fitments": []
           },
           {
-            "fitments": ["bow", "expander"]
+            "fitments": ["bow", "super scanner"]
           }
         ]
     }
@@ -1217,7 +1217,7 @@ TEST_F (PendingStateUpdaterTests, Fitments)
   auto inv = buildingInv.Get (bId, "domob");
   inv->GetInventory ().AddFungibleCount ("bow", 2);
   inv->GetInventory ().AddFungibleCount ("sword", 1);
-  inv->GetInventory ().AddFungibleCount ("expander", 1);
+  inv->GetInventory ().AddFungibleCount ("super scanner", 1);
   inv.reset ();
 
   /* Invalid move format, no fitments will be pending.  */
@@ -1237,14 +1237,14 @@ TEST_F (PendingStateUpdaterTests, Fitments)
   Process ("domob", R"({
     "c":
       {
-        "1": {"fit": ["sword", "expander"]}
+        "1": {"fit": ["sword", "super scanner"]}
       }
   })");
   ExpectStateJson (R"(
     {
       "characters":
         [
-          {"fitments": ["sword", "expander"]}
+          {"fitments": ["sword", "super scanner"]}
         ]
     }
   )");
@@ -1261,7 +1261,7 @@ TEST_F (PendingStateUpdaterTests, Fitments)
     {
       "characters":
         [
-          {"fitments": ["sword", "expander"]}
+          {"fitments": ["sword", "super scanner"]}
         ]
     }
   )");


### PR DESCRIPTION
This restructures the roconfig data for fitments to match up with the light fitments from game design (and also needs to unbreak some tests that relied on changed stuff from those fitments).  With this, the light fitments are in properly, except for the construction resources (and of course the fitments not yet implemented at all).  Others (medium / heavy / very heavy) will be added later.