### PR TITLE
Compress waypoints data in moves

### DIFF
--- a/gametest/buildings_enterexit.py
+++ b/gametest/buildings_enterexit.py
@@ -40,8 +40,9 @@ class BuildingsEnterExitTest (PXTest):
     self.generate (1)
     self.changeCharacterVehicle ("domob", "light attacker")
     self.moveCharactersTo ({"domob": {"x": 20, "y": 0}})
-    self.getCharacters ()["domob"].sendMove ({
-      "wp": [{"x": 3, "y": 0}],
+    c = self.getCharacters ()["domob"]
+    c.sendMove ({
+      "wp": c.findPath ({"x": 3, "y": 0}),
       "eb": building
     })
     self.generate (2)

--- a/gametest/mining.py
+++ b/gametest/mining.py
@@ -78,7 +78,7 @@ class MiningTest (PXTest):
     self.assertEqual (self.isMining ("domob 2"), False)
 
     self.mainLogger.info ("Movement stops mining...")
-    self.getCharacters ()["domob"].sendMove ({"wp": []})
+    self.getCharacters ()["domob"].sendMove ({"wp": None})
     self.generate (1)
     self.assertEqual (self.isMining ("domob"), False)
     self.assertEqual (self.isMining ("domob 2"), False)

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -25,20 +25,14 @@ from pxtest import PXTest, offsetCoord
 
 class MovementTest (PXTest):
 
-  def offsetWaypoints (self, wp):
-    """
-    Returns the waypoints, transformed by applying our coordinate offset.
-    """
-
-    return [offsetCoord (p, self.offset, False) for p in wp]
-
   def setWaypoints (self, owner, wp):
     """
     Sends a move to update the waypoints of the character with the given owner.
     """
 
     c = self.getCharacters ()[owner]
-    return c.sendMove ({"wp": self.offsetWaypoints (wp)})
+    offset = [offsetCoord (p, self.offset, False) for p in wp]
+    return c.sendMove ({"wp": offset})
 
   def moveTowards (self, owner, target):
     """
@@ -170,7 +164,7 @@ class MovementTest (PXTest):
 
     # Move the character with reduced speed.
     c = self.getCharacters ()["domob"]
-    wp = self.offsetWaypoints ([{"x": 100, "y": 0}])
+    wp = [offsetCoord ({"x": 100, "y": 0}, self.offset, False)]
     c.sendMove ({"wp": wp, "speed": 1000})
     self.generate (10)
     pos, mv = self.getMovement ("domob")

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -32,7 +32,10 @@ class MovementTest (PXTest):
 
     c = self.getCharacters ()[owner]
     offset = [offsetCoord (p, self.offset, False) for p in wp]
-    return c.sendMove ({"wp": offset})
+
+    encoded = self.rpc.game.encodewaypoints (wp=offset)
+
+    return c.sendMove ({"wp": encoded})
 
   def moveTowards (self, owner, target):
     """
@@ -165,7 +168,8 @@ class MovementTest (PXTest):
     # Move the character with reduced speed.
     c = self.getCharacters ()["domob"]
     wp = [offsetCoord ({"x": 100, "y": 0}, self.offset, False)]
-    c.sendMove ({"wp": wp, "speed": 1000})
+    encoded = self.rpc.game.encodewaypoints (wp=wp)
+    c.sendMove ({"wp": encoded, "speed": 1000})
     self.generate (10)
     pos, mv = self.getMovement ("domob")
     self.assertEqual (pos, {"x": 10, "y": 0})
@@ -183,7 +187,7 @@ class MovementTest (PXTest):
     # Sending another movement in-between without speed will revert it to
     # the default one.
     c = self.getCharacters ()["domob"]
-    c.sendMove ({"wp": wp, "speed": 1000})
+    c.sendMove ({"wp": encoded, "speed": 1000})
     self.generate (10)
     pos, _ = self.getMovement ("domob")
     self.assertEqual (pos, {"x": 50, "y": 0})
@@ -196,7 +200,7 @@ class MovementTest (PXTest):
     # Letting the movement finish and then sending a new movement will also
     # revert to intrinsic speed.
     c = self.getCharacters ()["domob"]
-    c.sendMove ({"wp": wp, "speed": 1000})
+    c.sendMove ({"wp": encoded, "speed": 1000})
     self.generate (10)
     pos, _ = self.getMovement ("domob")
     self.assertEqual (pos, {"x": 30, "y": 0})

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -86,7 +86,7 @@ class PendingTest (PXTest):
     self.mainLogger.info ("Performing pending updates...")
     self.createCharacters ("domob")
     c1 = self.getCharacters ()["domob"]
-    c1.sendMove ({"wp": []})
+    c1.sendMove ({"wp": None})
 
     sleepSome ()
     self.assertEqual (self.getPendingState (), {

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -108,7 +108,7 @@ class PendingTest (PXTest):
 
     self.createCharacters ("domob")
     self.createCharacters ("andy")
-    c1.sendMove ({"wp": [{"x": 5, "y": -5}]})
+    c1.sendMove ({"wp": self.rpc.game.encodewaypoints (wp=[{"x": 5, "y": -5}])})
     c1.sendMove ({"pu": {"f": {"foo": 2}}})
 
     cb1 = self.getCharacters ()["inbuilding"]

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -135,7 +135,7 @@ class Character (object):
                                         faction=self.data["faction"],
                                         l1range=1000,
                                         exbuildings=[])
-    return path["wp"]
+    return path["encoded"]
 
   def moveTowards (self, target):
     """

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -124,10 +124,10 @@ class Character (object):
     idStr = self.getIdStr ()
     return self.test.sendMove (self.data["owner"], {"c": {idStr: mv}})
 
-  def moveTowards (self, target):
+  def findPath (self, target):
     """
-    Sends a move with waypoints matching the findpath output from the
-    current position to target.
+    Computes the findpath output from the current position to the given
+    target, and returns it as encoded string suitable for a "wp" move.
     """
 
     path = self.test.rpc.game.findpath (source=self.getPosition (),
@@ -135,7 +135,15 @@ class Character (object):
                                         faction=self.data["faction"],
                                         l1range=1000,
                                         exbuildings=[])
-    return self.sendMove ({"wp": path["wp"]})
+    return path["wp"]
+
+  def moveTowards (self, target):
+    """
+    Sends a move with waypoints matching the findpath output from the
+    current position to target.
+    """
+
+    return self.sendMove ({"wp": self.findPath (target)})
 
   def expectPartial (self, expected):
     """

--- a/gametest/safezones.py
+++ b/gametest/safezones.py
@@ -108,7 +108,7 @@ class SafeZonesTest (PXTest):
     # Move out of the safe zone.  After the first block, we are still in
     # and there should not be any combat.  After that, we are out and combat
     # will resume.
-    c.sendMove ({"wp": [relativePos (0, 12)], "speed": 1000})
+    c.sendMove ({"wp": c.findPath (relativePos (0, 12)), "speed": 1000})
     self.generate (1)
     chars = self.getCharacters ()
     c = chars["red"]

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -200,7 +200,7 @@ TEST_F (PXLogicTests, WaypointsBeforeMovement)
   UpdateState (R"([
     {
       "name": "domob",
-      "move": {"c": {"1": {"wp": [{"x": -1, "y": 0}]}}}
+      "move": {"c": {"1": {"wp": )" + WpStr ({HexCoord (-1, 0)}) + R"(}}}
     }
   ])");
 
@@ -278,7 +278,7 @@ TEST_F (PXLogicTests, KilledVehicleNoLongerBlocks)
   UpdateState (R"([
     {
       "name": "moving",
-      "move": {"c": {"3": {"wp": [{"x": 10, "y": 0}]}}}
+      "move": {"c": {"3": {"wp": )" + WpStr ({HexCoord (10, 0)}) + R"(}}}
     }
   ])");
 
@@ -306,7 +306,7 @@ TEST_F (PXLogicTests, NewBuildingBlocksMovement)
   UpdateState (R"([
     {
       "name": "moving",
-      "move": {"c": {"2": {"wp": [{"x": 0, "y": 0}]}}}
+      "move": {"c": {"2": {"wp": )" + WpStr ({HexCoord (0, 0)}) + R"(}}}
     },
     {
       "name": "builder",
@@ -740,7 +740,7 @@ TEST_F (PXLogicTests, FinishingProspecting)
   UpdateState (R"([
     {
       "name": "domob",
-      "move": {"c": {"1": {"wp": [{"x": 0, "y": 5}]}}}
+      "move": {"c": {"1": {"wp": )" + WpStr ({HexCoord (0, 5)}) + R"(}}}
     }
   ])");
 

--- a/src/movement.hpp
+++ b/src/movement.hpp
@@ -29,10 +29,31 @@
 #include "hexagonal/coord.hpp"
 #include "hexagonal/pathfinder.hpp"
 
+#include <json/json.h>
+
 #include <functional>
 
 namespace pxd
 {
+
+/**
+ * Encodes a list of hex coordinates (waypoints) into a compressed string
+ * that is used for moves.  Returns true on success, and false if it failed.
+ * This may be the case e.g. when the final size is too large for our
+ * maximum uncompressed size.
+ *
+ * The format is to write out the waypoints as JSON array, serialise it,
+ * compress is using libxayautil, and then base64 encode.  But that is
+ * an implementation detail.
+ */
+bool EncodeWaypoints (const std::vector<HexCoord>& wp,
+                      Json::Value& jsonWp, std::string& encoded);
+
+/**
+ * Tries to decode an encoded list of waypoints.  Returns true on success
+ * and false if they were completely invalid (e.g. malformed).
+ */
+bool DecodeWaypoints (const std::string& encoded, std::vector<HexCoord>& wp);
 
 /**
  * Computes the edge weight used for movement of a given faction character

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -785,7 +785,7 @@ TEST_F (CharacterUpdateTests, WhenBusy)
   Process (R"([
     {
       "name": "domob",
-      "move": {"c": {"1": {"wp": [{"x": -3, "y": 4}]}}}
+      "move": {"c": {"1": {"wp": )" + WpStr ({HexCoord (-3, 4)}) + R"(}}}
     },
     {
       "name": "domob",
@@ -816,7 +816,7 @@ TEST_F (CharacterUpdateTests, InvalidWhenInsideBuilding)
   Process (R"([
     {
       "name": "domob",
-      "move": {"c": {"1": {"wp": [{"x": -3, "y": 4}]}}}
+      "move": {"c": {"1": {"wp": )" + WpStr ({HexCoord (-3, 4)}) + R"(}}}
     },
     {
       "name": "domob",
@@ -852,15 +852,23 @@ TEST_F (CharacterUpdateTests, BasicWaypoints)
     },
     {
       "name": "domob",
+      "move": {"c": {"1": {"wp": []}}}
+    },
+    {
+      "name": "domob",
+      "move": {"c": {"1": {}}}
+    },
+    {
+      "name": "domob",
       "move": {"c": {"1": {"wp": {"x": 4, "y": 3}}}}
     },
     {
       "name": "domob",
-      "move": {"c": {"1": {"wp": [{"x": 4.5, "y": 3}]}}}
+      "move": {"c": {"1": {"wp": [{"x": 4, "y": 3}]}}}
     },
     {
       "name": "andy",
-      "move": {"c": {"1": {"wp": [{"x": 4, "y": 3}]}}}
+      "move": {"c": {"1": {"wp": 42}}}
     }
   ])");
 
@@ -874,7 +882,8 @@ TEST_F (CharacterUpdateTests, BasicWaypoints)
   /* Process a valid waypoints update move.  */
   Process (R"([{
     "name": "domob",
-    "move": {"c": {"1": {"wp": [{"x": -3, "y": 4}, {"x": 5, "y": 0}]}}}
+    "move": {"c": {"1": {"wp": )"
+        + WpStr ({HexCoord (-3, 4), HexCoord (5, 0)}) + R"(}}}
   }])");
 
   /* Verify that the valid move had the expected effect.  */
@@ -897,7 +906,7 @@ TEST_F (CharacterUpdateTests, EmptyWaypoints)
   GetTest ()->MutableVolatileMv ().set_partial_step (42);
   Process (R"([{
     "name": "domob",
-    "move": {"c": {"1": {"wp": []}}}
+    "move": {"c": {"1": {"wp": null}}}
   }])");
 
   h = GetTest ();
@@ -916,7 +925,7 @@ TEST_F (CharacterUpdateTests, WaypointsWithZeroSpeed)
   GetTest ()->MutableVolatileMv ().set_partial_step (42);
   Process (R"([{
     "name": "domob",
-    "move": {"c": {"1": {"wp": [{"x": -3, "y": 100}]}}}
+    "move": {"c": {"1": {"wp": )" + WpStr ({HexCoord (-3, 100)}) + R"(}}}
   }])");
 
   /* With zero speed of the character, we should just "stop" it but not
@@ -945,7 +954,9 @@ TEST_F (CharacterUpdateTests, ChosenSpeedWorks)
 
   Process (R"([{
     "name": "domob",
-    "move": {"c": {"1": {"wp": [{"x": 5, "y": 1}], "speed": 1000000}}}
+    "move": {"c": {"1": {"wp": )"
+        + WpStr ({HexCoord (5, 1)})
+        + R"(, "speed": 1000000}}}
   }])");
   EXPECT_EQ (GetTest ()->GetProto ().movement ().chosen_speed (), 1000000);
 
@@ -961,7 +972,9 @@ TEST_F (CharacterUpdateTests, ChosenSpeedInvalid)
   GetTest ()->MutableProto ().set_speed (1000);
   Process (R"([{
     "name": "domob",
-    "move": {"c": {"1": {"wp": [{"x": 5, "y": 1}], "speed": 1000}}}
+    "move": {"c": {"1": {"wp": )"
+        + WpStr ({HexCoord (5, 1)})
+        + R"(, "speed": 1000}}}
   }])");
 
   /* All of them are invalid in one way or another.  */
