### PR TITLE
Increase item quantity limit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,13 @@ PKG_CONFIG="${PKG_CONFIG} --static"
 PKG_CHECK_MODULES([BENCHMARK], [benchmark])
 PKG_CHECK_MODULES([GFLAGS], [gflags])
 
+# It seems that GMP does not support pkg-config, so we have to check for it
+# and set up the variables manually.
+AC_CHECK_LIB(gmp, __gmpz_init, ,
+  [AC_MSG_ERROR([GNU MP not found, see https://gmplib.org/])])
+AC_SUBST(GMP_CFLAGS, )
+AC_SUBST(GMP_LIBS, -lgmp)
+
 AC_CONFIG_FILES([
   Makefile \
   database/Makefile \

--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -6,12 +6,12 @@ CLEANFILES = schema.cpp
 libdatabase_la_CXXFLAGS = \
   -I$(top_srcdir) \
   $(XAYAGAME_CFLAGS) \
-  $(GLOG_CFLAGS) $(SQLITE3_CFLAGS) $(PROTOBUF_CFLAGS)
+  $(GLOG_CFLAGS) $(SQLITE3_CFLAGS) $(GMP_CFLAGS) $(PROTOBUF_CFLAGS)
 libdatabase_la_LIBADD = \
   $(top_builddir)/hexagonal/libhexagonal.la \
   $(top_builddir)/proto/libpxproto.la \
   $(XAYAGAME_LIBS) \
-  $(GLOG_LIBS) $(SQLITE3_LIBS) $(PROTOBUF_LIBS)
+  $(GLOG_LIBS) $(SQLITE3_LIBS) $(GMP_LIBS) $(PROTOBUF_LIBS)
 libdatabase_la_SOURCES = \
   account.cpp \
   building.cpp \

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -229,14 +229,14 @@ Character::IsBusy () const
 uint64_t
 Character::UsedCargoSpace (const RoConfig& cfg) const
 {
-  uint64_t res = 0;
+  QuantityProduct res;
   for (const auto& entry : inv.GetFungible ())
     {
       const auto& ro = cfg.Item (entry.first);
-      res += Inventory::Product (entry.second, ro.space ());
+      res.AddProduct (entry.second, ro.space ());
     }
 
-  return res;
+  return res.Extract ();
 }
 
 proto::TargetId

--- a/database/inventory.cpp
+++ b/database/inventory.cpp
@@ -202,7 +202,7 @@ void
 Inventory::SetFungibleCount (const std::string& type, const Quantity count)
 {
   CHECK_GE (count, 0);
-  CHECK_LE (count, MAX_ITEM_QUANTITY);
+  CHECK_LE (count, MAX_QUANTITY);
 
   auto& fungible = *Mutable ().mutable_fungible ();
 
@@ -215,8 +215,8 @@ Inventory::SetFungibleCount (const std::string& type, const Quantity count)
 void
 Inventory::AddFungibleCount (const std::string& type, const Quantity count)
 {
-  CHECK_GE (count, -MAX_ITEM_QUANTITY);
-  CHECK_LE (count, MAX_ITEM_QUANTITY);
+  CHECK_GE (count, -MAX_QUANTITY);
+  CHECK_LE (count, MAX_QUANTITY);
 
   /* Instead of getting and then setting the value using the existing methods,
      we could just query the map once and update directly.  But doing so would

--- a/database/inventory.cpp
+++ b/database/inventory.cpp
@@ -25,12 +25,6 @@ namespace pxd
 
 /* ************************************************************************** */
 
-/* Make sure that the product of item quantity and dual value (according to
-   the respective limits) can be computed safely.  */
-static_assert ((MAX_ITEM_QUANTITY * MAX_ITEM_DUAL) / MAX_ITEM_DUAL
-                  == MAX_ITEM_QUANTITY,
-               "item quantity and dual limits overflow multiplication");
-
 namespace
 {
 
@@ -240,18 +234,6 @@ Inventory::operator+= (const Inventory& other)
     AddFungibleCount (entry.first, entry.second);
 
   return *this;
-}
-
-int64_t
-Inventory::Product (const Quantity amount, const int64_t dual)
-{
-  CHECK_GE (amount, -MAX_ITEM_QUANTITY);
-  CHECK_LE (amount, MAX_ITEM_QUANTITY);
-
-  CHECK_GE (dual, -MAX_ITEM_DUAL);
-  CHECK_LE (dual, MAX_ITEM_DUAL);
-
-  return amount * dual;
 }
 
 /* ************************************************************************** */

--- a/database/inventory.hpp
+++ b/database/inventory.hpp
@@ -39,19 +39,19 @@ namespace pxd
 /* ************************************************************************** */
 
 /**
- * The maximum valid value for an item quantity.  If a move contains a number
+ * The maximum valid value for an item quantity or dual value (such as e.g. the
+ * per-unit price in a market order).  If a move contains a number
  * larger than this, it is considered invalid.  This is consensus relevant.
- * Through this limit, we ensure that values are "sane" and avoid potential
- * overflows when working with them.
  *
  * But this is not only applied to moves, but checked in general for any
  * item quantity.  So it should really be the total supply limit of anything
  * in the game.
  *
- * A value of one billion allows multiplication with another value in that
- * range (e.g. cargo per item or price per unit) without overflowing 64 bits.
+ * The value chosen here should be large enough for any practical need.  It is
+ * still significantly below full 64 bits, though, to give us some extra
+ * headway against overflows just in case.
  */
-static constexpr int64_t MAX_ITEM_QUANTITY = 1'000'000'000;
+static constexpr int64_t MAX_QUANTITY = (1ll << 50);
 
 /** Type for the quantity of an item.  */
 using Quantity = int64_t;

--- a/database/inventory.hpp
+++ b/database/inventory.hpp
@@ -53,14 +53,6 @@ namespace pxd
  */
 static constexpr int64_t MAX_ITEM_QUANTITY = 1'000'000'000;
 
-/**
- * The maximum value any "dual variables" for item quantities can have.
- * These are things that are multiplied with them, for instance per-unit
- * value/weight or cost.  By limiting this value, we ensure that the product
- * can always be safely computed in 64 bits.
- */
-static constexpr int64_t MAX_ITEM_DUAL = 1'000'000'000;
-
 /** Type for the quantity of an item.  */
 using Quantity = int64_t;
 
@@ -240,13 +232,6 @@ public:
    * Gives access to the underlying lazy proto for binding purposes.
    */
   const LazyProto<proto::Inventory>& GetProtoForBinding () const;
-
-  /**
-   * Computes the product of a quantity value with a dual value.  Both
-   * must be within the limits, or else the function CHECK-fails.  They may
-   * be signed, though.
-   */
-  static int64_t Product (Quantity amount, int64_t dual);
 
 };
 

--- a/database/inventory_tests.cpp
+++ b/database/inventory_tests.cpp
@@ -209,13 +209,6 @@ TEST_F (InventoryTests, ProtoRef)
   EXPECT_DEATH (ro.AddFungibleCount ("foo", 1), "non-mutable");
 }
 
-TEST_F (InventoryTests, DualProduct)
-{
-  const auto val = Inventory::Product (MAX_ITEM_QUANTITY, -MAX_ITEM_DUAL);
-  EXPECT_EQ (val % MAX_ITEM_DUAL, 0);
-  EXPECT_EQ (val / MAX_ITEM_QUANTITY, -MAX_ITEM_DUAL);
-}
-
 /* ************************************************************************** */
 
 struct CountResult : public Database::ResultType

--- a/database/inventory_tests.cpp
+++ b/database/inventory_tests.cpp
@@ -24,6 +24,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <map>
 
 namespace pxd
@@ -32,6 +33,59 @@ namespace
 {
 
 using google::protobuf::TextFormat;
+
+/* ************************************************************************** */
+
+TEST (QuantityProductTests, Initialisation)
+{
+  EXPECT_EQ (QuantityProduct ().Extract (), 0);
+  EXPECT_EQ (QuantityProduct (1, 0).Extract (), 0);
+  EXPECT_EQ (QuantityProduct (6, 7).Extract (), 42);
+  EXPECT_EQ (QuantityProduct (-5, 4).Extract (), -20);
+  EXPECT_EQ (QuantityProduct (1'000'000'000'000ll, -2).Extract (),
+             -2'000'000'000'000ll);
+}
+
+TEST (QuantityProductTests, AddProduct)
+{
+  QuantityProduct total;
+  total.AddProduct (6, 7);
+  total.AddProduct (-2, 5);
+  total.AddProduct (1'000'000'000, 1'000'000'000);
+  EXPECT_EQ (total.Extract (), 42 - 10 + 1'000'000'000'000'000'000ll);
+}
+
+TEST (QuantityProductTests, Comparison)
+{
+  QuantityProduct pos(10, 10);
+  EXPECT_TRUE (pos <= 100);
+  EXPECT_TRUE (pos <= 1'000'000'000'000);
+  EXPECT_FALSE (pos <= 99);
+  EXPECT_FALSE (pos > 100);
+  EXPECT_TRUE (pos > 99);
+
+  QuantityProduct zero;
+  EXPECT_TRUE (zero <= 0);
+  EXPECT_TRUE (zero <= 100);
+
+  QuantityProduct neg(-1, 1);
+  EXPECT_TRUE (neg <= 0);
+  EXPECT_TRUE (neg <= 100);
+}
+
+TEST (QuantityProductTests, Overflows)
+{
+  QuantityProduct pos(std::numeric_limits<int64_t>::max (),
+                      std::numeric_limits<int64_t>::max ());
+  EXPECT_FALSE (pos <= std::numeric_limits<int64_t>::max ());
+  EXPECT_DEATH (pos.Extract (), "is too large");
+
+  QuantityProduct neg(std::numeric_limits<int64_t>::max (),
+                      -std::numeric_limits<int64_t>::max ());
+  EXPECT_TRUE (neg <= 0);
+  EXPECT_TRUE (neg <= std::numeric_limits<int64_t>::max ());
+  EXPECT_DEATH (neg.Extract (), "is too large");
+}
 
 /* ************************************************************************** */
 

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -558,7 +558,7 @@ namespace
  * Parses a JSON dictionary giving fungible items and their quantities
  * into a std::map.  This will contain all item names and quantities
  * for "valid" entries, i.e. entries with a uint64 value that is within
- * the range (0, MAX_ITEM_QUANTITY].
+ * the range (0, MAX_QUANTITY].
  */
 FungibleAmountMap
 ParseFungibleQuantities (const Context& ctx, const Json::Value& obj)
@@ -587,7 +587,7 @@ ParseFungibleQuantities (const Context& ctx, const Json::Value& obj)
       const Quantity cnt = it->asUInt64 ();
 
       CHECK_GE (cnt, 0);
-      if (cnt == 0 || cnt > MAX_ITEM_QUANTITY)
+      if (cnt == 0 || cnt > MAX_QUANTITY)
         {
           LOG (WARNING)
               << "Invalid fungible amount for item " << key << ": " << cnt;

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1418,8 +1418,10 @@ MoveFungibleBetweenInventories (const Context& ctx,
                                 Inventory& from, Inventory& to,
                                 const std::string& fromName,
                                 const std::string& toName,
-                                int64_t maxSpace = -1)
+                                const int64_t maxSpace = -1)
 {
+  QuantityProduct usedSpace;
+
   for (const auto& entry : items)
     {
       const auto available = from.GetFungibleCount (entry.first);
@@ -1439,20 +1441,22 @@ MoveFungibleBetweenInventories (const Context& ctx,
 
           if (itemSpace > 0)
             {
-              const auto maxForSpace = maxSpace / itemSpace;
+              const auto available = maxSpace - usedSpace.Extract ();
+              CHECK_GE (available, 0);
+              const auto maxForSpace = available / itemSpace;
               if (cnt > maxForSpace)
                 {
                   LOG (WARNING)
                       << "Only moving " << maxForSpace << " of " << entry.first
                       << " instead of " << cnt
-                      << " for lack of space (only " << maxSpace << " free)";
+                      << " for lack of space (only " << available << " free)";
                   cnt = maxForSpace;
                 }
 
-              maxSpace -= Inventory::Product (cnt, itemSpace);
+              usedSpace.AddProduct (cnt, itemSpace);
             }
 
-          CHECK_GE (maxSpace, 0);
+          CHECK (usedSpace <= maxSpace);
         }
 
       /* Avoid making the inventories dirty if we do not move anything.  */
@@ -1467,6 +1471,8 @@ MoveFungibleBetweenInventories (const Context& ctx,
           << " from " << fromName << " to " << toName;
       to.AddFungibleCount (entry.first, cnt);
     }
+
+  CHECK (maxSpace == -1 || usedSpace <= maxSpace);
 }
 
 } // anonymous namespace

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -2061,7 +2061,7 @@ TEST_F (DropPickupMoveTests, InvalidDrop)
     },
     {
       "name": "domob",
-      "move": {"c": {"1": {"drop": {"f": {"foo": 1000000001}}}}}
+      "move": {"c": {"1": {"drop": {"f": {"foo": 10000000000000000}}}}}
     }
   ])");
 
@@ -2092,7 +2092,7 @@ TEST_F (DropPickupMoveTests, InvalidPickUp)
     },
     {
       "name": "domob",
-      "move": {"c": {"1": {"pu": {"f": {"foo": 1000000001}}}}}
+      "move": {"c": {"1": {"pu": {"f": {"foo": 10000000000000000}}}}}
     }
   ])");
 
@@ -3289,7 +3289,7 @@ TEST_F (GodModeTests, InvalidDropLoot)
             },
             {
               "pos": {"x": 1, "y": 2},
-              "fungible": {"foo": 1000000001}
+              "fungible": {"foo": 10000000000000000}
             },
             {
               "fungible": {"foo": 10}
@@ -3332,7 +3332,7 @@ TEST_F (GodModeTests, ValidDropLoot)
             },
             {
               "pos": {"x": 1, "y": 2},
-              "fungible": {"foo": 10, "bar": 1000000000}
+              "fungible": {"foo": 10, "bar": 1000000}
             },
             {
               "building": {"id": 100, "a": "domob"},
@@ -3344,7 +3344,7 @@ TEST_F (GodModeTests, ValidDropLoot)
 
   auto h = loot.GetByCoord (pos);
   EXPECT_EQ (h->GetInventory ().GetFungibleCount ("foo"), 20);
-  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("bar"), MAX_ITEM_QUANTITY);
+  EXPECT_EQ (h->GetInventory ().GetFungibleCount ("bar"), 1'000'000);
   auto i = buildingInv.Get (100, "domob");
   EXPECT_EQ (i->GetInventory ().GetFungibleCount ("foo"), 42);
 }

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -449,7 +449,7 @@ protected:
   Amount
   GetBaseCost () const override
   {
-    return Inventory::Product (num, revEngData->cost ());
+    return QuantityProduct (num, revEngData->cost ()).Extract ();
   }
 
   bool IsValid () const override;
