### PR TITLE
Allow excluding buildings for findpath

### DIFF
--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -62,7 +62,6 @@ class FindPathTest (PXTest):
     self.collectPremine ()
 
     findpath = self.rpc.game.findpath
-    setpathbuildings = self.rpc.game.setpathbuildings
 
     # Pair of coordinates that are next to each other, but where one
     # is an obstacle.
@@ -120,28 +119,32 @@ class FindPathTest (PXTest):
 
     # Invalid building specs for setpathbuildings.
     self.expectError (-32602, ".*Invalid method parameters.*",
-                      setpathbuildings, buildings={})
+                      self.rpc.game.setpathbuildings, buildings={})
+    coord = {"x": 1, "y": 2}
     for specs in [
       [42],
       ["foo"],
       [{}],
-      [{"rotationsteps": 0, "centre": {"x": 1, "y": 2}}],
-      [{"type": 42, "rotationsteps": 0, "centre": {"x": 1, "y": 2}}],
-      [{"type": "invalid", "rotationsteps": 0, "centre": {"x": 1, "y": 2}}],
-      [{"type": "checkmark", "centre": {"x": 1, "y": 2}}],
-      [{"type": "checkmark", "rotationsteps": "0", "centre": {"x": 1, "y": 2}}],
-      [{"type": "checkmark", "rotationsteps": -1, "centre": {"x": 1, "y": 2}}],
-      [{"type": "checkmark", "rotationsteps": 6, "centre": {"x": 1, "y": 2}}],
-      [{"type": "checkmark", "rotationsteps": 0}],
-      [{"type": "checkmark", "rotationsteps": 0, "centre": "(0, 0)"}],
-      [{"type": "checkmark", "rotationsteps": 0, "centre": {"x": 1}}],
+      [{"type": "checkmark", "rotationsteps": 0, "centre": coord}],
+      [{"id": -5, "type": "checkmark", "rotationsteps": 0, "centre": coord}],
+      [{"id": 0, "type": "checkmark", "rotationsteps": 0, "centre": coord}],
+      [{"id": 10, "rotationsteps": 0, "centre": coord}],
+      [{"id": 10, "type": 42, "rotationsteps": 0, "centre": coord}],
+      [{"id": 10, "type": "invalid", "rotationsteps": 0, "centre": coord}],
+      [{"id": 10, "type": "checkmark", "centre": coord}],
+      [{"id": 10, "type": "checkmark", "rotationsteps": "0", "centre": coord}],
+      [{"id": 10, "type": "checkmark", "rotationsteps": -1, "centre": coord}],
+      [{"id": 10, "type": "checkmark", "rotationsteps": 6, "centre": coord}],
+      [{"id": 10, "type": "checkmark", "rotationsteps": 0}],
+      [{"id": 10, "type": "checkmark", "rotationsteps": 0, "centre": "(0, 0)"}],
+      [{"id": 10, "type": "checkmark", "rotationsteps": 0, "centre": {"x": 1}}],
       [
-        {"type": "checkmark", "rotationsteps": 0, "centre": {"x": 1, "y": 0}},
-        {"type": "checkmark", "rotationsteps": 0, "centre": {"x": 1, "y": 0}},
+        {"id": 10, "type": "checkmark", "rotationsteps": 0, "centre": coord},
+        {"id": 10, "type": "checkmark", "rotationsteps": 0, "centre": coord},
       ],
     ]:
       self.expectError (-1, "buildings is invalid",
-                        setpathbuildings, buildings=specs)
+                        self.rpc.game.setpathbuildings, buildings=specs)
 
     # This is a very long path, which takes a non-negligible amount of time
     # to compute.  We use this later to ensure that multiple calls are

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -133,7 +133,8 @@ class Character (object):
     path = self.test.rpc.game.findpath (source=self.getPosition (),
                                         target=target,
                                         faction=self.data["faction"],
-                                        l1range=1000)
+                                        l1range=1000,
+                                        exbuildings=[])
     return self.sendMove ({"wp": path["wp"]})
 
   def expectPartial (self, expected):

--- a/gametest/safezones.py
+++ b/gametest/safezones.py
@@ -50,7 +50,8 @@ class SafeZonesTest (PXTest):
 
     self.mainLogger.info ("Testing findpath...")
     def findpath (**kwargs):
