### PR TITLE
Armour regeneration

### DIFF
--- a/database/building_tests.cpp
+++ b/database/building_tests.cpp
@@ -132,11 +132,11 @@ TEST_F (BuildingTests, CombatFields)
 
   h = tbl.GetById (id);
   EXPECT_EQ (h->GetHP ().armour (), 10);
-  h->MutableRegenData ().set_shield_regeneration_mhp (42);
+  h->MutableRegenData ().mutable_regeneration_mhp ()->set_shield (42);
   h.reset ();
 
   h = tbl.GetById (id);
-  EXPECT_EQ (h->GetRegenData ().shield_regeneration_mhp (), 42);
+  EXPECT_EQ (h->GetRegenData ().regeneration_mhp ().shield (), 42);
   EXPECT_FALSE (h->HasTarget ());
   proto::TargetId t;
   t.set_id (50);
@@ -210,7 +210,7 @@ TEST_F (BuildingsTableTests, QueryForRegen)
   auto h = tbl.CreateNew ("checkmark", "can regen", Faction::RED);
   h->MutableHP ().set_shield (10);
   h->MutableRegenData ().mutable_max_hp ()->set_shield (100);
-  h->MutableRegenData ().set_shield_regeneration_mhp (1);
+  h->MutableRegenData ().mutable_regeneration_mhp ()->set_shield (1);
   h.reset ();
 
   auto res = tbl.QueryForRegen ();

--- a/database/combat.cpp
+++ b/database/combat.cpp
@@ -109,10 +109,15 @@ bool
 CombatEntity::ComputeCanRegen (const proto::HP& hp,
                                const proto::RegenData& regen)
 {
-  if (regen.shield_regeneration_mhp () == 0)
-    return false;
+  if (regen.regeneration_mhp ().shield () > 0
+        && hp.shield () < regen.max_hp ().shield ())
+    return true;
 
-  return hp.shield () < regen.max_hp ().shield ();
+  if (regen.regeneration_mhp ().armour () > 0
+        && hp.armour () < regen.max_hp ().armour ())
+    return true;
+
+  return false;
 }
 
 HexCoord::IntT