@@ -2589,7 +2602,7 @@ TEST_F (ProspectingMoveTests, Success)
     {
       "name": "domob",
       "move": {"c": {"1": {
-        "wp": [{"x": 5, "y": -2}],
+        "wp": )" + WpStr ({HexCoord (5, -2)}) + R"(,
         "prospect": {}
       }}}
     }
@@ -2812,7 +2825,7 @@ TEST_F (MiningMoveTests, WaypointsStopMining)
     {
       "name": "domob",
       "move": {"c": {
-        "1": {"wp": []}
+        "1": {"wp": null}
       }}
     }
   ])");
@@ -2830,7 +2843,7 @@ TEST_F (MiningMoveTests, WaypointsNoMiningData)
     {
       "name": "domob",
       "move": {"c": {
-        "1": {"wp": []}
+        "1": {"wp": null}
       }}
     }
   ])");
@@ -2907,7 +2920,7 @@ TEST_F (MiningMoveTests, MiningAndWaypointsInSameMove)
     {
       "name": "domob",
       "move": {"c": {
-        "1": {"wp": [{"x": 5, "y": 10}], "mine": {}}
+        "1": {"wp": )" + WpStr ({HexCoord (5, 10)}) + R"(, "mine": {}}
       }}
     }
   ])");

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -787,13 +787,13 @@ TEST_F (PendingStateUpdaterTests, InvalidUpdate)
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
 
   Process ("andy", R"({
-    "c": {"1": {"wp": []}}
+    "c": {"1": {"wp": null}}
   })");
   Process ("domob", R"({
-    "c": {" 1 ": {"wp": []}}
+    "c": {" 1 ": {"wp": null}}
   })");
   Process ("domob", R"({
-    "c": {"42": {"wp": []}}
+    "c": {"42": {"wp": null}}
   })");
 
   ExpectStateJson (R"(
@@ -811,13 +811,10 @@ TEST_F (PendingStateUpdaterTests, Waypoints)
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 2));
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 3));
 
