### PR TITLE
Range reducer fitment

### DIFF
--- a/database/building.hpp
+++ b/database/building.hpp
@@ -39,7 +39,8 @@ struct BuildingResult : public ResultWithFaction, public ResultWithCoord,
   RESULT_COLUMN (int64_t, id, 1);
   RESULT_COLUMN (std::string, type, 2);
   RESULT_COLUMN (std::string, owner, 3);
-  RESULT_COLUMN (pxd::proto::Building, proto, 4);
+  RESULT_COLUMN (pxd::proto::CombatEffects, effects, 4);
+  RESULT_COLUMN (pxd::proto::Building, proto, 5);
 };
 
 /**
@@ -67,6 +68,9 @@ private:
 
   /** The building's centre position.  */
   HexCoord pos;
+
+  /** The combat effects.  */
+  LazyProto<proto::CombatEffects> effects;
 
   /** Generic data stored in the proto BLOB.  */
   LazyProto<proto::Building> data;
@@ -151,6 +155,18 @@ public:
    */
   void SetCentre (const HexCoord& c);
 
+  const proto::CombatEffects&
+  GetEffects () const override
+  {
+    return effects.Get ();
+  }
+
+  proto::CombatEffects&
+  MutableEffects () override
+  {
+    return effects.Mutable ();
+  }
+
   const proto::Building&
   GetProto () const
   {
@@ -176,9 +192,6 @@ public:
   {
     return data.Get ().combat_data ();
   }
-
-  const proto::CombatEffects& GetEffects () const override;
-  proto::CombatEffects& MutableEffects () override;
 
 };
 
@@ -252,6 +265,11 @@ public:
    * Deletes the row for a given building ID.
    */
   void DeleteById (Database::IdT id);
+
+  /**
+   * Clears the "effects" column for all buildings.
+   */
+  void ClearAllEffects ();
 
 };
 

--- a/database/building_tests.cpp
+++ b/database/building_tests.cpp
@@ -152,11 +152,20 @@ TEST_F (BuildingTests, CombatFields)
   EXPECT_FALSE (tbl.GetById (id)->HasTarget ());
 }
 
-TEST_F (BuildingTests, DummyCombatEffects)
+TEST_F (BuildingTests, CombatEffects)
 {
-  auto h = tbl.CreateNew ("checkmark", "andy", Faction::RED);
-  h->MutableEffects ().mutable_speed ()->set_percent (42);
-  EXPECT_FALSE (h->GetEffects ().has_speed ());
+  auto b = tbl.CreateNew ("checkmark", "domob", Faction::RED);
+  const auto id = b->GetId ();
+  EXPECT_FALSE (b->GetEffects ().has_speed ());
+  b.reset ();
+
+  b = tbl.GetById (id);
+  EXPECT_FALSE (b->GetEffects ().has_speed ());
+  b->MutableEffects ().mutable_speed ()->set_percent (42);
+  EXPECT_EQ (b->GetEffects ().speed ().percent (), 42);
+  b.reset ();
+
+  EXPECT_EQ (tbl.GetById (id)->GetEffects ().speed ().percent (), 42);
 }
 
 /* ************************************************************************** */
@@ -256,6 +265,18 @@ TEST_F (BuildingsTableTests, DeleteById)
   auto h = tbl.GetById (id1);
   ASSERT_NE (h, nullptr);
   EXPECT_EQ (h->GetOwner (), "domob");
+}
+
+TEST_F (BuildingsTableTests, ClearAllEffects)
+{
+  auto b = tbl.CreateNew ("checkmark", "domob", Faction::RED);
+  const auto id = b->GetId ();
+  b->MutableEffects ().mutable_speed ()->set_percent (10);
+  b.reset ();
+
+  tbl.ClearAllEffects ();
+
+  EXPECT_FALSE (tbl.GetById (id)->GetEffects ().has_speed ());
 }
 
 /* ************************************************************************** */

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -258,12 +258,6 @@ public:
     return inv;
   }
 
