### PR TITLE
Fitments with different shield vs armour damage

### DIFF
--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -99,6 +99,16 @@ message Attack
        chosen uniformly from the both-inclusive range.  */
     optional uint32 min = 1;
     optional uint32 max = 2;
+
+    /**
+     * If this is set, it specifies the factor (as percent) that the attack
+     * does damage to armour specifically.  If not, 100% (no modification)
+     * is assumed.
+     */
+    optional uint32 armour_percent = 3;
+
+    /** The factor (as percent) that this attack does damage to shields.  */
+    optional uint32 shield_percent = 4;
   }
 
   /** If this attack does damage, the stats for it.  */

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1,5 +1,61 @@
 fungible_items:
 {
+    key: "lf beam"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 5
+                    max: 15
+                    armour_percent: 60
+                    shield_percent: 140
+                  }
+              }
+          }
+      }
+  }
+
+fungible_items:
+{
+    key: "lf gun"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 5
+                    max: 15
+                    armour_percent: 140
+                    shield_percent: 60
+                  }
+              }
+          }
+      }
+  }
+
+fungible_items:
+{
     key: "lf retarder"
     value:
 	{


### PR DESCRIPTION
This implements (optional) percentages for attacks, which can specify that the attack is more or less effective against shields and armour (by setting a percentage for each type, by which the "base damage" gets modified).  This is used for the "laser beam" and "rail gun" fitments.