### PR TITLE
Mobile refinery

### DIFF
--- a/proto/character.proto
+++ b/proto/character.proto
@@ -19,6 +19,7 @@
 syntax = "proto2";
 
 import "proto/combat.proto";
+import "proto/modifier.proto";
 import "proto/movement.proto";
 
 package pxd.proto;
@@ -49,6 +50,22 @@ message MiningData
 
   /** Set to true if the character is currently mining.  */
   optional bool active = 2;
+
+}
+
+/**
+ * Data about mobile refining capabilities of a character.
+ */
+message MobileRefinery
+{
+
+  /**
+   * The "inefficiency factor" of mobile refining.  Refining in a mobile
+   * refinery costs the same vCHI fee and produces the same outputs as a
+   * normal refining step, but uses up more input ore per step.  This is
+   * specified by the modifier here.
+   */
+  optional StatModifier input = 1;
 
 }
 
@@ -97,6 +114,12 @@ message Character
 
   /** Total cargo space the character has.  */
   optional uint64 cargo_space = 9;
+
+  /**
+   * If this is set, the character can do mobile refining (and the stats for
+   * it are given here).
+   */
+  optional MobileRefinery refining = 10;
 
   /* Fields that are stored directly in the database and thus not part of the
      encoded protocol buffer:

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -207,6 +207,9 @@ message FitmentData
   /** Self-destruct ability of this fitment (if any).  */
   optional SelfDestruct self_destruct = 17;
 
+  /** If this is a mobile refinery, the stats for it.  */
+  optional MobileRefinery refining = 18;
+
 }
 
 /**

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1661,3 +1661,27 @@ fungible_items:
   }
 
 
+fungible_items:
+{
+    key: "vhf refinery"
+    value:
+	{
+        space: 1000
+        complexity: 2000
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "low"
+            refining: { input: { percent: 100 } }
+          }
+      }
+  }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -24,7 +24,7 @@ fungible_items:
     key: "test ore"
     value:
       {
-        space: 10
+        space: 15
         refines:
           {
             input_units: 3

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -252,7 +252,7 @@ fungible_items:
     value:
       {
         space: 50
-        complexity: 100
+        complexity: 10000
         with_blueprint: true
         vehicle:
           {

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -297,10 +297,26 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
           return false;
         }
 
-      if (!IsValidMaterialMap (cfg, i.refines ().outputs ()))
+      if (i.has_refines ())
         {
-          LOG (WARNING) << "Refines-to data is invalid for " << entry.first;
-          return false;
+          const auto& ref = i.refines ();
+          if (!IsValidMaterialMap (cfg, ref.outputs ()))
+            {
+              LOG (WARNING) << "Refines-to data is invalid for " << entry.first;
+              return false;
+            }
+
+          const unsigned inputSpace = ref.input_units () * i.space ();
+          unsigned outputSpace = 0;
+          for (const auto& out : ref.outputs ())
+            outputSpace += out.second * cfg.Item (out.first).space ();
+          if (outputSpace >= inputSpace)
+            {
+              LOG (WARNING)
+                  << "Refining " << entry.first
+                  << " does not reduce cargo space";
+              return false;
+            }
         }
 
       if (i.has_is_blueprint ())

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -374,6 +374,16 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
               << " does not specify a valid attack";
           return false;
         }
+
+      if (i.fitment ().has_refining ())
+        {
+          const auto& ref = i.fitment ().refining ();
+          if (!ref.input ().has_percent () || ref.input ().has_absolute ())
+            {
+              LOG (WARNING) << "Invalid refinery stats: " << ref.DebugString ();
+              return false;
+            }
+        }
     }
 
   for (const auto& entry : cfg->building_types ())

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -99,12 +99,23 @@ protected:
           const std::vector<std::string>& fitments)
   {
     auto c = characters.CreateNew ("domob", Faction::RED);
-    c->MutableProto ().set_vehicle (vehicle);
-    for (const auto& f : fitments)
-      c->MutableProto ().add_fitments (f);
-
-    DeriveCharacterStats (*c, ctx);
+    UpdateStats (*c, vehicle, fitments);
     return c;
+  }
+
+  /**
+   * Re-derives the stats of the given character.
+   */
+  void
+  UpdateStats (Character& c, const std::string& vehicle,
+               const std::vector<std::string>& fitments)
+  {
+    c.MutableProto ().set_vehicle (vehicle);
+    c.MutableProto ().clear_fitments ();
+    for (const auto& f : fitments)
+      c.MutableProto ().add_fitments (f);
+
+    DeriveCharacterStats (c, ctx);
   }
 
 };