--- a/database/combat_tests.cpp
+++ b/database/combat_tests.cpp
@@ -60,36 +60,50 @@ TEST_F (ComputeCanRegenTests, CanRegenerate)
     shield: 0
   )", R"(
     max_hp: { armour: 10 shield: 10 }
-    shield_regeneration_mhp: 100
+    regeneration_mhp: { shield: 100 }
+  )"));
+
+  EXPECT_TRUE (CanRegen (R"(
+    armour: 0
+    shield: 10
+  )", R"(
+    max_hp: { armour: 10 shield: 10 }
+    regeneration_mhp: { armour: 100 }
   )"));
 }
 
 TEST_F (ComputeCanRegenTests, NoRegeneration)
 {
   EXPECT_FALSE (CanRegen (R"(
-    armour: 10
+    armour: 0
     shield: 0
   )", R"(
     max_hp: { armour: 10 shield: 10 }
-    shield_regeneration_mhp: 0
   )"));
 }
 
-TEST_F (ComputeCanRegenTests, FullShield)
+TEST_F (ComputeCanRegenTests, FullHp)
 {
   EXPECT_FALSE (CanRegen (R"(
     armour: 1
     shield: 10
   )", R"(
     max_hp: { armour: 10 shield: 10 }
-    shield_regeneration_mhp: 100
+    regeneration_mhp: { shield: 100 }
   )"));
   EXPECT_FALSE (CanRegen (R"(
     armour: 1
     shield: 0
   )", R"(
     max_hp: { armour: 10 shield: 0 }
-    shield_regeneration_mhp: 100
+    regeneration_mhp: { shield: 100 }
+  )"));
+  EXPECT_FALSE (CanRegen (R"(
+    armour: 10
+    shield: 1
+  )", R"(
+    max_hp: { armour: 10 shield: 10 }
+    regeneration_mhp: { armour: 100 }
   )"));
 }
 

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -132,14 +132,14 @@ TEST_F (FighterTableTests, ProcessForRegen)
   const auto idChar = c->GetId ();
   c->MutableHP ().set_shield (2);
   c->MutableRegenData ().mutable_max_hp ()->set_shield (10);
-  c->MutableRegenData ().set_shield_regeneration_mhp (1);
+  c->MutableRegenData ().mutable_regeneration_mhp ()->set_shield (1);
   c.reset ();
 
   auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
   const auto idBuilding = b->GetId ();
   b->MutableHP ().set_shield (2);
   b->MutableRegenData ().mutable_max_hp ()->set_shield (10);
-  b->MutableRegenData ().set_shield_regeneration_mhp (1);
+  b->MutableRegenData ().mutable_regeneration_mhp ()->set_shield (1);
   b.reset ();
 
   unsigned cnt = 0;

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -62,7 +62,7 @@ class GodModeTest (PXTest):
             {
               "current": {"armour": 0, "shield": 0},
               "max": {"armour": 0, "shield": 0},
-              "regeneration": 0.0,
+              "regeneration": {"armour": 0.0, "shield": 0.0},
             },
         },
       "inventories": {},
@@ -88,7 +88,7 @@ class GodModeTest (PXTest):
             {
               "current": {"armour": 0, "shield": 0},
               "max": {"armour": 0, "shield": 0},
-              "regeneration": 0.0,
+              "regeneration": {"armour": 0.0, "shield": 0.0},
             },
         },
       "inventories": {},

--- a/gametest/prospecting_basic.py
+++ b/gametest/prospecting_basic.py
@@ -196,7 +196,7 @@ class BasicProspectingTest (PXTest):
     self.createCharacters ("target", 1)
     self.generate (1)
     self.setCharactersHP ({
-      "target": {"a": 1000, "s": 0},
+      "target": {"a": 1000, "ma": 1000, "s": 0, "ms": 100},
     })
     self.moveCharactersTo ({
       "target": self.offset,

--- a/gametest/vehiclefitments.py
+++ b/gametest/vehiclefitments.py
@@ -56,7 +56,7 @@ class VehicleFitmentsTest (PXTest):
     self.assertEqual (c.data["combat"]["hp"], {
       "current": {"armour": 1000, "shield": 100},
       "max": {"armour": 1000, "shield": 100},
-      "regeneration": 0.01,
+      "regeneration": {"armour": 0.0, "shield": 0.01},
     })
     self.assertEqual (len (c.data["combat"]["attacks"]), 2)
 
@@ -71,7 +71,7 @@ class VehicleFitmentsTest (PXTest):
     self.assertEqual (c.data["combat"]["hp"], {
       "current": {"armour": 1100, "shield": 100},
       "max": {"armour": 1100, "shield": 100},
-      "regeneration": 0.01,
+      "regeneration": {"armour": 0.0, "shield": 0.01},
     })
     self.assertEqual (len (c.data["combat"]["attacks"]), 3)
 
@@ -84,7 +84,7 @@ class VehicleFitmentsTest (PXTest):
     self.assertEqual (c.data["combat"]["hp"], {
       "current": {"armour": 1000, "shield": 100},
       "max": {"armour": 1000, "shield": 100},
-      "regeneration": 0.01,
+      "regeneration": {"armour": 0.0, "shield": 0.01},
     })
     self.assertEqual (len (c.data["combat"]["attacks"]), 2)
 

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -174,13 +174,13 @@ message HP
   optional uint32 shield = 2;
 
   /**
-   * Partially regnerated shield HP.  This is in units of 1/1000 HP point,
-   * so that the shield is incremented by one when this reaches 1000.
+   * Partially regenerated HP in 1/1000 HP units.  When it reaches
+   * 1000 for shield or armour, the "actual" HP are incremented accordingly.
    *
    * This field is only present for the current HP of a fighter, not the
    * maximum HP in its RegenData.
    */
-  optional uint32 shield_mhp = 3;
+  optional HP mhp = 3;
 
 }
 
@@ -195,8 +195,8 @@ message RegenData
   /** Maximum HP of the fighter.  */
   optional HP max_hp = 1;
 
-  /** Regeneration rate of shield HP in "milli HP per block".  */
-  optional uint32 shield_regeneration_mhp = 2;
+  /** Regeneration rate of HPs in "milli HP per block".  */
+  optional HP regeneration_mhp = 2;
 
 }
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -177,32 +177,35 @@ message FitmentData
   /** Modification to shield regeneration rate.  */
   optional StatModifier shield_regen = 8;
 
+  /** Modification to armour regeneration rate.  */
+  optional StatModifier armour_regen = 9;
+
   /** Modification of all attack ranges (and AoE area sizes).  */
-  optional StatModifier range = 9;
+  optional StatModifier range = 10;
 
   /** Modification of all attack damages (min and max).  */
-  optional StatModifier damage = 10;
+  optional StatModifier damage = 11;
 
   /** Modification to the received damage (e.g. armour hardening).  */
-  optional StatModifier received_damage = 11;
+  optional StatModifier received_damage = 12;
 
   /** Modification to the vehicle's allowed fitment complexity.  */
-  optional StatModifier complexity = 12;
+  optional StatModifier complexity = 13;
 
   /**
    * Modification to the vehicle's prospecting blocks.  Since a larger number
    * of blocks is worse, a fitment will likely have a negative modifier here.
    */
-  optional StatModifier prospecting_blocks = 13;
+  optional StatModifier prospecting_blocks = 14;
 
   /** MOdification to the vehicle's mining rate (min and max).  */
-  optional StatModifier mining_rate = 14;
+  optional StatModifier mining_rate = 15;
 
   /** Low-HP-boost this fitment provides (if any).  */
-  optional LowHpBoost low_hp_boost = 15;
+  optional LowHpBoost low_hp_boost = 16;
 
   /** Self-destruct ability of this fitment (if any).  */
-  optional SelfDestruct self_destruct = 16;
+  optional SelfDestruct self_destruct = 17;
 
 }
 

--- a/proto/modifier.proto
+++ b/proto/modifier.proto
@@ -33,4 +33,9 @@ message StatModifier
    */
   optional sint32 percent = 1;
 
+  /**
+   * Absolute change to the base value.
+   */
+  optional sint32 absolute = 2;
+
 }