-  bool
-  HasEffects () const
-  {
-    return !effects.IsEmpty ();
-  }
-
   const proto::CombatEffects&
   GetEffects () const override
   {

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -212,22 +212,16 @@ TEST_F (CharacterTests, CombatEffects)
 {
   auto h = tbl.CreateNew ("domob", Faction::RED);
   const auto id = h->GetId ();
-  EXPECT_FALSE (h->HasEffects ());
   EXPECT_FALSE (h->GetEffects ().has_speed ());
   h.reset ();
 
   h = tbl.GetById (id);
-  EXPECT_FALSE (h->HasEffects ());
   EXPECT_FALSE (h->GetEffects ().has_speed ());
   h->MutableEffects ().mutable_speed ()->set_percent (42);
-  EXPECT_TRUE (h->HasEffects ());
   EXPECT_EQ (h->GetEffects ().speed ().percent (), 42);
   h.reset ();
 
-  h = tbl.GetById (id);
-  EXPECT_TRUE (h->HasEffects ());
-  EXPECT_EQ (h->GetEffects ().speed ().percent (), 42);
-  h.reset ();
+  EXPECT_EQ (tbl.GetById (id)->GetEffects ().speed ().percent (), 42);
 }
 
 TEST_F (CharacterTests, AttackRange)
@@ -576,7 +570,6 @@ TEST_F (CharacterTableTests, ClearAllEffects)
 
   c = tbl.GetById (id);
   EXPECT_EQ (c->GetProto ().speed (), 123);
-  EXPECT_FALSE (c->HasEffects ());
   EXPECT_FALSE (c->GetEffects ().has_speed ());
 }
 

--- a/database/combat.hpp
+++ b/database/combat.hpp
@@ -249,16 +249,12 @@ public:
   virtual const proto::CombatData& GetCombatData () const = 0;
 
   /**
-   * Returns the combat effects applied to this entity (or a default
-   * proto if the entity does not support effects, like buildings).
+   * Returns the combat effects applied to this entity.
    */
   virtual const proto::CombatEffects& GetEffects () const = 0;
 
   /**
-   * Returns a mutable reference to the effects proto.  If this entity
-   * does not support effects, this must still return a mutable reference,
-   * but its value is not defined and it may be freely modified without
-   * any effects.
+   * Returns a mutable reference to the effects proto.
    */
   virtual proto::CombatEffects& MutableEffects () = 0;
 

--- a/database/fighter.cpp
+++ b/database/fighter.cpp
@@ -87,4 +87,11 @@ FighterTable::ProcessWithTarget (const Callback& cb)
   }
 }
 
+void
+FighterTable::ClearAllEffects ()
+{
+  buildings.ClearAllEffects ();
+  characters.ClearAllEffects ();
+}
+
 } // namespace pxd

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -89,6 +89,11 @@ public:
    */
   void ProcessWithTarget (const Callback& cb);
 
+  /**
+   * Removes all combat effects in the database.
+   */
+  void ClearAllEffects ();
+
 };
 
 } // namespace pxd

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -213,5 +213,39 @@ TEST_F (FighterTableTests, ProcessWithTarget)
   EXPECT_EQ (cnt, 2);
 }
 
