### PR TITLE
Damage reduction modifier / fitment

### DIFF
--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -167,7 +167,7 @@ message LowHpBoost
 message HP
 {
 
-  /** The "permanent" armour based HP.  */
+  /** The "permanent" armour-based HP.  */
   optional uint32 armour = 1;
 
   /** The regenerating, shield-based HP.  */
@@ -178,7 +178,7 @@ message HP
    * so that the shield is incremented by one when this reaches 1000.
    *
    * This field is only present for the current HP of a fighter, not the
-   * maximum HP in its CombatData.
+   * maximum HP in its RegenData.
    */
   optional uint32 shield_mhp = 3;
 
@@ -217,5 +217,11 @@ message CombatData
 
   /** Any self-destruct attacks this fighter has.  */
   repeated SelfDestruct self_destructs = 3;
+
+  /**
+   * Reduction applied to any damage received (e.g. from the "armour hardener"
+   * upgrade fitment).
+   */
+  optional StatModifier received_damage_modifier = 4;
 
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -183,23 +183,26 @@ message FitmentData
   /** Modification of all attack damages (min and max).  */
   optional StatModifier damage = 10;
 
+  /** Modification to the received damage (e.g. armour hardening).  */
+  optional StatModifier received_damage = 11;
+
   /** Modification to the vehicle's allowed fitment complexity.  */
-  optional StatModifier complexity = 11;
+  optional StatModifier complexity = 12;
 
   /**
    * Modification to the vehicle's prospecting blocks.  Since a larger number
    * of blocks is worse, a fitment will likely have a negative modifier here.
    */
-  optional StatModifier prospecting_blocks = 12;
+  optional StatModifier prospecting_blocks = 13;
 
   /** MOdification to the vehicle's mining rate (min and max).  */
-  optional StatModifier mining_rate = 13;
+  optional StatModifier mining_rate = 14;
 
   /** Low-HP-boost this fitment provides (if any).  */
-  optional LowHpBoost low_hp_boost = 14;
+  optional LowHpBoost low_hp_boost = 15;
 
   /** Self-destruct ability of this fitment (if any).  */
-  optional SelfDestruct self_destruct = 15;
+  optional SelfDestruct self_destruct = 16;
 
 }
 

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1219,6 +1219,26 @@ fungible_items:
 
 fungible_items:
 {
+    key: "lf dmgred"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: LIGHT
+            received_damage: { percent: -5 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "lf dmgext"
     value:
 	{

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -148,6 +148,7 @@ ApplyFitments (Character& c, const Context& ctx)
   StatModifier maxArmour, maxShield;
   StatModifier shieldRegen;
   StatModifier range, damage;
+  StatModifier recvDamage;
 
   auto& pb = c.MutableProto ();
   auto* cd = pb.mutable_combat_data ();
@@ -174,7 +175,13 @@ ApplyFitments (Character& c, const Context& ctx)
       shieldRegen += fitment.shield_regen ();
       range += fitment.range ();
       damage += fitment.damage ();
+      recvDamage += fitment.received_damage ();
     }
+
+  if (recvDamage.IsNeutral ())
+    cd->clear_received_damage_modifier ();
+  else
+    *cd->mutable_received_damage_modifier () = recvDamage.ToProto ();
 
   pb.set_cargo_space (cargo (pb.cargo_space ()));
   pb.set_speed (speed (pb.speed ()));

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -230,6 +230,16 @@ TEST_F (DeriveCharacterStatsTests, RangeDamage)
   EXPECT_EQ (a->area (), 11);
 }
 
+TEST_F (DeriveCharacterStatsTests, ReceivedDamage)
+{
+  auto c = Derive ("chariot", {});
+  EXPECT_FALSE (c->GetProto ().combat_data ().has_received_damage_modifier ());
+
+  c = Derive ("chariot", {"lf dmgred", "lf dmgred"});
+  const auto& cd = c->GetProto ().combat_data ();
+  EXPECT_EQ (cd.received_damage_modifier ().percent (), -10);
+}
+
 TEST_F (DeriveCharacterStatsTests, StackingButNotCompounding)
 {
   auto c = Derive ("chariot", {"lf turbo", "lf turbo", "lf turbo"});

--- a/src/modifier.hpp
+++ b/src/modifier.hpp
@@ -50,6 +50,15 @@ public:
   {}
 
   /**
+   * Returns true if this modifier has no effect.
+   */
+  bool
+  IsNeutral () const
+  {
+    return percent == 0;
+  }
+
+  /**
    * Adds another modifier "on top of" the current one.
    */
   StatModifier&

--- a/src/modifier_tests.cpp
+++ b/src/modifier_tests.cpp
@@ -58,6 +58,16 @@ TEST_F (StatModifierTests, Default)
   EXPECT_EQ (m (1'000), 1'000);
 }
 
+TEST_F (StatModifierTests, IsNeutral)
+{
+  StatModifier m;
+  EXPECT_TRUE (m.IsNeutral ());
+  m += Modifier ("percent: 10");
+  EXPECT_FALSE (m.IsNeutral ());
+  m += Modifier ("percent: -10");
+  EXPECT_TRUE (m.IsNeutral ());
+}
+
 TEST_F (StatModifierTests, Application)
 {
   StatModifier m = Modifier ("percent: 50");


### PR DESCRIPTION
This defines a new fitment property, which will apply a modifier to the damage received by some fighter (e.g. reduce all damage by 10%).  We use it to define the `dmgred` fitment (armour hardener).

Whenever an attack does damage to a fighter, we apply the received damage modifier to the damage before processing it further.  As with all modifiers, the *change* is rounded towards zero, so there is only an effect if the reduction is *at least a full HP*.