--- a/proto/roconfig/buildings/b_et.pb.text
+++ b/proto/roconfig/buildings/b_et.pb.text
@@ -12,7 +12,6 @@ building_types: {
                 max_hp: {
                     armour: 50 shield: 0
                 }
-                shield_regeneration_mhp: 0
             }
         }
 
@@ -29,7 +28,7 @@ building_types: {
                 max_hp: {
                     armour: 1000 shield: 200
                 }
-                shield_regeneration_mhp: 500
+                regeneration_mhp: { shield: 500 }
             }
         }
 

--- a/proto/roconfig/buildings/b_rt.pb.text
+++ b/proto/roconfig/buildings/b_rt.pb.text
@@ -12,7 +12,6 @@ building_types: {
                 max_hp: {
                     armour: 50 shield: 0
                 }
-                shield_regeneration_mhp: 0
             }
         }
 
@@ -29,7 +28,7 @@ building_types: {
                 max_hp: {
                     armour: 1000 shield: 200
                 }
-                shield_regeneration_mhp: 500
+                regeneration_mhp: { shield: 500 }
             }
         }
 

--- a/proto/roconfig/buildings/g_et.pb.text
+++ b/proto/roconfig/buildings/g_et.pb.text
@@ -12,7 +12,6 @@ building_types: {
                 max_hp: {
                     armour: 50 shield: 0
                 }
-                shield_regeneration_mhp: 0
             }
         }
 
@@ -29,7 +28,7 @@ building_types: {
                 max_hp: {
                     armour: 1000 shield: 200
                 }
-                shield_regeneration_mhp: 500
+                regeneration_mhp: { shield: 500 }
             }
         }
 

--- a/proto/roconfig/buildings/g_rt.pb.text
+++ b/proto/roconfig/buildings/g_rt.pb.text
@@ -12,7 +12,6 @@ building_types: {
                 max_hp: {
                     armour: 50 shield: 0
                 }
-                shield_regeneration_mhp: 0
             }
         }
 
@@ -29,7 +28,7 @@ building_types: {
                 max_hp: {
                     armour: 1000 shield: 200
                 }
-                shield_regeneration_mhp: 500
+                regeneration_mhp: { shield: 500 }
             }
         }
 

--- a/proto/roconfig/buildings/r_et.pb.text
+++ b/proto/roconfig/buildings/r_et.pb.text
@@ -13,7 +13,6 @@ building_types: {
                 max_hp: {
                     armour: 50 shield: 0
                 }
-                shield_regeneration_mhp: 0
             }
         }
 