+TEST_F (FighterTableTests, Effects)
+{
+  auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  const auto bId = b->GetId ();
+  b->MutableEffects ().mutable_speed ()->set_percent (10);
+  b.reset ();
+
+  auto c = characters.CreateNew ("domob", Faction::GREEN);
+  const auto cId = c->GetId ();
+  c->MutableEffects ().mutable_speed ()->set_percent (20);
+  c.reset ();
+
+  proto::TargetId targetId;
+  targetId.set_type (proto::TargetId::TYPE_BUILDING);
+  targetId.set_id (bId);
+  auto f = tbl.GetForTarget(targetId);
+  EXPECT_EQ (f->GetEffects ().speed ().percent (), 10);
+
+  targetId.set_type (proto::TargetId::TYPE_CHARACTER);
+  targetId.set_id (cId);
+  f = tbl.GetForTarget(targetId);
+  EXPECT_EQ (f->GetEffects ().speed ().percent (), 20);
+
+  tbl.ClearAllEffects ();
+
+  targetId.set_type (proto::TargetId::TYPE_BUILDING);
+  targetId.set_id (bId);
+  EXPECT_FALSE (tbl.GetForTarget (targetId)->GetEffects ().has_speed ());
+
+  targetId.set_type (proto::TargetId::TYPE_CHARACTER);
+  targetId.set_id (cId);
+  EXPECT_FALSE (tbl.GetForTarget (targetId)->GetEffects ().has_speed ());
+}
+
 } // anonymous namespace
 } // namespace pxd

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -70,7 +70,11 @@ CREATE TABLE IF NOT EXISTS `characters` (
   `target` BLOB NULL,
 
   -- Any combat effects that apply to the character (or NULL if none).
-  -- This is a serialised CombatEffects protocol buffer.
+  -- This is a serialised CombatEffects protocol buffer.  The effects
+  -- are set by the combat damaging phase, and then in effect until
+  -- after the next block's damaging phase (so that e.g. range effects
+  -- stay active through targeting and when that target gets actually
+  -- affected next block).
   `effects` BLOB NULL,
 
   -- Flag indicating if the character is currently moving.  This is set

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -164,6 +164,10 @@ CREATE TABLE IF NOT EXISTS `buildings` (
   -- The attacked target (if any), as a serialised TargetId proto.
   `target` BLOB NULL,
 
+  -- Any combat effects that apply to the building (or NULL if none).
+  -- This is a serialised CombatEffects protocol buffer.
+  `effects` BLOB NULL,
+
   -- The range of the longest attack this building has or NULL if there
   -- is no attack at all.
   `attackrange` INTEGER NULL,
@@ -181,6 +185,7 @@ CREATE INDEX IF NOT EXISTS `buildings_attackrange`
   ON `buildings` (`attackrange`);
 CREATE INDEX IF NOT EXISTS `buildings_canregen` ON `buildings` (`canregen`);
 CREATE INDEX IF NOT EXISTS `buildings_target` ON `buildings` (`target`);
+CREATE INDEX IF NOT EXISTS `buildings_effects` ON `buildings` (`effects`);
 
 -- =============================================================================
 

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -61,6 +61,9 @@ message CombatEffects
   /** Modification to the speed.  */
   optional StatModifier speed = 1;
 
+  /** Modification to the range.  */
+  optional StatModifier range = 2;
+
 }
 
 /**

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -953,6 +953,30 @@ fungible_items:
 
 fungible_items:
 {
+    key: "lf rangered"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "high"
+            vehicle_size: LIGHT
+            attack:
+              {
+                area: 3
+                effects: { range: { percent: -15 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "lf rangeext"
     value:
 	{

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -87,6 +87,8 @@ ComputeModifier (const CombatEntity& f, CombatModifier& mod)
       mod.damage += b.damage ();
       mod.range += b.range ();
     }
+
+  mod.range += f.GetEffects ().range ();
 }
 
 } // anonymous namespace
@@ -523,6 +525,8 @@ DamageProcessor::ApplyEffects (const proto::Attack& attack,
 
   if (attackEffects.has_speed ())
     *targetEffects.mutable_speed () += attackEffects.speed ();
+  if (attackEffects.has_range ())
+    *targetEffects.mutable_range () += attackEffects.range ();
 }
 
 void

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -65,10 +65,11 @@ struct CombatModifier
 };
 
 /**
- * Computes the low-HP boosts to damage and range for the given entity.
+ * Computes the modifier to apply for a given entity (composed of low-HP boosts
+ * and effects).
  */
 void