@@ -261,6 +272,15 @@ TEST_F (DeriveCharacterStatsTests, FitmentAttacksAlsoBoosted)
     });
   const auto& a = c->GetProto ().combat_data ().attacks (2);
   EXPECT_EQ (a.damage ().max (), 10);
+}
+
+TEST_F (DeriveCharacterStatsTests, MobileRefinery)
+{
+  auto c = Derive ("chariot", {"vhf refinery", "vhf refinery"});
+  EXPECT_EQ (c->GetProto ().refining ().input ().percent (), 100);
+
+  UpdateStats (*c, "chariot", {});
+  EXPECT_FALSE (c->GetProto ().has_refining ());
 }
 
 /* ************************************************************************** */

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -20,6 +20,7 @@
 
 #include "buildings.hpp"
 #include "jsonutils.hpp"
+#include "modifier.hpp"
 #include "protoutils.hpp"
 
 #include "database/account.hpp"
@@ -283,6 +284,14 @@ template <>
   const auto& pb = c.GetProto ();
   if (pb.has_prospecting_blocks ())
     res["prospectingblocks"] = IntToJson (pb.prospecting_blocks ());
+
+  if (pb.has_refining ())
+    {
+      Json::Value ref(Json::objectValue);
+      const StatModifier inputMod(pb.refining ().input ());
+      ref["inefficiency"] = IntToJson (inputMod (100));
+      res["refining"] = ref;
+    }
 
   return res;
 }

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -432,6 +432,29 @@ TEST_F (CharacterJsonTests, ProspectingRate)
   })");
 }
 