@@ -30,7 +29,7 @@ building_types: {
                 max_hp: {
                     armour: 1000 shield: 200
                 }
-                shield_regeneration_mhp: 500
+                regeneration_mhp: { shield: 500 }
             }
         }
 

--- a/proto/roconfig/buildings/r_rt.pb.text
+++ b/proto/roconfig/buildings/r_rt.pb.text
@@ -12,7 +12,6 @@ building_types: {
                 max_hp: {
                     armour: 50 shield: 0
                 }
-                shield_regeneration_mhp: 0
             }
         }
 
@@ -29,7 +28,7 @@ building_types: {
                 max_hp: {
                     armour: 1000 shield: 200
                 }
-                shield_regeneration_mhp: 500
+                regeneration_mhp: { shield: 500 }
             }
         }
 

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1419,6 +1419,26 @@ fungible_items:
 
 fungible_items:
 {
+    key: "lf armourregen"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: LIGHT
+            armour_regen: { absolute: 2000 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "lf lowhpboost"
     value:
 	{

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -185,7 +185,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 100 shield: 30 }
-                shield_regeneration_mhp: 500
+                regeneration_mhp: { shield: 500 }
               }
             combat_data:
               {
@@ -219,7 +219,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 1000 shield: 100 }
-                shield_regeneration_mhp: 10
+                regeneration_mhp: { shield: 10 }
               }
             combat_data:
               {
@@ -261,7 +261,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 1000 shield: 100 }
-                shield_regeneration_mhp: 1000
+                regeneration_mhp: { shield: 1000 }
               }
             combat_data: {}
             size: HEAVY

--- a/proto/roconfig/items/vehicles_others.pb.text
+++ b/proto/roconfig/items/vehicles_others.pb.text
@@ -15,7 +15,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 50 }
-                shield_regeneration_mhp: 2000
+                regeneration_mhp: { shield: 2000 }
               }
             mining_rate: { min: 0 max: 4000000 }
             prospecting_blocks: 9
@@ -45,7 +45,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 100 shield: 200 }
-                shield_regeneration_mhp: 5000
+                regeneration_mhp: { shield: 5000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 8
@@ -76,7 +76,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 500 shield: 1000 }
-                shield_regeneration_mhp: 20000
+                regeneration_mhp: { shield: 20000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 7
@@ -105,7 +105,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 10 }
-                shield_regeneration_mhp: 1000
+                regeneration_mhp: { shield: 1000 }
               }
             mining_rate: { min: 0 max: 0 }
             prospecting_blocks: 5
@@ -135,7 +135,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 500 shield: 200 }
-                shield_regeneration_mhp: 4000
+                regeneration_mhp: { shield: 4000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 8
@@ -169,7 +169,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 1000 shield: 300 }
-                shield_regeneration_mhp: 6000
+                regeneration_mhp: { shield: 6000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 7
@@ -205,7 +205,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 2000 shield: 500 }
-                shield_regeneration_mhp: 10000
+                regeneration_mhp: { shield: 10000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 6
@@ -234,7 +234,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 50 shield: 250 }
-                shield_regeneration_mhp: 5000
+                regeneration_mhp: { shield: 5000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 5
@@ -268,7 +268,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 200 shield: 500 }
-                shield_regeneration_mhp: 15000
+                regeneration_mhp: { shield: 15000 }
               }
             mining_rate: { min: 0 max: 10000000 }
             prospecting_blocks: 5
@@ -304,7 +304,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 750 shield: 2500 }
-                shield_regeneration_mhp: 30000
+                regeneration_mhp: { shield: 30000 }
               }
             mining_rate: { min: 0 max: 12000000 }
             prospecting_blocks: 4
@@ -340,7 +340,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 2000 shield: 5000 }
-                shield_regeneration_mhp: 35000
+                regeneration_mhp: { shield: 35000 }
               }
             mining_rate: { min: 0 max: 14000000 }
             prospecting_blocks: 3
@@ -369,7 +369,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 50 }
-                shield_regeneration_mhp: 2000
+                regeneration_mhp: { shield: 2000 }
               }
             mining_rate: { min: 0 max: 4000000 }
             prospecting_blocks: 9