-ComputeLowHpBoosts (const CombatEntity& f, CombatModifier& mod)
+ComputeModifier (const CombatEntity& f, CombatModifier& mod)
 {
   mod.damage = StatModifier ();
   mod.range = StatModifier ();
@@ -136,10 +137,12 @@ SelectTarget (TargetFinder& targets, xaya::Random& rnd, const Context& ctx,
     }
   CHECK_GE (range, 0);
 
-  /* Apply the low-HP boost to range (if any).  */
-  CombatModifier lowHpMod;
-  ComputeLowHpBoosts (*f, lowHpMod);
-  range = lowHpMod.range (range);
+  /* Apply the modifier to range (if any).  */
+  {
+    CombatModifier mod;
+    ComputeModifier (*f, mod);
+    range = mod.range (range);
+  }
 
   HexCoord::IntT closestRange;
   std::vector<proto::TargetId> closestTargets;
@@ -227,9 +230,20 @@ private:
   /**
    * Modifiers to combat stats for all fighters that will deal damage.  This
    * is filled in (e.g. from their low-HP boosts) before actual damaging starts,
-   * and is used to make the damaging independent of processing order.
+   * and is used to make the damaging independent of processing order.  This is
+   * especially important so that HP changes do not influence low-HP boosts.
    */
   std::map<TargetKey, CombatModifier> modifiers;
+
+  /**
+   * Combat effects that are being applied by this round of damage to
+   * the given targets.  This is accumulated here so that the original
+   * effects are unaffected, and only later written back to the fighters
+   * after all damaging is done.  This ensures that we do not take current
+   * changes into effect right now in a messy way, e.g. for self-destruct
+   * rounds (which do not rely on "modifiers" but recompute them).
+   */
+  std::map<TargetKey, proto::CombatEffects> newEffects;
 
   /**
    * For each target that was attacked with a gain_hp attack, we store all
@@ -284,9 +298,10 @@ private:
                     CombatEntity& target, std::set<TargetKey>& newDead);
 
   /**
-   * Applies combat effects (non-damage) to a target.
+   * Applies combat effects (non-damage) to a target.  They are not saved
+   * directly to the target for now, but accumulated in newEffects.
    */
-  void ApplyEffects (const proto::Attack& attack, CombatEntity& target) const;
+  void ApplyEffects (const proto::Attack& attack, const CombatEntity& target);
 
   /**
    * Deals damage for one fighter with a target to the respective target
@@ -493,7 +508,7 @@ DamageProcessor::ApplyDamage (const unsigned dmg, const CombatEntity& attacker,
 
 void
 DamageProcessor::ApplyEffects (const proto::Attack& attack,
-                               CombatEntity& target) const
+                               const CombatEntity& target)
 {
   CHECK (!ctx.Map ().SafeZones ().IsNoCombat (target.GetCombatPosition ()));
 
@@ -503,11 +518,11 @@ DamageProcessor::ApplyEffects (const proto::Attack& attack,
   const auto targetId = target.GetIdAsTarget ();
   VLOG (1) << "Applying combat effects to " << targetId.DebugString ();
 
-  const auto& effects = attack.effects ();
-  auto& pb = target.MutableEffects ();
+  const auto& attackEffects = attack.effects ();
+  auto& targetEffects = newEffects[targetId];
 
-  if (effects.has_speed ())
-    *pb.mutable_speed () += effects.speed ();
+  if (attackEffects.has_speed ())
+    *targetEffects.mutable_speed () += attackEffects.speed ();
 }
 
 void
@@ -586,7 +601,7 @@ DamageProcessor::ProcessSelfDestructs (FighterTable::Handle f,
   CHECK_EQ (f->GetHP ().armour (), 0);
   CHECK_EQ (f->GetHP ().shield (), 0);
   CombatModifier mod;
-  ComputeLowHpBoosts (*f, mod);
+  ComputeModifier (*f, mod);
 
   for (const auto& sd : f->GetCombatData ().self_destructs ())
     {
@@ -619,7 +634,7 @@ DamageProcessor::Process ()
   fighters.ProcessWithTarget ([&] (FighterTable::Handle f)
     {
       CombatModifier mod;
-      ComputeLowHpBoosts (*f, mod);
+      ComputeModifier (*f, mod);
       CHECK (modifiers.emplace (f->GetIdAsTarget (), std::move (mod)).second);
     });
 
@@ -729,6 +744,21 @@ DamageProcessor::Process ()
                                maxHp.armour ()));
       hp.set_shield (std::min (hp.shield () + entry.second.shield (),
                                maxHp.shield ()));
+    }
+
+  /* Update combat effects on fighters (clear all previous effects in the
+     database, and put back in those that are accumulated in newEffects).
+
+     Conceptually, target finding, waiting for the new block, and then
+     applying damaging is "one thing".  Swapping over the effects is done
+     here, so it is right after that whole "combat block" for the rest
+     of processing (e.g. movement or regeneration) and also the next
+     combat block.  */
+  characters.ClearAllEffects ();
+  for (auto& entry : newEffects)
+    {
+      auto f = fighters.GetForTarget (entry.first.ToProto ());
+      f->MutableEffects () = std::move (entry.second);
     }
 }
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -754,7 +754,7 @@ DamageProcessor::Process ()
      here, so it is right after that whole "combat block" for the rest
      of processing (e.g. movement or regeneration) and also the next
      combat block.  */