@@ -603,7 +603,7 @@ protected:
   GetBaseCost () const override
   {
     const Amount one = ctx.RoConfig ()->params ().bp_copy_cost () * complexity;
-    return Inventory::Product (num, one);
+    return QuantityProduct (num, one).Extract ();
   }
 
   bool IsValid () const override;
@@ -751,7 +751,7 @@ protected:
   {
     const Amount baseCost = ctx.RoConfig ()->params ().construction_cost ();
     const Amount one = baseCost * outputData->complexity ();
-    return Inventory::Product (num, one);
+    return QuantityProduct (num, one).Extract ();
   }
 
   bool IsValid () const override;
@@ -816,15 +816,15 @@ ConstructionOperation::IsValid () const
   const auto inv = invTable.Get (buildingId, name);
   for (const auto& entry : outputData->construction_resources ())
     {
+      const QuantityProduct required(num, entry.second);
       const auto balance = inv->GetInventory ().GetFungibleCount (entry.first);
-      const auto required = Inventory::Product (num, entry.second);
       if (required > balance)
         {
           LOG (WARNING)
               << "Can't construct " << num << " " << output
               << " as " << name << " in building " << buildingId
               << " has only " << balance << " " << entry.first
-              << " while the construction needs " << required;
+              << " while the construction needs " << required.Extract ();
           return false;
         }
     }
@@ -875,8 +875,8 @@ ConstructionOperation::ExecuteSpecific (xaya::Random& rnd)
   auto& inv = invHandle->GetInventory ();
   for (const auto& entry : outputData->construction_resources ())
     {
-      const auto required = Inventory::Product (num, entry.second);
-      inv.AddFungibleCount (entry.first, -required);
+      const QuantityProduct required(num, entry.second);
+      inv.AddFungibleCount (entry.first, -required.Extract ());
     }
 
   if (fromOriginal)


### PR DESCRIPTION
This implements #130:  Using the [GMP library](https://gmplib.org/), we are able to increase the maximum quantity of any item (e.g. for move parsing and also the assumed total supply limit) to 2^50 from just 1B.  This should be more than enough for any use.