@@ -399,7 +399,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 100 shield: 200 }
-                shield_regeneration_mhp: 5000
+                regeneration_mhp: { shield: 5000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 8
@@ -430,7 +430,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 500 shield: 1000 }
-                shield_regeneration_mhp: 20000
+                regeneration_mhp: { shield: 20000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 7
@@ -459,7 +459,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 10 }
-                shield_regeneration_mhp: 1000
+                regeneration_mhp: { shield: 1000 }
               }
             mining_rate: { min: 0 max: 0 }
             prospecting_blocks: 5
@@ -489,7 +489,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 500 shield: 200 }
-                shield_regeneration_mhp: 4000
+                regeneration_mhp: { shield: 4000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 8
@@ -523,7 +523,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 1000 shield: 300 }
-                shield_regeneration_mhp: 6000
+                regeneration_mhp: { shield: 6000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 7
@@ -559,7 +559,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 2000 shield: 500 }
-                shield_regeneration_mhp: 10000
+                regeneration_mhp: { shield: 10000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 6
@@ -588,7 +588,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 50 shield: 250 }
-                shield_regeneration_mhp: 5000
+                regeneration_mhp: { shield: 5000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 5
@@ -622,7 +622,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 200 shield: 500 }
-                shield_regeneration_mhp: 15000
+                regeneration_mhp: { shield: 15000 }
               }
             mining_rate: { min: 0 max: 10000000 }
             prospecting_blocks: 5
@@ -658,7 +658,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 750 shield: 2500 }
-                shield_regeneration_mhp: 30000
+                regeneration_mhp: { shield: 30000 }
               }
             mining_rate: { min: 0 max: 12000000 }
             prospecting_blocks: 4
@@ -694,7 +694,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 2000 shield: 5000 }
-                shield_regeneration_mhp: 35000
+                regeneration_mhp: { shield: 35000 }
               }
             mining_rate: { min: 0 max: 14000000 }
             prospecting_blocks: 3
@@ -723,7 +723,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 50 }
-                shield_regeneration_mhp: 2000
+                regeneration_mhp: { shield: 2000 }
               }
             mining_rate: { min: 0 max: 4000000 }
             prospecting_blocks: 9
@@ -753,7 +753,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 100 shield: 200 }
-                shield_regeneration_mhp: 5000
+                regeneration_mhp: { shield: 5000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 8
@@ -784,7 +784,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 500 shield: 1000 }
-                shield_regeneration_mhp: 20000
+                regeneration_mhp: { shield: 20000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 7
@@ -813,7 +813,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 10 }
-                shield_regeneration_mhp: 1000
+                regeneration_mhp: { shield: 1000 }
               }
             mining_rate: { min: 0 max: 0 }
             prospecting_blocks: 5
@@ -843,7 +843,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 500 shield: 200 }
-                shield_regeneration_mhp: 4000
+                regeneration_mhp: { shield: 4000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 8
@@ -877,7 +877,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 1000 shield: 300 }
-                shield_regeneration_mhp: 6000
+                regeneration_mhp: { shield: 6000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 7
@@ -913,7 +913,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 2000 shield: 500 }
-                shield_regeneration_mhp: 10000
+                regeneration_mhp: { shield: 10000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 6
@@ -942,7 +942,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 50 shield: 250 }
-                shield_regeneration_mhp: 5000
+                regeneration_mhp: { shield: 5000 }
               }
             mining_rate: { min: 0 max: 8000000 }
             prospecting_blocks: 5
@@ -976,7 +976,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 200 shield: 500 }
-                shield_regeneration_mhp: 15000
+                regeneration_mhp: { shield: 15000 }
               }
             mining_rate: { min: 0 max: 10000000 }
             prospecting_blocks: 5
@@ -1012,7 +1012,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 750 shield: 2500 }
-                shield_regeneration_mhp: 30000
+                regeneration_mhp: { shield: 30000 }
               }
             mining_rate: { min: 0 max: 12000000 }
             prospecting_blocks: 4
@@ -1048,7 +1048,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 2000 shield: 5000 }
-                shield_regeneration_mhp: 35000
+                regeneration_mhp: { shield: 35000 }
               }
             mining_rate: { min: 0 max: 14000000 }
             prospecting_blocks: 3