-  characters.ClearAllEffects ();
+  fighters.ClearAllEffects ();
   for (auto& entry : newEffects)
     {
       auto f = fighters.GetForTarget (entry.first.ToProto ());

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -471,6 +471,27 @@ TEST_F (TargetSelectionTests, LowHpBoost)
   EXPECT_EQ (characters.GetById (idArea)->GetTarget ().id (), idNormal);
 }
 
+TEST_F (TargetSelectionTests, CombatEffect)
+{
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  const auto id1 = c->GetId ();
+  c->SetPosition (HexCoord (0, 0));
+  c->MutableEffects ().mutable_range ()->set_percent (-10);
+  AddAttack (*c).set_range (10);
+  c.reset ();
+
+  c = characters.CreateNew ("andy", Faction::GREEN);
+  const auto id2 = c->GetId ();
+  c->SetPosition (HexCoord (10, 0));
+  c->MutableEffects ().mutable_range ()->set_percent (100);
+  AddAttack (*c).set_range (5);
+  c.reset ();
+
+  FindCombatTargets (db, rnd, ctx);
+  EXPECT_FALSE (characters.GetById (id1)->HasTarget ());
+  EXPECT_EQ (characters.GetById (id2)->GetTarget ().id (), id1);
+}
+
 /* ************************************************************************** */
 
 class DealDamageTests : public CombatTests
@@ -702,6 +723,44 @@ TEST_F (DealDamageTests, ReceivedDamageModifier)
   EXPECT_EQ (c->GetHP ().armour (), 92);
 }
 
