### PR TITLE
Real artefacts (somewhat) and blueprint tweaks

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -7,6 +7,7 @@ ROCONFIG_TEXT_PROTOS = \
   roconfig/resourcedist.pb.text \
   roconfig/safezones.pb.text \
   \
+  roconfig/items/artefacts.pb.text \
   roconfig/items/fitments.pb.text \
   roconfig/items/materials.pb.text \
   roconfig/items/vehicles_others.pb.text \

--- a/proto/roconfig.cpp
+++ b/proto/roconfig.cpp
@@ -180,6 +180,9 @@ constexpr const char* SUFFIX_BP_COPY = " bpc";
 /** Suffix for prize items.  */
 constexpr const char* SUFFIX_PRIZE = " prize";
 
+/** Space usage of a blueprint.  */
+constexpr const unsigned BLUEPRINT_SPACE = 1;
+
 /**
  * Tries to strip the given suffix of an item name.  Returns true and the
  * base name (without suffix) if successful, and false otherwise (i.e. if
@@ -237,7 +240,7 @@ ConstructItemData (const RoConfig& cfg, const std::string& item)
   if (base != nullptr && base->with_blueprint ())
     {
       auto res = std::make_unique<proto::ItemData> ();
-      res->set_space (0);
+      res->set_space (BLUEPRINT_SPACE);
       auto* bp = res->mutable_is_blueprint ();
       bp->set_for_item (baseName);
       bp->set_original (true);
@@ -248,7 +251,7 @@ ConstructItemData (const RoConfig& cfg, const std::string& item)
   if (base != nullptr && base->with_blueprint ())
     {
       auto res = std::make_unique<proto::ItemData> ();
-      res->set_space (0);
+      res->set_space (BLUEPRINT_SPACE);
       auto* bp = res->mutable_is_blueprint ();
       bp->set_for_item (baseName);
       bp->set_original (false);

--- a/proto/roconfig/items/artefacts.pb.text
+++ b/proto/roconfig/items/artefacts.pb.text
@@ -1,0 +1,66 @@
+fungible_items:
+  {
+    key: "art c"
+    value:
+      {
+        space: 1
+        reveng:
+          {
+            cost: 1
+            possible_outputs: "rv s bpo"
+            possible_outputs: "gv s bpo"
+            possible_outputs: "bv s bpo"
+            possible_outputs: "lf retarder bpo"
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "art uc"
+    value:
+      {
+        space: 1
+        reveng:
+          {
+            cost: 1
+            possible_outputs: "rv lt bpo"
+            possible_outputs: "gv lt bpo"
+            possible_outputs: "bv lt bpo"
+            possible_outputs: "hf longretard bpo"
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "art r"
+    value:
+      {
+        space: 1
+        reveng:
+          {
+            cost: 1
+            possible_outputs: "rv ma bpo"
+            possible_outputs: "gv ma bpo"
+            possible_outputs: "bv ma bpo"
+            possible_outputs: "vhf missile bpo"
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "art ur"
+    value:
+      {
+        space: 1
+        reveng:
+          {
+            cost: 1
+            possible_outputs: "rv vla bpo"
+            possible_outputs: "gv vla bpo"
+            possible_outputs: "bv vla bpo"
+          }
+      }
+  }

--- a/proto/roconfig/items/vehicles_others.pb.text
+++ b/proto/roconfig/items/vehicles_others.pb.text
@@ -100,7 +100,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 18750 }
         vehicle:
           {
-            cargo_space: 27600000
+            cargo_space: 0
             speed: 4000
             regen_data:
               {
@@ -454,7 +454,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 18750 }
         vehicle:
           {
-            cargo_space: 27600000
+            cargo_space: 0
             speed: 4000
             regen_data:
               {
@@ -808,7 +808,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 18750 }
         vehicle:
           {
-            cargo_space: 27600000
+            cargo_space: 0
             speed: 4000
             regen_data:
               {

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -133,13 +133,13 @@ TEST_F (RoItemsTests, Blueprints)
 
   const auto& orig = cfg.Item ("bow bpo");
   ASSERT_TRUE (orig.has_is_blueprint ());
-  EXPECT_EQ (orig.space (), 0);
+  EXPECT_EQ (orig.space (), 1);
   EXPECT_EQ (orig.is_blueprint ().for_item (), "bow");
   EXPECT_TRUE (orig.is_blueprint ().original ());
 
   const auto& copy = cfg.Item ("bow bpc");
   ASSERT_TRUE (copy.has_is_blueprint ());
-  EXPECT_EQ (copy.space (), 0);
+  EXPECT_EQ (copy.space (), 1);
   EXPECT_EQ (copy.is_blueprint ().for_item (), "bow");
   EXPECT_FALSE (copy.is_blueprint ().original ());
 }
@@ -157,6 +157,7 @@ TEST_F (RoItemsTests, PrizeItems)
           const auto* itm = cfg.ItemOrNull (p.name () + " prize");
           ASSERT_NE (itm, nullptr) << "Prize item not defined: " << p.name ();
           EXPECT_TRUE (itm->has_prize ()) << "Not a prize: " << p.name ();
+          EXPECT_EQ (itm->space (), 0);
         }
     }
 }


### PR DESCRIPTION
This changes the scout vehicles to have exactly zero cargo space and blueprints to use up one unit - so that scout vehicles cannot be used to transport blueprints (or anything else).  It also adds in the four types of artefacts that will be in the real game (common, uncommon, rare and ultra-rare), although the reveng outputs are not yet complete and just a list of example items / vehicles.