--- a/proto/roconfig/items/vehicles_starter.pb.text
+++ b/proto/roconfig/items/vehicles_starter.pb.text
@@ -12,7 +12,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 10 }
-                shield_regeneration_mhp: 1000
+                regeneration_mhp: { shield: 1000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 10
@@ -35,7 +35,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 10 }
-                shield_regeneration_mhp: 1000
+                regeneration_mhp: { shield: 1000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 10
@@ -58,7 +58,7 @@ fungible_items:
             regen_data:
               {
                 max_hp: { armour: 20 shield: 10 }
-                shield_regeneration_mhp: 1000
+                regeneration_mhp: { shield: 1000 }
               }
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 10

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -70,7 +70,7 @@ InsertCharacters (Database& db, const unsigned numIdle,
       auto c = tbl.CreateNew ("green", Faction::GREEN);
       const auto id = c->GetId ();
       auto& regen = c->MutableRegenData ();
-      regen.set_shield_regeneration_mhp (1000);
+      regen.mutable_regeneration_mhp ()->set_shield (1'000);
       regen.mutable_max_hp ()->set_armour (targetHP);
       c->MutableHP ().set_armour (targetHP);
       c.reset ();

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -146,7 +146,7 @@ ApplyFitments (Character& c, const Context& ctx)
   StatModifier cargo, speed;
   StatModifier prospecting, mining;
   StatModifier maxArmour, maxShield;
-  StatModifier shieldRegen;
+  StatModifier shieldRegen, armourRegen;
   StatModifier range, damage;
   StatModifier recvDamage;
 
@@ -173,6 +173,7 @@ ApplyFitments (Character& c, const Context& ctx)
       maxArmour += fitment.max_armour ();
       maxShield += fitment.max_shield ();
       shieldRegen += fitment.shield_regen ();
+      armourRegen += fitment.armour_regen ();
       range += fitment.range ();
       damage += fitment.damage ();
       recvDamage += fitment.received_damage ();
@@ -206,8 +207,10 @@ ApplyFitments (Character& c, const Context& ctx)
   auto& regen = c.MutableRegenData ();
   regen.mutable_max_hp ()->set_armour (maxArmour (regen.max_hp ().armour ()));
   regen.mutable_max_hp ()->set_shield (maxShield (regen.max_hp ().shield ()));
-  regen.mutable_regeneration_mhp ()->set_shield (
-      shieldRegen (regen.regeneration_mhp ().shield ()));
+
+  auto* regenMhp = regen.mutable_regeneration_mhp ();
+  regenMhp->set_shield (shieldRegen (regenMhp->shield ()));
+  regenMhp->set_armour (armourRegen (regenMhp->armour ()));
 
   for (auto& a : *cd->mutable_attacks ())
     {

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -206,8 +206,8 @@ ApplyFitments (Character& c, const Context& ctx)
   auto& regen = c.MutableRegenData ();
   regen.mutable_max_hp ()->set_armour (maxArmour (regen.max_hp ().armour ()));
   regen.mutable_max_hp ()->set_shield (maxShield (regen.max_hp ().shield ()));
-  regen.set_shield_regeneration_mhp (
-      shieldRegen (regen.shield_regeneration_mhp ()));
+  regen.mutable_regeneration_mhp ()->set_shield (
+      shieldRegen (regen.regeneration_mhp ().shield ()));
 
   for (auto& a : *cd->mutable_attacks ())
     {

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -214,6 +214,11 @@ TEST_F (DeriveCharacterStatsTests, MaxHpRegen)
 
   c = Derive ("chariot", {"lf replenisher"});
   EXPECT_EQ (c->GetRegenData ().regeneration_mhp ().shield (), 11);
+  EXPECT_EQ (c->GetRegenData ().regeneration_mhp ().armour (), 0);
+
+  c = Derive ("chariot", {"lf armourregen"});
+  EXPECT_EQ (c->GetRegenData ().regeneration_mhp ().shield (), 10);
+  EXPECT_EQ (c->GetRegenData ().regeneration_mhp ().armour (), 2'000);
 }
 
 TEST_F (DeriveCharacterStatsTests, RangeDamage)

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -119,7 +119,8 @@ TEST_F (DeriveCharacterStatsTests, BaseVehicleStats)
   EXPECT_EQ (pb.mining ().rate ().max (), 100);
   EXPECT_EQ (c->GetRegenData ().max_hp ().armour (), 1'000);
   EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 1'00);
-  EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 10);
+  EXPECT_EQ (c->GetRegenData ().regeneration_mhp ().armour (), 0);
+  EXPECT_EQ (c->GetRegenData ().regeneration_mhp ().shield (), 10);
 }
 
 TEST_F (DeriveCharacterStatsTests, ProspectingRate)
@@ -212,7 +213,7 @@ TEST_F (DeriveCharacterStatsTests, MaxHpRegen)
   EXPECT_EQ (c->GetRegenData ().max_hp ().shield (), 110);
 
   c = Derive ("chariot", {"lf replenisher"});
-  EXPECT_EQ (c->GetRegenData ().shield_regeneration_mhp (), 11);
+  EXPECT_EQ (c->GetRegenData ().regeneration_mhp ().shield (), 11);
 }
 
 TEST_F (DeriveCharacterStatsTests, RangeDamage)

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -280,11 +280,12 @@ TEST_F (CharacterJsonTests, HP)
   auto c = tbl.CreateNew ("domob", Faction::RED);
   c->MutableHP ().set_armour (42);
   c->MutableHP ().set_shield (5);
-  c->MutableHP ().set_shield_mhp (1);
+  c->MutableHP ().mutable_mhp ()->set_shield (1);
   auto& regen = c->MutableRegenData ();
   regen.mutable_max_hp ()->set_armour (100);
   regen.mutable_max_hp ()->set_shield (10);
-  regen.set_shield_regeneration_mhp (1001);
+  regen.mutable_regeneration_mhp ()->set_shield (1'001);
+  regen.mutable_regeneration_mhp ()->set_armour (42);
   c.reset ();
 
   ExpectStateJson (R"({
@@ -297,7 +298,7 @@ TEST_F (CharacterJsonTests, HP)
                 {
                   "max": {"armour": 100, "shield": 10},
                   "current": {"armour": 42, "shield": 5.001},
-                  "regeneration": 1.001
+                  "regeneration": {"shield": 1.001, "armour": 0.042}
                 }
             }
         }
@@ -710,9 +711,9 @@ TEST_F (BuildingJsonTests, CombatData)
   att->mutable_damage ()->set_min (1);
   att->mutable_damage ()->set_max (2);
   h->MutableHP ().set_armour (42);
-  h->MutableHP ().set_shield_mhp (1);
+  h->MutableHP ().mutable_mhp ()->set_shield (1);
   auto& regen = h->MutableRegenData ();
-  regen.set_shield_regeneration_mhp (1'001);
+  regen.mutable_regeneration_mhp ()->set_shield (1'001);
   regen.mutable_max_hp ()->set_armour (100);
   regen.mutable_max_hp ()->set_shield (50);
   proto::TargetId t;
@@ -736,7 +737,7 @@ TEST_F (BuildingJsonTests, CombatData)
                 {
                   "max": {"armour": 100, "shield": 50},
                   "current": {"armour": 42, "shield": 0.001},
-                  "regeneration": 1.001
+                  "regeneration": {"shield": 1.001, "armour": 0}
                 },
               "attacks":
                 [

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -355,7 +355,7 @@ TEST_F (PXLogicTests, DamageKillsRegeneration)
   c = characters.GetById (idTarget);
   ASSERT_TRUE (c != nullptr);
   auto& regen = c->MutableRegenData ();
-  regen.set_shield_regeneration_mhp (2000);
+  regen.mutable_regeneration_mhp ()->set_shield (2'000);
   regen.mutable_max_hp ()->set_shield (100);
   c->MutableHP ().set_shield (1);
   c->MutableHP ().set_armour (0);

--- a/src/modifier.cpp
+++ b/src/modifier.cpp
@@ -25,7 +25,12 @@ proto::StatModifier
 StatModifier::ToProto () const
 {
   proto::StatModifier res;
-  res.set_percent (percent);
+
+  if (percent != 0)
+    res.set_percent (percent);
+
+  if (absolute != 0)
+    res.set_absolute (absolute);
 
   return res;
 }


### PR DESCRIPTION
This extends the general game logic to support also regeneration of armour (not just shields), and it adds a new fitment (`armourregen`) that enables armour regeneration (it is the only way to actually get a non-zero regeneration rate).  As previously, this only adds the light variant of the fitment; others will be added with a general data update as part of #142.

Note that this slightly changes also the game-state JSON for characters and buildings.  Instead of just returning the regeneration rate directly, it now returns a JSON-subobject (like the max and current HP) for regeneration of both types of HP.