+TEST_F (DealDamageTests, ModifiedRange)
+{
+  /* The original range modifier should be used for the range, area
+     and area around target, even if another attack in the same round
+     applies a different range modifier.  */
+
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  c->MutableEffects ().mutable_range ()->set_percent (200);
+  AddAttack (*c, 5, 1, 1);
+  AddAreaAttack (*c, 2, 1, 1).set_range (5);
+  c.reset ();
+
+  c = characters.CreateNew ("target", Faction::GREEN);
+  const auto idTarget1 = c->GetId ();
+  c->SetPosition (HexCoord (10, 0));
+  SetHp (*c, 0, 100, 0, 100);
+  auto& attack = CombatTests::AddAttack (*c);
+  attack.set_area (10);
+  attack.mutable_effects ()->mutable_speed ()->set_percent (-50);
+  c.reset ();
+
+  c = characters.CreateNew ("target", Faction::GREEN);
+  const auto idTarget2 = c->GetId ();
+  c->SetPosition (HexCoord (14, 0));
+  SetHp (*c, 0, 100, 0, 100);
+  NoAttacks (*c);
+  c.reset ();
+
+  FindTargetsAndDamage ();
+  EXPECT_EQ (characters.GetById (idTarget1)->GetHP ().armour (), 98);
+  EXPECT_EQ (characters.GetById (idTarget2)->GetHP ().armour (), 99);
+
+  /* Now the changed range modifier should take effect.  */
+  FindTargetsAndDamage ();
+  EXPECT_EQ (characters.GetById (idTarget1)->GetHP ().armour (), 98);
+  EXPECT_EQ (characters.GetById (idTarget2)->GetHP ().armour (), 99);
+}
+
 TEST_F (DealDamageTests, SafeZone)
 {
   /* One attacker has both area and normal attacks and also a slowing effect.
@@ -902,9 +961,13 @@ TEST_F (DealDamageTests, Effects)
 {
   auto c = characters.CreateNew ("red", Faction::RED);
   AddAttack (*c, 5, 1, 1);
-  auto& attack = CombatTests::AddAttack (*c);
-  attack.set_range (5);
-  attack.mutable_effects ()->mutable_speed ()->set_percent (-10);
+  for (unsigned i = 0; i < 2; ++i)
+    {
+      auto& attack = CombatTests::AddAttack (*c);
+      attack.set_range (5);
+      attack.mutable_effects ()->mutable_speed ()->set_percent (-10);
+      attack.mutable_effects ()->mutable_range ()->set_percent (-15);
+    }
   c.reset ();
 
   c = characters.CreateNew ("green", Faction::GREEN);
@@ -918,7 +981,8 @@ TEST_F (DealDamageTests, Effects)
   FindTargetsAndDamage ();
 
   c = characters.GetById (idTarget);
-  EXPECT_EQ (c->GetEffects ().speed ().percent (), -10);
+  EXPECT_EQ (c->GetEffects ().speed ().percent (), -20);
+  EXPECT_EQ (c->GetEffects ().range ().percent (), -30);
 }
 
 TEST_F (DealDamageTests, EffectsAndDamageApplied)
@@ -1327,6 +1391,35 @@ TEST_F (SelfDestructTests, StackingAndLowHpBoost)
     TargetKey (proto::TargetId::TYPE_CHARACTER, idDestructed)
   ));
   EXPECT_EQ (characters.GetById (idAttacker)->GetHP ().armour (), 100 - 24);
+}
+
+TEST_F (SelfDestructTests, CombatEffects)
+{
+  /* The original combat effects (e.g. range modifier) will be taken into
+     account also for self-destructs, even if the effects are changed
+     by an attack in the current round.  */
+
+  auto c = characters.CreateNew ("red", Faction::RED);
+  const auto idAttacker = c->GetId ();
+  SetHp (*c, 0, 100, 0, 100);
+  AddAttack (*c, 100, 1, 1);
+  auto& attack = CombatTests::AddAttack (*c);
+  attack.set_area (100);
+  attack.mutable_effects ()->mutable_range ()->set_percent (-50);
+  c.reset ();
+
+  c = characters.CreateNew ("green", Faction::GREEN);
+  const auto idDestructed = c->GetId ();
+  c->SetPosition (HexCoord (10, 0));
+  c->MutableEffects ().mutable_range ()->set_percent (200);
+  SetHp (*c, 0, 1, 0, 1);
+  AddSelfDestruct (*c, 5, 10);
+  c.reset ();
+
+  EXPECT_THAT (FindTargetsAndDamage (), ElementsAre (
+    TargetKey (proto::TargetId::TYPE_CHARACTER, idDestructed)
+  ));
+  EXPECT_EQ (characters.GetById (idAttacker)->GetHP ().armour (), 90);
 }
 
 TEST_F (SelfDestructTests, Chain)

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -109,13 +109,6 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
 
   FindCombatTargets (db, rnd, ctx);
 
-  /* At the very end of processing this block, clear temporary combat effects
-     again.  They only need to be present from when they are applied during
-     combat damage until all other processing based on stats (including
-     targeting) has been done.  There is no need to persist them in the
-     actual game state between blocks.  */
-  CharacterTable (db).ClearAllEffects ();
-
 #ifdef ENABLE_SLOW_ASSERTS
   ValidateStateSlow (db, ctx);
 #endif // ENABLE_SLOW_ASSERTS


### PR DESCRIPTION
This adds a new fitment, `rangered`, which reduces the range of enemies in an AoE.  Range reduction works by applying the effect in the block *after* targeting someone.  So at the end of block N, Alice may target Bob with her range reducer, which is then shown as "disrupting" Bob's systems in the frontend while waiting for block N+1.  Then at the beginning of block N+1, Bob's range gets actually reduced by Alice's attack, although Bob's attacks are still done normally.  But when targeting happens at the end of block N+1 (and then while dealing damage at block N+2), Bob's range is reduced accordingly.

To make this work, we change the way effects are computed and updated:  Instead of applying them during damaging directly and then clearing them at the end of the block, we compute a set of "new" effects during damaging, and then atomically replace all effects with the new effects between damaging and regeneration.  This ensures that even effects that affect attacks themselves (like the range reduction) are processed in a way that has no weird order dependencies.

For now, only the `lf` variant of the range reducer is defined as fitment.  Other variants will be added with a general data update as per #142.