-  /* Some invalid updates that will just not show up (i.e. ID 1 will have no
+  /* An invalid update that will just not show up (i.e. ID 1 will have no
      pending updates later on).  */
   Process ("domob", R"({
     "c": {"1": {"wp": "foo"}}
-  })");
-  Process ("domob", R"({
-    "c": {"1": {"wp": {"x": 4.5, "y": 3.141}}}
   })");
 
   /* Perform valid updates.  Only the waypoints updates will be tracked, and
@@ -825,12 +822,12 @@ TEST_F (PendingStateUpdaterTests, Waypoints)
   Process ("domob", R"({
     "c":
       {
-        "2": {"wp": [{"x": 0, "y": 100}]},
-        "3": {"wp": [{"x": 1, "y": -2}]}
+        "2": {"wp": )" + WpStr ({HexCoord (0, 100)}) + R"(},
+        "3": {"wp": )" + WpStr ({HexCoord (1, -2)}) + R"(}
       }
   })");
   Process ("domob", R"({
-    "c": {"2": {"wp": []}}
+    "c": {"2": {"wp": null}}
   })");
   Process ("domob", R"({
     "c": {"2": {"send": "andy"}}
@@ -1275,7 +1272,7 @@ TEST_F (PendingStateUpdaterTests, CreationAndUpdateTogether)
 
   ProcessWithDevPayment ("domob", characterCost, R"({
     "nc": [{}],
-    "c": {"1": {"wp": []}}
+    "c": {"1": {"wp": null}}
   })");
 
   ExpectStateJson (R"(

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -567,6 +567,35 @@ PXRpcServer::getserviceinfo (const std::string& name, const Json::Value& op)
     });
 }
 
+std::string
+PXRpcServer::encodewaypoints (const Json::Value& wp)
+{
+  LOG (INFO) << "RPC method called: encodewaypoints\n" << wp;
+
+  /* This method does not use any game state (as it just exposes the
+     JSON compression code).  But since it is only really needed for testing,
+     there is no use in exposing it for the nonstate RPC server as well.  */
+
+  CHECK (wp.isArray ());
+
+  std::vector<HexCoord> wpArr;
+  for (const auto& entry : wp)
+    {
+      HexCoord c;
+      if (!CoordFromJson (entry, c))
+        ReturnError (ErrorCode::INVALID_ARGUMENT, "invalid waypoints");
+      wpArr.push_back (c);
+    }
+
+  Json::Value jsonWp;
+  std::string encoded;
+  if (!EncodeWaypoints (wpArr, jsonWp, encoded))
+    ReturnError (ErrorCode::FINDPATH_ENCODE_FAILED,
+                 "could not encode waypoints");
+
+  return encoded;
+}
+
 /* ************************************************************************** */
 
 } // namespace pxd

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -63,6 +63,7 @@ enum class ErrorCode
 
   /* Specific errors with findpath.  */
   FINDPATH_NO_CONNECTION = 1,