-      path = self.rpc.game.findpath (l1range=1000, wpdist=1000, **kwargs)
+      path = self.rpc.game.findpath (exbuildings=[], l1range=1000, wpdist=1000,
+                                     **kwargs)
       return path["dist"]
     self.expectError (1, "no connection",
                       findpath, faction="g",

--- a/src/dynobstacles.cpp
+++ b/src/dynobstacles.cpp
@@ -53,9 +53,11 @@ DynObstacles::DynObstacles (Database& db, const Context& ctx)
 bool
 DynObstacles::AddBuilding (const std::string& type,
                            const proto::ShapeTransformation& trafo,
-                           const HexCoord& pos)
+                           const HexCoord& pos,
+                           std::vector<HexCoord>& shape)
 {
-  for (const auto& c : GetBuildingShape (type, trafo, pos, chain))
+  shape = GetBuildingShape (type, trafo, pos, chain);
+  for (const auto& c : shape)
     {
       auto ref = buildings.Access (c);
       if (ref)
@@ -68,8 +70,9 @@ DynObstacles::AddBuilding (const std::string& type,
 void
 DynObstacles::AddBuilding (const Building& b)
 {
+  std::vector<HexCoord> shape;
   CHECK (AddBuilding (b.GetType (), b.GetProto ().shape_trafo (),
-                      b.GetCentre ()))
+                      b.GetCentre (), shape))
       << "Error adding building " << b.GetId ();
 }
 

--- a/src/dynobstacles.hpp
+++ b/src/dynobstacles.hpp
@@ -109,11 +109,13 @@ public:
 
   /**
    * Adds a building from the raw data (without requiring a Building instance).
+   * Also exposes the building's shape to the caller for further processing.
    * Returns false if adding failed, e.g. because the buildings overlap.
    */
   bool AddBuilding (const std::string& type,
                     const proto::ShapeTransformation& trafo,
-                    const HexCoord& pos);
+                    const HexCoord& pos,
+                    std::vector<HexCoord>& shape);
 
   /**
    * Adds a new building.  CHECK-fails if something goes wrong.

--- a/src/dynobstacles_tests.cpp
+++ b/src/dynobstacles_tests.cpp
@@ -121,15 +121,16 @@ TEST_F (DynObstaclesTests, AddingBuildings)
 
   {
     DynObstacles dyn(ctx.Chain ());
+    std::vector<HexCoord> shape;
     ASSERT_TRUE (dyn.AddBuilding (b1->GetType (),
                                   b1->GetProto ().shape_trafo (),
-                                  b1->GetCentre ()));
+                                  b1->GetCentre (), shape));
     ASSERT_TRUE (dyn.AddBuilding (b2->GetType (),
                                   b2->GetProto ().shape_trafo (),
-                                  b2->GetCentre ()));
+                                  b2->GetCentre (), shape));
     ASSERT_FALSE (dyn.AddBuilding (b1->GetType (),
                                    b1->GetProto ().shape_trafo (),
-                                   b1->GetCentre ()));
+                                   b1->GetCentre (), shape));
   }
 }
 

--- a/src/movement.hpp
+++ b/src/movement.hpp
@@ -36,12 +36,12 @@ namespace pxd
 
 /**
  * Computes the edge weight used for movement of a given faction character
- * on the map.  This is shared between the RPC server's findpath method
- * and the actual GSP movement processing logic.
+ * on the map, not including dynamic obstacles.  This is shared between the
+ * RPC server's findpath method and the actual GSP movement processing logic.
  */
-inline PathFinder::DistanceT MovementEdgeWeight (
-    const BaseMap& map, const DynObstacles& dyn, Faction f,
-    const HexCoord& from, const HexCoord& to);
+inline PathFinder::DistanceT MovementEdgeWeight (const BaseMap& map, Faction f,
+                                                 const HexCoord& from,
+                                                 const HexCoord& to);
 
 /**
  * Clears all movement for the given character (stops its movement entirely).

--- a/src/movement_tests.cpp
+++ b/src/movement_tests.cpp
@@ -169,18 +169,18 @@ TEST_F (MovementEdgeWeightTests, StarterZones)
   ASSERT_EQ (ctx.Map ().SafeZones ().StarterFor (outside), Faction::INVALID);
 
   /* Moving out of the starter zone does nothing special.  */
-  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), dyn, Faction::RED,
+  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), Faction::RED,
                                  redStarter, outside),
              1'000);
-  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), dyn, Faction::GREEN,
+  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), Faction::GREEN,
                                  redStarter, outside),
              1'000);
 
   /* Into the starter zone changes the weights.  */
-  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), dyn, Faction::RED,
+  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), Faction::RED,
                                  outside, redStarter),
              1'000 / 3);
