### PR TITLE
Update number of ore found on regions

### DIFF
--- a/proto/config.proto
+++ b/proto/config.proto
@@ -352,18 +352,10 @@ message BuildingData
  *
  * The radii themselves are just constants in the source code.  The proto
  * data in this message holds the more complex things, like the list of
- * areas and the amounts per resource type.
+ * areas and also how the ores correspond to artefacts.
  */
 message ResourceDistribution
 {
-
-  /**
-   * The "base amount" of resource to be found for each resource type in
-   * a region.  These numbers fall off to zero (with a minimum of one unit)
-   * as with the chance.  If we denote the resulting number by X, then the
-   * actual amount found will be uniformly chosen from [X, 2X].
-   */
-  map<string, uint32> base_amounts = 1;
 
   /**
    * One area where resources can be found.
@@ -380,7 +372,7 @@ message ResourceDistribution
   }
 
   /** Resource areas.  */
-  repeated Area areas = 2;
+  repeated Area areas = 1;
 
   /**
    * Data specifying the artefacts found together with a particular
@@ -410,7 +402,7 @@ message ResourceDistribution
   }
 
   /** The artefacts that can be found with each ore type.  */
-  map<string, PossibleArtefacts> possible_artefacts = 3;
+  map<string, PossibleArtefacts> possible_artefacts = 2;
 
 }
 
@@ -538,14 +530,19 @@ message Params
   /** Nubmer of blocks for constructing an item, per complexity.  */
   optional uint32 construction_blocks = 11;
 
+  /** Minimum units of ore found in a prospected region.  */
+  optional int64 min_region_ore = 12;
+  /** Maximum units of ore found in a prospected region.  */
+  optional int64 max_region_ore = 13;
+
   /** The address to which developer payments should be sent.  */
-  optional string dev_addr = 12;
+  optional string dev_addr = 14;
 
   /** Whether or not god mode is enabled.  */
-  optional bool god_mode = 13;
+  optional bool god_mode = 15;
 
   /** Spawn areas for the factions (with the "r", "g", "b" string as key).  */
-  map<string, SpawnArea> spawn_areas = 14;
+  map<string, SpawnArea> spawn_areas = 16;
 
   /**
    * Prospecting prizes.  They are just a list and not a map, because the
@@ -555,7 +552,7 @@ message Params
    * It is replaced rather than concatenated (which would be the default
    * behaviour for proto merge).
    */
-  repeated ProspectingPrize prizes = 15;
+  repeated ProspectingPrize prizes = 17;
 
 }
 

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -15,6 +15,9 @@ params:
     construction_cost: 1
     construction_blocks: 1
 
+    min_region_ore: 2000000
+    max_region_ore: 100000000
+
     # The address configured here (for mainnet) is the premine address of Xaya
     # controlled by the Xaya team.  See also Xaya Core's src/chainparams.cpp.
     dev_addr: "DHy2615XKevE23LVRVZVxGeqxadRGyiFW4"

--- a/proto/roconfig/resourcedist.pb.text
+++ b/proto/roconfig/resourcedist.pb.text
@@ -1,16 +1,6 @@
 resource_dist:
 {
 
-base_amounts: { key: "raw a" value: 7 }
-base_amounts: { key: "raw b" value: 7 }
-base_amounts: { key: "raw c" value: 7 }
-base_amounts: { key: "raw d" value: 7 }
-base_amounts: { key: "raw e" value: 7 }
-base_amounts: { key: "raw f" value: 7 }
-base_amounts: { key: "raw g" value: 7 }
-base_amounts: { key: "raw h" value: 7 }
-base_amounts: { key: "raw i" value: 7 }
-
 possible_artefacts:
   {
     key: "raw a"

--- a/proto/roconfig/test_params.pb.text
+++ b/proto/roconfig/test_params.pb.text
@@ -10,6 +10,11 @@ params:
     construction_cost: 100
     construction_blocks: 10
 
+    # We have tests that use up all materials (and then reprospect a region),
+    # so that we need lower limits than on mainnet.
+    min_region_ore: 10
+    max_region_ore: 20
+
     dev_addr: "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p"
     god_mode: true
 

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -365,12 +365,6 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
         }
     }
 
-  for (const auto& entry : cfg->resource_dist ().base_amounts ())
-    if (!IsRawMaterial (cfg, entry.first))
-      {
-        LOG (WARNING) << "Invalid base amounts in resource dist";
-        return false;
-      }
   for (const auto& area : cfg->resource_dist ().areas ())
     for (const auto& type : area.resources ())
       if (!IsRawMaterial (cfg, type))

--- a/src/prospecting.cpp
+++ b/src/prospecting.cpp
@@ -145,7 +145,7 @@ FinishProspecting (Character& c, Database& db, RegionsTable& regions,
   /* Determine the mine-able resource here.  */
   std::string type;
   Quantity amount;
-  DetectResource (pos, ctx.RoConfig ()->resource_dist (), rnd, type, amount);
+  DetectResource (pos, *ctx.RoConfig (), rnd, type, amount);
   prosp->set_resource (type);
   r->SetResourceLeft (amount);
 

--- a/src/resourcedist.hpp
+++ b/src/resourcedist.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@ namespace pxd
  * Determines the type and initial amount of resource mine-able that should
  * be found by prospecting in the given coordinate.
  */
-void DetectResource (const HexCoord& pos, const proto::ResourceDistribution& rd,
+void DetectResource (const HexCoord& pos, const proto::ConfigData& cfg,
                      xaya::Random& rnd, std::string& type, Quantity& amount);
 
 namespace internal


### PR DESCRIPTION
Instead of specifying a base amount of ore found on a prospected region per type, we just specify a minimum and maximum value to be found (for all types of ore) in the roconfig params.  Rare materials will be rare through fewer regions and less output of refinement rather than through less ores on any region.  (Although the random span of outcomes is now much larger than before with the [X, 2X] system.)

This also updates the numbers to match the new units measured in cm^3, namely to much higher values than before (2M to 100M for now and the upcoming competition).