+  FINDPATH_ENCODE_FAILED = 4,
 
   /* Specific errors with getregionat.  */
   REGIONAT_OUT_OF_MAP = 2,
@@ -290,31 +291,34 @@ NonStateRpcServer::findpath (const Json::Value& exbuildings,
 
   /* Now step the path and construct waypoints, so that it is a principal
      direction between each of them.  */
-  Json::Value wp(Json::arrayValue);
+  std::vector<HexCoord> wp;
   PathFinder::Stepper path = finder.StepPath (sourceCoord);
-  HexCoord lastWp = path.GetPosition ();
-  wp.append (CoordToJson (lastWp));
-  HexCoord prev = lastWp;
+  wp.push_back (path.GetPosition ());
+  HexCoord prev = wp.back ();
   while (path.HasMore ())
     {
       path.Next ();
 
       HexCoord dir;
       HexCoord::IntT steps;
-      if (!lastWp.IsPrincipalDirectionTo (path.GetPosition (), dir, steps))
-        {
-          wp.append (CoordToJson (prev));
-          lastWp = prev;
-        }
+      if (!wp.back ().IsPrincipalDirectionTo (path.GetPosition (), dir, steps))
+        wp.push_back (prev);
 
       prev = path.GetPosition ();
     }
-  if (lastWp != path.GetPosition ())
-    wp.append (CoordToJson (path.GetPosition ()));
+  if (wp.back () != path.GetPosition ())
+    wp.push_back (path.GetPosition ());
+
+  Json::Value jsonWp;
+  std::string encoded;
+  if (!EncodeWaypoints (wp, jsonWp, encoded))
+    ReturnError (ErrorCode::FINDPATH_ENCODE_FAILED,
+                 "could not encode waypoints");
 
   Json::Value res(Json::objectValue);
   res["dist"] = dist;
-  res["wp"] = wp;
+  res["wp"] = jsonWp;
+  res["encoded"] = encoded;
 
   return res;
 }

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -226,6 +226,8 @@ public:
     return nonstate.getbuildingshape (centre, rot, type);
   }
 