-  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), dyn, Faction::GREEN,
+  EXPECT_EQ (MovementEdgeWeight (ctx.Map (), Faction::GREEN,
                                  outside, redStarter),
              PathFinder::NO_CONNECTION);
 }

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -251,7 +251,14 @@ NonStateRpcServer::findpath (const std::string& faction,
   const auto edges = [this, f, &dynCopy] (const HexCoord& from,
                                           const HexCoord& to)
     {
-      return MovementEdgeWeight (map, dynCopy->obstacles, f, from, to);
+      const auto base = MovementEdgeWeight (map, f, from, to);
+      if (base == PathFinder::NO_CONNECTION)
+        return PathFinder::NO_CONNECTION;
+
+      if (!dynCopy->obstacles.IsPassable (to, f))
+        return PathFinder::NO_CONNECTION;
+
+      return base;
     };
   const PathFinder::DistanceT dist = finder.Compute (edges, sourceCoord,
                                                      l1range);

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -139,7 +139,8 @@ public:
                               const BaseMap& m, const xaya::Chain c);
 
   bool setpathbuildings (const Json::Value& buildings) override;
-  Json::Value findpath (const std::string& faction,
+  Json::Value findpath (const Json::Value& exbuildings,
+                        const std::string& faction,
                         int l1range, const Json::Value& source,
                         const Json::Value& target) override;
   Json::Value getregionat (const Json::Value& coord) override;
@@ -205,11 +206,11 @@ public:
   }
 
   Json::Value
-  findpath (const std::string& faction,
+  findpath (const Json::Value& exbuildings, const std::string& faction,
             int l1range, const Json::Value& source,
             const Json::Value& target) override
   {
-    return nonstate.findpath (faction, l1range, source, target);
+    return nonstate.findpath (exbuildings, faction, l1range, source, target);
   }
 
   Json::Value

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -32,6 +32,7 @@
 #include <json/json.h>
 #include <jsonrpccpp/server.h>
 
+#include <map>
 #include <mutex>
 
 namespace pxd
@@ -81,7 +82,29 @@ private:
   const BaseMap& map;
 
   /**
-   * DynObstacles map used for findpath.  This is decoupled from the
+   * Data relevant for findpath about the set of buildings on the map.
+   */
+  struct BuildingsData
+  {
+
+    /** DynObstacles instance with all those buildings added.  */
+    DynObstacles obstacles;
+
+    /**
+     * Map from coordinate to the corresponding building ID.  We use that
+     * to selectively exclude buildings by ID from the obstacle map, e.g.
+     * when pathing "to" a building to enter it.
+     */
+    std::unordered_map<HexCoord, Database::IdT> buildingIds;
+
+    explicit BuildingsData (const xaya::Chain c)
+      : obstacles(c)
+    {}
+
+  };
+
+  /**
+   * Building data used for findpath.  This is decoupled from the
    * actual game state, so that it can be done even for Charon clients
    * locally.  It contains a set of buildings, which are specified
    * explicitly by the caller (with a separate RPC and then remembered
@@ -91,16 +114,24 @@ private:
    * and then the instance itself does not need to be kept locked while the
    * call is running.
    */
-  std::shared_ptr<const DynObstacles> dyn;
+  std::shared_ptr<const BuildingsData> dyn;
 
   /** Mutex for protecting dyn in concurrent calls.  */
   std::mutex mutDynObstacles;
 
   /**
-   * Constructs a fresh dynamic obstacles instance without any extra
+   * Constructs a fresh BuildingsData instance without any extra
    * buildings added yet.
    */
-  std::shared_ptr<DynObstacles> InitDynObstacles () const;
+  std::shared_ptr<BuildingsData> InitBuildingsData () const;
+
+  /**
+   * Processes a JSON array of building specifications and adds them
+   * to the given dynamic obstacle map.  Returns false if something
+   * goes wrong, e.g. the JSON format is invalid or some buildings overlap.
+   */
+  bool AddBuildingsFromJson (const Json::Value& buildings,
+                             BuildingsData& dyn) const;
 
 public:
 

--- a/src/rpc-stubs/nonstate.json
+++ b/src/rpc-stubs/nonstate.json
@@ -14,7 +14,8 @@
         "source": {},
         "target": {},
         "faction": "",
-        "l1range": 100
+        "l1range": 100,
+        "exbuildings": [1, 2, 3]
       },
     "returns": {}
   },

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -97,7 +97,8 @@
         "source": {},
         "target": {},
         "faction": "",
-        "l1range": 100
+        "l1range": 100,
+        "exbuildings": [1, 2, 3]
       },
     "returns": {}
   },


### PR DESCRIPTION
This adds a new argument `exbuildings` to the `findpath` RPC method.  The argument expects an array of building IDs (can be empty).  Buildings referenced by it will then not be treated as obstacles (while all other buildings set with `setpathbuildings` are still obstacles).  With this it is possible to compute paths "to" a building, e.g. for entering it.

To make this work, the data passed into `setpathbuildings` now also needs to include `id` values.  But if the output of a GSP's `getbuildings` method is passed, that will be fine already.