### PR TITLE
Give out artefacts for prospecting

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -83,6 +83,7 @@ ROCONFIG_TEXT_PROTOS = \
 
 ROCONFIG_TEXT_PROTOS_REGTEST = \
   roconfig/test_params.pb.text \
+  roconfig/test_resourcedist.pb.text \
   roconfig/test_safezones.pb.text \
   roconfig/buildings/test.pb.text \
   roconfig/items/test.pb.text

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -382,6 +382,36 @@ message ResourceDistribution
   /** Resource areas.  */
   repeated Area areas = 2;
 
+  /**
+   * Data specifying the artefacts found together with a particular
+   * ore in a region.
+   */
+  message PossibleArtefacts
+  {
+
+    /**
+     * Entry for one artefact with its chance of finding it.
+     */
+    message Entry
+    {
+      /** The artefact's item name.  */
+      optional string artefact = 1;
+      /** The chance as 1 / N.  */
+      optional uint32 probability = 2;
+    }
+
+    /**
+     * Entries for all the artefacts that can be found with a given ore
+     * in a region.  They are checked in order until the end or the first
+     * artefact is discovered.
+     */
+    repeated Entry entries = 1;
+
+  }
+
+  /** The artefacts that can be found with each ore type.  */
+  map<string, PossibleArtefacts> possible_artefacts = 3;
+
 }
 
 /* ************************************************************************** */

--- a/proto/roconfig/resourcedist.pb.text
+++ b/proto/roconfig/resourcedist.pb.text
@@ -1,66 +1,100 @@
-#   GSP for the Taurion blockchain game
-#   Copyright (C) 2019  Autonomous Worlds Ltd
-#
-#   This program is free software: you can redistribute it and/or modify
-#   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation, either version 3 of the License, or
-#   (at your option) any later version.
-#
-#   This program is distributed in the hope that it will be useful,
-#   but WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#   GNU General Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License
-#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 resource_dist:
 {
 
-base_amounts:
+base_amounts: { key: "raw a" value: 7 }
+base_amounts: { key: "raw b" value: 7 }
+base_amounts: { key: "raw c" value: 7 }
+base_amounts: { key: "raw d" value: 7 }
+base_amounts: { key: "raw e" value: 7 }
+base_amounts: { key: "raw f" value: 7 }
+base_amounts: { key: "raw g" value: 7 }
+base_amounts: { key: "raw h" value: 7 }
+base_amounts: { key: "raw i" value: 7 }
+
+possible_artefacts:
   {
     key: "raw a"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+      }
   }
-base_amounts:
+possible_artefacts:
   {
     key: "raw b"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+      }
   }
-base_amounts:
+possible_artefacts:
   {
     key: "raw c"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+        entries: { artefact: "art uc" probability: 50 }
+      }
   }
-base_amounts:
+possible_artefacts:
   {
     key: "raw d"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+        entries: { artefact: "art uc" probability: 50 }
+      }
   }
-base_amounts:
+possible_artefacts:
   {
     key: "raw e"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+        entries: { artefact: "art uc" probability: 50 }
+      }
   }
-base_amounts:
+possible_artefacts:
   {
     key: "raw f"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+        entries: { artefact: "art uc" probability: 50 }
+        entries: { artefact: "art r" probability: 100 }
+      }
   }
-base_amounts:
+possible_artefacts:
   {
     key: "raw g"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+        entries: { artefact: "art uc" probability: 50 }
+        entries: { artefact: "art r" probability: 100 }
+      }
   }
-base_amounts:
+possible_artefacts:
   {
     key: "raw h"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+        entries: { artefact: "art uc" probability: 50 }
+        entries: { artefact: "art r" probability: 100 }
+        entries: { artefact: "art ur" probability: 200 }
+      }
   }
-base_amounts:
+possible_artefacts:
   {
     key: "raw i"
-    value: 7
+    value:
+      {
+        entries: { artefact: "art c" probability: 20 }
+        entries: { artefact: "art uc" probability: 50 }
+        entries: { artefact: "art r" probability: 100 }
+        entries: { artefact: "art ur" probability: 200 }
+      }
   }
 
 areas:

--- a/proto/roconfig/test_resourcedist.pb.text
+++ b/proto/roconfig/test_resourcedist.pb.text
@@ -21,7 +21,7 @@ resource_dist:
 
     possible_artefacts:
       {
-        key: "raw b"
+        key: "raw f"
         value:
           {
             # This allows us to test randomisation (as well as checking

--- a/proto/roconfig/test_resourcedist.pb.text
+++ b/proto/roconfig/test_resourcedist.pb.text
@@ -1,0 +1,34 @@
+resource_dist:
+  {
+
+    # For testing, we overwrite the artefact chances in the base
+    # resource distribution.  This is a proto map, which means that when
+    # merging, later keys (i.e. from here) override previous values (from
+    # the main configuration).
+
+    possible_artefacts:
+      {
+        key: "raw a"
+        value:
+          {
+            # This list allows us to test that we always work through the
+            # checks in order.  We will get art r all the time, and art c
+            # never.
+            entries: { artefact: "art r" probability: 1 }
+            entries: { artefact: "art c" probability: 1 }
+          }
+      }
+
+    possible_artefacts:
+      {
+        key: "raw b"
+        value:
+          {
+            # This allows us to test randomisation (as well as checking
+            # that sometimes nothing is found).
+            entries: { artefact: "art c" probability: 2 }
+            entries: { artefact: "art r" probability: 2 }
+          }
+      }
+
+  }

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -42,7 +42,7 @@ Params::RevEngSuccessChance (const unsigned existingBp) const
     {
     case xaya::Chain::MAIN:
     case xaya::Chain::TEST:
-      base = 2'000;
+      base = 10;
       break;
     case xaya::Chain::REGTEST:
       base = 1;


### PR DESCRIPTION
This implements #140:  When prospecting, artefacts can be found; which ones and the chances for each one depend on what type of resource has been found, e.g. rare artefacts can only be found in regions that also yield rare ores.  If an artefact does not fit into the prospecting character's cargo, it will be dropped on the floor instead.

The data for artefact chances is based on what we want for the competition for now, and will likely need changing for the full game (making it harder to find artefacts).  This also ups the chance of reverse engineering drastically for the competition.