+  std::string encodewaypoints (const Json::Value& wp) override;
+
 };
 
 } // namespace pxd

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -119,5 +119,14 @@
         "rot": 42
       },
     "returns": []
+  },
+
+  {
+    "name": "encodewaypoints",
+    "params":
+      {
+        "wp": [{"x": 1, "y": 2}]
+      },
+    "returns": "encoded"
   }
 ]

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -18,6 +18,8 @@
 
 #include "testutils.hpp"
 
+#include "movement.hpp"
+
 #include <xayautil/hash.hpp>
 
 #include <glog/logging.h>
@@ -197,6 +199,15 @@ PartialJsonEqual (const Json::Value& actual, const Json::Value& expected)
     }
 
   return true;
+}
+
+std::string
+WpStr (const std::vector<HexCoord>& wp)
+{
+  Json::Value jsonWp;
+  std::string encoded;
+  CHECK (EncodeWaypoints (wp, jsonWp, encoded));
+  return "\"" + encoded + "\"";
 }
 
 } // namespace pxd

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -76,6 +76,14 @@ Json::Value ParseJson (const std::string& str);
  */
 bool PartialJsonEqual (const Json::Value& actual, const Json::Value& expected);
 
+/**
+ * Encodes one or more waypoints for a "wp" move.  This is a wrapper around
+ * the main encoding function, which asserts that encoding was successful
+ * and also adds quotes around the string so it can be concat directly
+ * with others into a JSON literal.
+ */
+std::string WpStr (const std::vector<HexCoord>& wp);
+
 } // namespace pxd
 
 #endif // PXD_TESTUTILS_HPP


### PR DESCRIPTION
With #145, paths sent in moves got a lot bigger when moving long distances.  Moving e.g. across the entire map could result in a list of waypoints that exceeds the value-size-limit in Xaya.  This change replaces the value passed to `wp` in a move with an encoded string (which is the previous array serialised as string, compressed and base64-encoded).  Moves across the map that previously would have taken 3.5 KiB now need less than 700 bytes in encoded form (which is good enough for the 2 KiB size limit).

The first impact this has is that now the `findpath` method returns an additional output, `encoded`.  This is the encoded string corresponding to the returned waypoints in `wp`.

Secondly, the `wp` field in a character update move now needs to be passed a string of the right form (i.e. returned by `findpath`) instead of a plain JSON array of waypoints.  It can also be set explicitly to JSON `null`, which corresponds to an empty set of waypoints, e.g. for stopping movement or mining.