### PR TITLE
Implement shield-drain effect (syphon fitment)

### DIFF
--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -117,6 +117,14 @@ message Attack
   /** If this attack has non-damage effects, the stats for it.  */
   optional CombatEffects effects = 4;
 
+  /**
+   * If true, then HP drained through this attack's damage will be given
+   * back to the attacker (if any).  This works per HP type, i.e. shield
+   * HP drained are added to the shield (if not full) and armour HP are
+   * added to the armour (if not full).
+   */
+  optional bool gain_hp = 5;
+
 }
 
 /**

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -363,6 +363,61 @@ fungible_items:
       }
   }
 
+fungible_items:
+{
+    key: "lf syphon"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 25000 }
+        construction_resources: { key: "mat b" value: 25000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 3
+                    max: 9
+                    armour_percent: 0
+                  }
+                gain_hp: true
+              }
+          }
+      }
+  }
+
+fungible_items:
+{
+    key: "lf syphonaoe"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 25000 }
+        construction_resources: { key: "mat b" value: 25000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                area: 4
+                damage:
+                  {
+                    min: 1
+                    max: 5
+                    armour_percent: 0
+                  }
+                gain_hp: true
+              }
+          }
+      }
+  }
 
 fungible_items:
 {

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -251,6 +251,18 @@ private:
         return false;
       }
 
+    if (!attack.has_damage () && !attack.has_effects ())
+      {
+        LOG (WARNING) << "Attack has neither damage nor effect";
+        return false;
+      }
+
+    if (attack.gain_hp () && !attack.has_damage ())
+      {
+        LOG (WARNING) << "Attack has gain_hp but no damage";
+        return false;
+      }
+
     return true;
   }
 


### PR DESCRIPTION
This implements a "shield drain" effect in the combat logic, i.e. an attack that damages a target, but then gives back the HP drained to the attacker's shield.  This is used in the new `syphon` fitment as well as the `syphonaoe` (with AoE damage).

The logic is implemented carefully in a way to not introduce any dependence on the order in which attackers are processed.  Gained HP are credited only after all damaging is done, and they in particular don't prevent someone from dying.  Also if the shield of a target is completely drained in a round and more than one attacker were involved, noone gets anything (as that would then raise the question of how it is split).