+TEST_F (CharacterJsonTests, MobileRefinery)
+{
+  tbl.CreateNew ("no refining", Faction::RED);
+
+  auto c = tbl.CreateNew ("has refinery", Faction::RED);
+  c->MutableProto ().mutable_refining ()->mutable_input ()->set_percent (100);
+  c.reset ();
+
+  ExpectStateJson (R"({
+    "characters":
+      [
+        {
+          "owner": "no refining",
+          "refining": null
+        },
+        {
+          "owner": "has refinery",
+          "refining": {"inefficiency": 200}
+        }
+      ]
+  })");
+}
+
 TEST_F (CharacterJsonTests, DamageLists)
 {
   const auto id1 = tbl.CreateNew ("domob", Faction::RED)->GetId ();

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -248,6 +248,12 @@ protected:
   void TryBuildingUpdates (const std::string& name, const Json::Value& mv);
 
   /**
+   * Parses and handles a potential character update that triggers
+   * mobile refining.
+   */
+  void TryMobileRefining (Character& c, const Json::Value& upd);
+
+  /**
    * Parses and handles a potential move with requested service operations.
    * Each valid operation will be passed to PerformServiceOperation for
    * either execution or recording in the pending state.

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -487,6 +487,8 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
   std::vector<std::string> fitments;
   if (ParseSetFitments (c, upd, fitments))
     state.AddCharacterFitments (c, fitments);
+
+  TryMobileRefining (c, upd);
 }
 
 void

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -22,7 +22,7 @@
 
 #include <glog/logging.h>
 
-#include <string>
+#include <sstream>
 
 namespace pxd
 {
@@ -187,17 +187,13 @@ RefiningOperation::IsValid () const
       return false;
     }
 
-  const auto buildingId = GetBuilding ().GetId ();
-  const auto& name = GetAccount ().GetName ();
-
-  const auto inv = invTable.Get (buildingId, name);
-  const auto balance = inv->GetInventory ().GetFungibleCount (type);
+  const auto balance = GetBaseInventory ().GetFungibleCount (type);
   if (amount > balance)
     {
       LOG (WARNING)
           << "Can't refine " << amount << " " << type
-          << " as balance of " << name << " in building " << buildingId
-          << " is only " << balance;
+          << " with " << GetLocationInfo ()
+          << " as balance is only " << balance;
       return false;
     }
 
@@ -228,15 +224,11 @@ RefiningOperation::SpecificToPendingJson () const
 void
 RefiningOperation::ExecuteSpecific (xaya::Random& rnd)
 {
-  const auto buildingId = GetBuilding ().GetId ();
-  const auto& name = GetAccount ().GetName ();
-
   LOG (INFO)
-      << name << " in building " << buildingId
+      << GetLocationInfo ()
       << " refines " << amount << " " << type;
 
-  auto invHandle = invTable.Get (buildingId, name);
-  auto& inv = invHandle->GetInventory ();
+  auto& inv = GetBaseInventory ();
   inv.AddFungibleCount (type, -amount);
 
   const unsigned steps = GetSteps ();
@@ -497,17 +489,13 @@ RevEngOperation::IsValid () const
   if (num <= 0)
     return false;
 
-  const auto buildingId = GetBuilding ().GetId ();
-  const auto& name = GetAccount ().GetName ();
-
-  const auto inv = invTable.Get (buildingId, name);
-  const auto balance = inv->GetInventory ().GetFungibleCount (type);
+  const auto balance = GetBaseInventory ().GetFungibleCount (type);
   if (num > balance)
     {
       LOG (WARNING)
           << "Can't reveng " << num << " " << type
-          << " as balance of " << name << " in building " << buildingId
-          << " is only " << balance;
+          << " with " << GetLocationInfo ()
+          << " as balance is only " << balance;
       return false;
     }
 
@@ -530,15 +518,11 @@ RevEngOperation::SpecificToPendingJson () const
 void
 RevEngOperation::ExecuteSpecific (xaya::Random& rnd)
 {
-  const auto buildingId = GetBuilding ().GetId ();
-  const auto& name = GetAccount ().GetName ();
-
   LOG (INFO)
-      << name << " in building " << buildingId
+      << GetLocationInfo ()
       << " reverse engineers " << num << " " << type;
 
-  auto invHandle = invTable.Get (buildingId, name);
-  auto& inv = invHandle->GetInventory ();
+  auto& inv = GetBaseInventory ();
   inv.AddFungibleCount (type, -num);
 
   const size_t numOptions = revEngData->possible_outputs_size ();
@@ -654,17 +638,13 @@ BlueprintCopyOperation::IsValid () const
   if (num <= 0)
     return false;
 
-  const auto buildingId = GetBuilding ().GetId ();
-  const auto& name = GetAccount ().GetName ();
-
-  const auto inv = invTable.Get (buildingId, name);
-  const auto balance = inv->GetInventory ().GetFungibleCount (original);
+  const auto balance = GetBaseInventory ().GetFungibleCount (original);
   if (balance == 0)
     {
       LOG (WARNING)
           << "Can't copy blueprint " << original
-          << " as " << name
-          << " does not own any in building " << buildingId;
+          << " with " << GetLocationInfo ()
+          << " as there is none";
       return false;
     }
   CHECK_GT (balance, 0);
@@ -689,24 +669,20 @@ BlueprintCopyOperation::SpecificToPendingJson () const
 void
 BlueprintCopyOperation::ExecuteSpecific (xaya::Random& rnd)
 {
-  const auto buildingId = GetBuilding ().GetId ();
-  const auto& name = GetAccount ().GetName ();
-
   LOG (INFO)
-      << name << " in building " << buildingId
+      << GetLocationInfo ()
       << " copies " << original << " " << num << " times";
 
-  auto invHandle = invTable.Get (buildingId, name);
-  auto& inv = invHandle->GetInventory ();
+  auto& inv = GetBaseInventory ();
   inv.AddFungibleCount (original, -1);
 
   auto op = CreateOngoing ();
   const unsigned baseDuration
       = ctx.RoConfig ()->params ().bp_copy_blocks () * complexity;
   op->SetHeight (ctx.Height () + num * baseDuration);
-  op->SetBuildingId (buildingId);
+  op->SetBuildingId (GetBuilding ().GetId ());
   auto& cp = *op->MutableProto ().mutable_blueprint_copy ();
-  cp.set_account (name);
+  cp.set_account (GetAccount ().GetName ());
   cp.set_original_type (original);
   cp.set_copy_type (copy);
   cp.set_num_copies (num);
@@ -810,26 +786,23 @@ ConstructionOperation::IsValid () const
   if (num <= 0)
     return false;
 
-  const auto buildingId = GetBuilding ().GetId ();
-  const auto& name = GetAccount ().GetName ();
-
-  const auto inv = invTable.Get (buildingId, name);
+  auto& inv = GetBaseInventory ();
   for (const auto& entry : outputData->construction_resources ())
     {
       const QuantityProduct required(num, entry.second);
-      const auto balance = inv->GetInventory ().GetFungibleCount (entry.first);
+      const auto balance = inv.GetFungibleCount (entry.first);
       if (required > balance)
         {
           LOG (WARNING)
               << "Can't construct " << num << " " << output
-              << " as " << name << " in building " << buildingId
-              << " has only " << balance << " " << entry.first
+              << " with " << GetLocationInfo ()
+              << " as there is only " << balance << " " << entry.first
               << " while the construction needs " << required.Extract ();
           return false;
         }
     }
 
-  const auto bpBalance = inv->GetInventory ().GetFungibleCount (blueprint);
+  const auto bpBalance = inv.GetFungibleCount (blueprint);
   Quantity bpRequired;
   if (fromOriginal)
     bpRequired = 1;
@@ -839,8 +812,8 @@ ConstructionOperation::IsValid () const
     {
       LOG (WARNING)
           << "Can't construct " << num << " items from " << blueprint
-          << " as " << name << " in building " << buildingId
-          << " has only " << bpBalance;
+          << " with " << GetLocationInfo ()
+          << " as as there are only " << bpBalance << " blueprints";
       return false;
     }
 
@@ -864,15 +837,11 @@ ConstructionOperation::SpecificToPendingJson () const
 void
 ConstructionOperation::ExecuteSpecific (xaya::Random& rnd)
 {
-  const auto buildingId = GetBuilding ().GetId ();
-  const auto& name = GetAccount ().GetName ();
-
   LOG (INFO)
-      << name << " in building " << buildingId
+      << GetLocationInfo ()
       << " constructs " << num << " " << output;
 
-  auto invHandle = invTable.Get (buildingId, name);
-  auto& inv = invHandle->GetInventory ();
+  auto& inv = GetBaseInventory ();
   for (const auto& entry : outputData->construction_resources ())
     {
       const QuantityProduct required(num, entry.second);
@@ -885,7 +854,7 @@ ConstructionOperation::ExecuteSpecific (xaya::Random& rnd)
     inv.AddFungibleCount (blueprint, -num);
 
   auto op = CreateOngoing ();
-  op->SetBuildingId (buildingId);
+  op->SetBuildingId (GetBuilding ().GetId ());
 
   /* When constructing from an original, the items have to be constructed
      in series.  With blueprint copies, we need to have as many copies as items
@@ -898,7 +867,7 @@ ConstructionOperation::ExecuteSpecific (xaya::Random& rnd)
     op->SetHeight (ctx.Height () + baseDuration);
 
   auto& c = *op->MutableProto ().mutable_item_construction ();
-  c.set_account (name);
+  c.set_account (GetAccount ().GetName ());
   c.set_output_type (output);
   c.set_num_items (num);
   if (fromOriginal)
@@ -911,10 +880,18 @@ ConstructionOperation::ExecuteSpecific (xaya::Random& rnd)
 
 ServiceOperation::ServiceOperation (Account& a, BuildingsTable::Handle b,
                                     const ContextRefs& refs)
-  : accounts(refs.accounts), ongoings(refs.ongoings),
-    acc(a), building(std::move (b)),
-    ctx(refs.ctx),
-    invTable(refs.invTable), itemCounts(refs.cnt)
+  : accounts(refs.accounts), invTable(refs.invTable), ongoings(refs.ongoings),
+    acc(a), building(std::move (b)), character(nullptr),
+    ctx(refs.ctx), itemCounts(refs.cnt)
+{
+  buildingInv = invTable.Get (building->GetId (), acc.GetName ());
+}
+
+ServiceOperation::ServiceOperation (Account& a, Character& c,
+                                    const ContextRefs& refs)
+  : accounts(refs.accounts), invTable(refs.invTable), ongoings(refs.ongoings),
+    acc(a), character(&c),
+    ctx(refs.ctx), itemCounts(refs.cnt)
 {}
 
 void
@@ -922,6 +899,14 @@ ServiceOperation::GetCosts (Amount& base, Amount& fee) const
 {
   base = GetBaseCost ();
   CHECK_GE (base, 0);
+
+  /* If this is not happening inside a building (but instead with a character),
+     there is no service fee.  */
+  if (building == nullptr)
+    {
+      fee = 0;
+      return;
+    }
 
   /* Service is free if the building is an ancient one or if the owner is
      using their own building.  Even though they would get the fee back in
@@ -941,10 +926,50 @@ ServiceOperation::GetCosts (Amount& base, Amount& fee) const
   fee = (base * building->GetProto ().service_fee_percent () + 99) / 100;
 }
 
+std::string
+ServiceOperation::GetLocationInfo () const
+{
+  std::ostringstream out;
+
+  if (building != nullptr)
+    out << acc.GetName () << " in building " << building->GetId ();
+  else
+    {
+      CHECK (character != nullptr);
+      out << "character " << character->GetId ();
+    }
+
+  return out.str ();
+}
+
+const Inventory&
+ServiceOperation::GetBaseInventory () const
+{
+  return const_cast<ServiceOperation*> (this)->GetBaseInventory ();
+}
+
+Inventory&
+ServiceOperation::GetBaseInventory ()
+{
+  if (buildingInv != nullptr)
+    return buildingInv->GetInventory ();
+
+  CHECK (character != nullptr)
+      << "Service operation has neither building inventory nor character";
+  return character->GetInventory ();
+}
+
 OngoingsTable::Handle
 ServiceOperation::CreateOngoing ()
 {
   return ongoings.CreateNew (ctx.Height ());
+}
+
+const Building&
+ServiceOperation::GetBuilding () const
+{
+  CHECK (building != nullptr);
+  return *building;
 }
 
 bool
@@ -956,10 +981,20 @@ ServiceOperation::IsFullyValid () const
       return false;
     }
 
-  if (!IsSupported (GetBuilding ()))
+  CHECK (building != nullptr || character != nullptr);
+
+  if (building != nullptr && !IsSupported (GetBuilding ()))
     {
       LOG (WARNING)
           << "Building " << GetBuilding ().GetId ()
+          << " does not support service operation: " << rawMove;
+      return false;
+    }
+
+  if (character != nullptr && !IsSupported (*character))
+    {
+      LOG (WARNING)
+          << "Character " << character->GetId ()
           << " does not support service operation: " << rawMove;
       return false;
     }
@@ -984,7 +1019,10 @@ ServiceOperation::ToPendingJson () const
   Json::Value res = SpecificToPendingJson ();
   CHECK (res.isObject ());
 
-  res["building"] = IntToJson (building->GetId ());
+  if (building != nullptr)
+    res["building"] = IntToJson (building->GetId ());
+  if (character != nullptr)
+    res["character"] = IntToJson (character->GetId ());
 
   Amount base, fee;
   GetCosts (base, fee);
@@ -1007,6 +1045,7 @@ ServiceOperation::Execute (xaya::Random& rnd)
   CHECK_GE (fee, 0);
   if (fee > 0)
     {
+      CHECK (building != nullptr);
       auto owner = accounts.GetByName (building->GetOwner ());
       CHECK (owner != nullptr);
       CHECK_NE (owner->GetName (), acc.GetName ());

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -238,6 +238,18 @@ public:
       ItemCounts& cnt,
       OngoingsTable& ong);
 
+  /**
+   * Tries to parse and return a refining operation on a character, i.e.
+   * using a mobile refinery.
+   */
+  static std::unique_ptr<ServiceOperation> ParseMobileRefining (
+      Account& acc, Character& c, const Json::Value& data,
+      const Context& ctx,
+      AccountsTable& accounts,
+      BuildingInventoriesTable& inv,
+      ItemCounts& cnt,
+      OngoingsTable& ong);
+
 };
 
 } // namespace pxd


### PR DESCRIPTION
This extends the service-operation framework to support operations done with characters rather than inside buildings, and uses that to implement the "mobile refinery" fitment.  It only exists as `vhf refinery` variant (not the lighter ones).

When a character has it equipped, it can refine ores in its local inventory without the need to go to a refinery.  The only drawback is that this uses up twice as much input ore for each refinement step (the vCHI cost and the outputs are the same).

To trigger such an operation, send a character-update move like this:

    {"c": {"42": {"ref": {"i": "raw f", "n": 20000}}}}