### PR TITLE
Implement friendly combat and "ally shield projector"

### DIFF
--- a/database/building.cpp
+++ b/database/building.cpp
@@ -75,14 +75,14 @@ Building::~Building ()
           (`id`, `type`,
            `faction`, `owner`, `x`, `y`,
            `hp`, `regendata`, `target`,
-           `attackrange`, `canregen`,
+           `attackrange`, `friendlyrange`, `canregen`,
            `effects`, `proto`)
           VALUES
           (?1, ?2,
            ?3, ?4, ?5, ?6,
            ?7, ?8, ?9,
-           ?10, ?11,
-           ?12, ?13)
+           ?10, ?11, ?12,
+           ?13, ?14)
       )");
 
       stmt.Bind (1, id);
@@ -93,15 +93,15 @@ Building::~Building ()
       else
         stmt.Bind (4, owner);
       BindCoordParameter (stmt, 5, 6, pos);
-      CombatEntity::BindFields (stmt, 7, 11);
-      CombatEntity::BindFullFields (stmt, 8, 9, 10);
+      CombatEntity::BindFields (stmt, 7, 12);
+      CombatEntity::BindFullFields (stmt, 8, 9, 10, 11);
 
       if (effects.IsEmpty ())
-        stmt.BindNull (12);
+        stmt.BindNull (13);
       else
-        stmt.BindProto (12, effects);
+        stmt.BindProto (13, effects);
 
-      stmt.BindProto (13, data);
+      stmt.BindProto (14, data);
       stmt.Execute ();
 
       return;
@@ -194,7 +194,7 @@ BuildingsTable::QueryWithAttacks ()
   auto stmt = db.Prepare (R"(
     SELECT *
       FROM `buildings`
-      WHERE `attackrange` IS NOT NULL
+      WHERE (`attackrange` IS NOT NULL) OR (`friendlyrange` IS NOT NULL)
       ORDER BY `id`
   )");
   return stmt.Query<BuildingResult> ();

--- a/database/building.cpp
+++ b/database/building.cpp
@@ -74,15 +74,15 @@ Building::~Building ()
         INSERT OR REPLACE INTO `buildings`
           (`id`, `type`,
            `faction`, `owner`, `x`, `y`,
-           `hp`, `regendata`, `target`,
+           `hp`, `regendata`, `target`, `friendlytargets`,
            `attackrange`, `friendlyrange`, `canregen`,
            `effects`, `proto`)
           VALUES
           (?1, ?2,
            ?3, ?4, ?5, ?6,
-           ?7, ?8, ?9,
-           ?10, ?11, ?12,
-           ?13, ?14)
+           ?7, ?8, ?9, ?10,
+           ?11, ?12, ?13,
+           ?14, ?15)
       )");
 
       stmt.Bind (1, id);
@@ -93,15 +93,15 @@ Building::~Building ()
       else
         stmt.Bind (4, owner);
       BindCoordParameter (stmt, 5, 6, pos);
-      CombatEntity::BindFields (stmt, 7, 12);
-      CombatEntity::BindFullFields (stmt, 8, 9, 10, 11);
+      CombatEntity::BindFields (stmt, 7, 10, 13);
+      CombatEntity::BindFullFields (stmt, 8, 9, 11, 12);
 
       if (effects.IsEmpty ())
-        stmt.BindNull (13);
+        stmt.BindNull (14);
       else
-        stmt.BindProto (13, effects);
+        stmt.BindProto (14, effects);
 
-      stmt.BindProto (14, data);
+      stmt.BindProto (15, data);
       stmt.Execute ();
 
       return;
@@ -218,7 +218,7 @@ BuildingsTable::QueryWithTarget ()
   auto stmt = db.Prepare (R"(
     SELECT *
       FROM `buildings`
-      WHERE `target` IS NOT NULL
+      WHERE (`target` IS NOT NULL) OR `friendlytargets`
       ORDER BY `id`
   )");
   return stmt.Query<BuildingResult> ();

--- a/database/building.hpp
+++ b/database/building.hpp
@@ -246,7 +246,7 @@ public:
   Database::Result<BuildingResult> QueryAll ();
 
   /**
-   * Queries for all buildings with attacks.
+   * Queries for all buildings with attacks (including friendly ones).
    */
   Database::Result<BuildingResult> QueryWithAttacks ();
 

--- a/database/building.hpp
+++ b/database/building.hpp
@@ -257,7 +257,8 @@ public:
 
   /**
    * Queries for all buildings that have a combat target and thus need
-   * to be processed for damage.
+   * to be processed for damage.  This includes buildings that only have
+   * a friendly target in range.
    */
   Database::Result<BuildingResult> QueryWithTarget ();
 

--- a/database/building_tests.cpp
+++ b/database/building_tests.cpp
@@ -143,18 +143,24 @@ TEST_F (BuildingTests, CombatFields)
   h = tbl.GetById (id);
   EXPECT_EQ (h->GetRegenData ().regeneration_mhp ().shield (), 42);
   EXPECT_FALSE (h->HasTarget ());
+  EXPECT_FALSE (h->HasFriendlyTargets ());
   proto::TargetId t;
   t.set_id (50);
   h->SetTarget (t);
+  h->SetFriendlyTargets (true);
   h.reset ();
 
   h = tbl.GetById (id);
   ASSERT_TRUE (h->HasTarget ());
   EXPECT_EQ (h->GetTarget ().id (), 50);
+  EXPECT_TRUE (h->HasFriendlyTargets ());
   h->ClearTarget ();
+  h->SetFriendlyTargets (false);
   h.reset ();
 
-  EXPECT_FALSE (tbl.GetById (id)->HasTarget ());
+  h = tbl.GetById (id);
+  EXPECT_FALSE (h->HasTarget ());
+  EXPECT_FALSE (h->HasFriendlyTargets ());
 }
 
 TEST_F (BuildingTests, CombatEffects)
@@ -262,6 +268,14 @@ TEST_F (BuildingsTableTests, QueryWithTarget)
   res = tbl.QueryWithTarget ();
   ASSERT_TRUE (res.Step ());
   EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "andy");
+  ASSERT_FALSE (res.Step ());
+
+  tbl.GetById (id1)->SetFriendlyTargets (true);
+  tbl.GetById (id2)->ClearTarget ();
+
+  res = tbl.QueryWithTarget ();
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "domob");
   ASSERT_FALSE (res.Step ());
 }
 

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -89,7 +89,7 @@ Character::~Character ()
            `volatilemv`, `hp`,
            `canregen`,
            `faction`,
-           `ismoving`, `ismining`, `attackrange`,
+           `ismoving`, `ismining`, `attackrange`, `friendlyrange`,
            `regendata`, `target`, `inventory`, `effects`, `proto`)
           VALUES
           (?1,
@@ -98,23 +98,23 @@ Character::~Character ()
            ?7, ?8,
            ?9,
            ?101,
-           ?102, ?103, ?104,
-           ?105, ?106, ?107, ?108, ?109)
+           ?102, ?103, ?104, ?105,
+           ?106, ?107, ?108, ?109, ?110)
       )");
 
       BindFieldValues (stmt);
-      CombatEntity::BindFullFields (stmt, 105, 106, 104);
+      CombatEntity::BindFullFields (stmt, 106, 107, 104, 105);
 
       if (effects.IsEmpty ())
-        stmt.BindNull (108);
+        stmt.BindNull (109);
       else
-        stmt.BindProto (108, effects);
+        stmt.BindProto (109, effects);
 
       BindFactionParameter (stmt, 101, faction);
       stmt.Bind (102, data.Get ().has_movement ());
       stmt.Bind (103, data.Get ().mining ().active ());
-      stmt.BindProto (107, inv.GetProtoForBinding ());
-      stmt.BindProto (109, data);
+      stmt.BindProto (108, inv.GetProtoForBinding ());
+      stmt.BindProto (110, data);
       stmt.Execute ();
 
       return;
@@ -337,7 +337,8 @@ CharacterTable::QueryWithAttacks ()
   auto stmt = db.Prepare (R"(
     SELECT *
       FROM `characters`
-      WHERE `attackrange` IS NOT NULL AND `inBuilding` IS NULL
+      WHERE ((`attackrange` IS NOT NULL) OR (`friendlyrange` IS NOT NULL))
+          AND `inBuilding` IS NULL
       ORDER BY `id`
   )");
   return stmt.Query<CharacterResult> ();

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -87,7 +87,7 @@ Character::~Character ()
            `owner`, `x`, `y`,
            `inbuilding`, `enterbuilding`,
            `volatilemv`, `hp`,
-           `canregen`,
+           `canregen`, `friendlytargets`,
            `faction`,
            `ismoving`, `ismining`, `attackrange`, `friendlyrange`,
            `regendata`, `target`, `inventory`, `effects`, `proto`)
@@ -96,7 +96,7 @@ Character::~Character ()
            ?2, ?3, ?4,
            ?5, ?6,
            ?7, ?8,
-           ?9,
+           ?9, ?10,
            ?101,
            ?102, ?103, ?104, ?105,
            ?106, ?107, ?108, ?109, ?110)
@@ -134,7 +134,8 @@ Character::~Character ()
               `enterbuilding` = ?6,
               `volatilemv` = ?7,
               `hp` = ?8,
-              `canregen` = ?9
+              `canregen` = ?9,
+              `friendlytargets` = ?10
           WHERE `id` = ?1
       )");
 
@@ -179,7 +180,7 @@ Character::Validate () const
 void
 Character::BindFieldValues (Database::Statement& stmt) const
 {
-  CombatEntity::BindFields (stmt, 8, 9);
+  CombatEntity::BindFields (stmt, 8, 10, 9);
 
   stmt.Bind (1, id);
   stmt.Bind (2, owner);
@@ -359,7 +360,7 @@ CharacterTable::QueryWithTarget ()
   auto stmt = db.Prepare (R"(
     SELECT *
       FROM `characters`
-      WHERE `target` IS NOT NULL
+      WHERE (`target` IS NOT NULL) OR `friendlytargets`
       ORDER BY `id`
   )");
   return stmt.Query<CharacterResult> ();

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -396,7 +396,8 @@ public:
 
   /**
    * Queries for all characters that have a combat target and thus need
-   * to be processed for damage.
+   * to be processed for damage.  This also includes ones that have
+   * just a friendly target.
    */
   Database::Result<CharacterResult> QueryWithTarget ();
 

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -383,8 +383,9 @@ public:
   Database::Result<CharacterResult> QueryMining ();
 
   /**
-   * Queries for all characters with attacks.  This only includes characters
-   * on the map, as characters in buildings can't attack anyway.
+   * Queries for all characters with attacks (including friendly ones).
+   * This only includes characters on the map, as characters in buildings
+   * can't attack anyway.
    */
   Database::Result<CharacterResult> QueryWithAttacks ();
 

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -231,21 +231,30 @@ TEST_F (CharacterTests, AttackRange)
   c.reset ();
 
   c = tbl.GetById (id);
-  EXPECT_EQ (c->GetAttackRange (), CombatEntity::NO_ATTACKS);
-  c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (0);
+  EXPECT_EQ (c->GetAttackRange (false), CombatEntity::NO_ATTACKS);
+  EXPECT_EQ (c->GetAttackRange (true), CombatEntity::NO_ATTACKS);
+  auto* att = c->MutableProto ().mutable_combat_data ()->add_attacks ();
+  att->set_range (0);
+  att = c->MutableProto ().mutable_combat_data ()->add_attacks ();
+  att->set_range (1);
+  att->set_friendlies (true);
   c.reset ();
 
   c = tbl.GetById (id);
-  EXPECT_EQ (c->GetAttackRange (), 0);
+  EXPECT_EQ (c->GetAttackRange (false), 0);
+  EXPECT_EQ (c->GetAttackRange (true), 1);
   c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (5);
   c.reset ();
 
   c = tbl.GetById (id);
-  EXPECT_EQ (c->GetAttackRange (), 5);
+  EXPECT_EQ (c->GetAttackRange (false), 5);
+  EXPECT_EQ (c->GetAttackRange (true), 1);
   c->MutableProto ().clear_combat_data ();
   c.reset ();
 
-  EXPECT_EQ (tbl.GetById (id)->GetAttackRange (), CombatEntity::NO_ATTACKS);
+  c = tbl.GetById (id);
+  EXPECT_EQ (c->GetAttackRange (false), CombatEntity::NO_ATTACKS);
+  EXPECT_EQ (c->GetAttackRange (true), CombatEntity::NO_ATTACKS);
 }
 
 TEST_F (CharacterTests, UsedCargoSpace)
@@ -344,14 +353,21 @@ TEST_F (CharacterTableTests, QueryWithAttacks)
   tbl.CreateNew ("domob", Faction::RED);
   tbl.CreateNew ("andy", Faction::RED)
     ->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (0);
-  auto h = tbl.CreateNew ("inbuilding", Faction::RED);
-  h->SetBuildingId (100);
-  h->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (1);
-  h.reset ();
+  auto c = tbl.CreateNew ("inbuilding", Faction::RED);
+  c->SetBuildingId (100);
+  c->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (1);
+  c.reset ();
+  c = tbl.CreateNew ("daniel", Faction::RED);
+  auto* att = c->MutableProto ().mutable_combat_data ()->add_attacks ();
+  att->set_area (1);
+  att->set_friendlies (true);
+  c.reset ();
 
   auto res = tbl.QueryWithAttacks ();
   ASSERT_TRUE (res.Step ());
   EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "andy");
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "daniel");
   ASSERT_FALSE (res.Step ());
 }
 

--- a/database/character_tests.cpp
+++ b/database/character_tests.cpp
@@ -190,6 +190,25 @@ TEST_F (CharacterTests, Target)
   EXPECT_FALSE (tbl.GetById (id)->HasTarget ());
 }
 
+TEST_F (CharacterTests, FriendlyTargets)
+{
+  auto c = tbl.CreateNew ("domob", Faction::RED);
+  const auto id = c->GetId ();
+  c.reset ();
+
+  c = tbl.GetById (id);
+  EXPECT_FALSE (c->HasFriendlyTargets ());
+  c->SetFriendlyTargets (true);
+  c.reset ();
+
+  c = tbl.GetById (id);
+  EXPECT_TRUE (c->HasFriendlyTargets ());
+  c->SetFriendlyTargets (false);
+  c.reset ();
+
+  EXPECT_FALSE (tbl.GetById (id)->HasFriendlyTargets ());
+}
+
 TEST_F (CharacterTests, Inventory)
 {
   auto h = tbl.CreateNew ("domob", Faction::RED);
@@ -486,6 +505,14 @@ TEST_F (CharacterTableTests, QueryWithTarget)
   res = tbl.QueryWithTarget ();
   ASSERT_TRUE (res.Step ());
   EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "andy");
+  ASSERT_FALSE (res.Step ());
+
+  tbl.GetById (id1)->SetFriendlyTargets (true);
+  tbl.GetById (id2)->ClearTarget ();
+
+  res = tbl.QueryWithTarget ();
+  ASSERT_TRUE (res.Step ());
+  EXPECT_EQ (tbl.GetFromResult (res)->GetOwner (), "domob");
   ASSERT_FALSE (res.Step ());
 }
 

--- a/database/combat.cpp
+++ b/database/combat.cpp
@@ -26,7 +26,9 @@ namespace pxd
 constexpr HexCoord::IntT CombatEntity::NO_ATTACKS;
 
 CombatEntity::CombatEntity (Database& d)
-  : db(d), isNew(true), oldCanRegen(false)
+  : db(d), isNew(true),
+    friendlyTargets(false), oldCanRegen(false),
+    isDirty(true)
 {
   hp.SetToDefault ();
   regenData.SetToDefault ();
@@ -62,6 +64,7 @@ CombatEntity::BindFullFields (Database::Statement& stmt,
 
 void
 CombatEntity::BindFields (Database::Statement& stmt, const unsigned indHp,
+                          const unsigned indFriendlyTargets,
                           const unsigned indCanRegen) const
 {
   bool canRegen = oldCanRegen;
@@ -69,6 +72,7 @@ CombatEntity::BindFields (Database::Statement& stmt, const unsigned indHp,
     canRegen = ComputeCanRegen (hp.Get (), regenData.Get ());
 
   stmt.BindProto (indHp, hp);
+  stmt.Bind (indFriendlyTargets, friendlyTargets);
   stmt.Bind (indCanRegen, canRegen);
 }
 

--- a/database/combat.tpp
+++ b/database/combat.tpp
@@ -43,6 +43,11 @@ template <typename T>
   else
     oldAttackRange = res.template Get<typename T::attackrange> ();
 
+  if (res.template IsNull<typename T::friendlyrange> ())
+    oldFriendlyRange = NO_ATTACKS;
+  else
+    oldFriendlyRange = res.template Get<typename T::friendlyrange> ();
+
   oldCanRegen = res.template Get<typename T::canregen> ();
 }
 

--- a/database/combat.tpp
+++ b/database/combat.tpp
@@ -25,7 +25,7 @@ namespace pxd
 
 template <typename T>
   CombatEntity::CombatEntity (Database& d, const Database::Result<T>& res)
-    : db(d), isNew(false)
+    : db(d), isNew(false), isDirty(false)
 {
   static_assert (std::is_base_of<ResultWithCombat, T>::value,
                  "CombatEntity needs a ResultWithCombat");
@@ -49,6 +49,7 @@ template <typename T>
     oldFriendlyRange = res.template Get<typename T::friendlyrange> ();
 
   oldCanRegen = res.template Get<typename T::canregen> ();
+  friendlyTargets = res.template Get<typename T::friendlytargets> ();
 }
 
 } // namespace pxd

--- a/database/combat_tests.cpp
+++ b/database/combat_tests.cpp
@@ -118,12 +118,12 @@ protected:
    * Calls FindAttackRange based on the combat data given as text proto.
    */
   static HexCoord::IntT
-  FindRange (const std::string str)
+  FindRange (const bool friendly, const std::string str)
   {
     proto::CombatData pb;
     CHECK (TextFormat::ParseFromString (str, &pb));
 
-    return CombatEntity::FindAttackRange (pb);
+    return CombatEntity::FindAttackRange (pb, friendly);
   }
 
 };
@@ -133,12 +133,13 @@ namespace
 
 TEST_F (FindAttackRangeTests, NoAttacks)
 {
-  EXPECT_EQ (FindRange (""), CombatEntity::NO_ATTACKS);
+  EXPECT_EQ (FindRange (false, ""), CombatEntity::NO_ATTACKS);
+  EXPECT_EQ (FindRange (true, ""), CombatEntity::NO_ATTACKS);
 }
 
 TEST_F (FindAttackRangeTests, MaximumRange)
 {
-  EXPECT_EQ (FindRange (R"(
+  EXPECT_EQ (FindRange (false, R"(
     attacks: { range: 5 }
     attacks: { range: 42 }
     attacks: { range: 1 }
@@ -147,19 +148,31 @@ TEST_F (FindAttackRangeTests, MaximumRange)
 
 TEST_F (FindAttackRangeTests, AreaAttacks)
 {
-  EXPECT_EQ (FindRange (R"(
+  EXPECT_EQ (FindRange (false, R"(
     attacks: { range: 5 area: 2 }
   )"), 5);
-  EXPECT_EQ (FindRange (R"(
+  EXPECT_EQ (FindRange (false, R"(
     attacks: { area: 3 }
   )"), 3);
 }
 
 TEST_F (FindAttackRangeTests, ZeroRange)
 {
-  EXPECT_EQ (FindRange (R"(
+  EXPECT_EQ (FindRange (false, R"(
     attacks: { range: 0 }
   )"), 0);
+}
+
+TEST_F (FindAttackRangeTests, Friendly)
+{
+  EXPECT_EQ (FindRange (false, R"(
+    attacks: { range: 1 }
+    attacks: { range: 2 friendlies: true }
+  )"), 1);
+  EXPECT_EQ (FindRange (true, R"(
+    attacks: { range: 1 }
+    attacks: { range: 2 friendlies: true }
+  )"), 2);
 }
 
 } // anonymous namespace

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -87,7 +87,8 @@ public:
 
   /**
    * Retrieves and processes all fighers that have a target, i.e. for whom
-   * we need to deal damage.
+   * we need to deal damage.  This includes fighters that have only
+   * friendlies in range but a friendly attack.
    */
   void ProcessWithTarget (const Callback& cb);
 

--- a/database/fighter.hpp
+++ b/database/fighter.hpp
@@ -74,7 +74,9 @@ public:
 
   /**
    * Retrieves all fighters from the database that have an attack and runs
-   * the callback on each one.
+   * the callback on each one.  This includes fighters with only friendly
+   * attacks, and hence essentially means "process everyone that needs it
+   * for target finding".
    */
   void ProcessWithAttacks (const Callback& cb);
 

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -96,6 +96,13 @@ TEST_F (FighterTableTests, ProcessWithAttacks)
   b->MutableProto ().mutable_combat_data ()->add_attacks ()->set_range (5);
   b.reset ();
 
+  c = characters.CreateNew ("daniel", Faction::RED);
+  const auto idFriendly = c->GetId ();
+  auto* att = c->MutableProto ().mutable_combat_data ()->add_attacks ();
+  att->set_area (1);
+  att->set_friendlies (true);
+  c.reset ();
+
   unsigned cnt = 0;
   tbl.ProcessWithAttacks ([&] (FighterTable::Handle f)
     {
@@ -114,12 +121,18 @@ TEST_F (FighterTableTests, ProcessWithAttacks)
           EXPECT_EQ (f->GetIdAsTarget ().id (), idChar);
           break;
 
+        case 3:
+          EXPECT_EQ (f->GetIdAsTarget ().type (),
+                     proto::TargetId::TYPE_CHARACTER);
+          EXPECT_EQ (f->GetIdAsTarget ().id (), idFriendly);
+          break;
+
         default:
-          FAIL () << "Too many regen-able fighters returned";
+          FAIL () << "Too many attack-able fighters returned";
           break;
         }
     });
-  EXPECT_EQ (cnt, 2);
+  EXPECT_EQ (cnt, 3);
 }
 
 TEST_F (FighterTableTests, ProcessForRegen)

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -200,6 +200,11 @@ TEST_F (FighterTableTests, ProcessWithTarget)
   b->SetTarget (t);
   b.reset ();
 
+  c = characters.CreateNew ("daniel", Faction::RED);
+  const auto idFriendly = c->GetId ();
+  c->SetFriendlyTargets (true);
+  c.reset ();
+
   unsigned cnt = 0;
   tbl.ProcessWithTarget ([&] (FighterTable::Handle f)
     {
@@ -218,12 +223,18 @@ TEST_F (FighterTableTests, ProcessWithTarget)
           EXPECT_EQ (f->GetIdAsTarget ().id (), idChar);
           break;
 
+        case 3:
+          EXPECT_EQ (f->GetIdAsTarget ().type (),
+                     proto::TargetId::TYPE_CHARACTER);
+          EXPECT_EQ (f->GetIdAsTarget ().id (), idFriendly);
+          break;
+
         default:
           FAIL () << "Too many targets returned";
           break;
         }
     });
-  EXPECT_EQ (cnt, 2);
+  EXPECT_EQ (cnt, 3);
 }
 
 TEST_F (FighterTableTests, Effects)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -94,6 +94,10 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- full proto) every time.
   `attackrange` INTEGER NULL,
 
+  -- The range of the longest "attack" affecting friendlies, or NULL if there
+  -- is no such attack.
+  `friendlyrange` INTEGER NULL,
+
   -- Flag indicating whether a character may need HP regeneration.  This is
   -- set here (based on the RegenData and current HP) so that we can only
   -- retrieve and process characters that need regeneration.
@@ -117,6 +121,8 @@ CREATE INDEX IF NOT EXISTS `characters_ismoving` ON `characters` (`ismoving`);
 CREATE INDEX IF NOT EXISTS `characters_ismining` ON `characters` (`ismining`);
 CREATE INDEX IF NOT EXISTS `characters_attackrange`
   ON `characters` (`attackrange`);
+CREATE INDEX IF NOT EXISTS `characters_friendlyrange`
+  ON `characters` (`friendlyrange`);
 CREATE INDEX IF NOT EXISTS `characters_canregen` ON `characters` (`canregen`);
 CREATE INDEX IF NOT EXISTS `characters_target` ON `characters` (`target`);
 CREATE INDEX IF NOT EXISTS `characters_effects` ON `characters` (`effects`);
@@ -169,8 +175,9 @@ CREATE TABLE IF NOT EXISTS `buildings` (
   `effects` BLOB NULL,
 
   -- The range of the longest attack this building has or NULL if there
-  -- is no attack at all.
+  -- is no attack at all, and the longest friendly affecting "attack".
   `attackrange` INTEGER NULL,
+  `friendlyrange` INTEGER NULL,
 
   -- Flag indicating whether a building may need HP regeneration.
   `canregen` INTEGER NULL NOT NULL,
@@ -183,6 +190,8 @@ CREATE TABLE IF NOT EXISTS `buildings` (
 CREATE INDEX IF NOT EXISTS `buildings_pos` ON `buildings` (`x`, `y`);
 CREATE INDEX IF NOT EXISTS `buildings_attackrange`
   ON `buildings` (`attackrange`);
+CREATE INDEX IF NOT EXISTS `buildings_friendlyrange`
+  ON `buildings` (`friendlyrange`);
 CREATE INDEX IF NOT EXISTS `buildings_canregen` ON `buildings` (`canregen`);
 CREATE INDEX IF NOT EXISTS `buildings_target` ON `buildings` (`target`);
 CREATE INDEX IF NOT EXISTS `buildings_effects` ON `buildings` (`effects`);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -69,6 +69,11 @@ CREATE TABLE IF NOT EXISTS `characters` (
   -- as we later on only process attacks of characters with a selected target.
   `target` BLOB NULL,
 
+  -- Whether or not friendlies are in range of a friendly attack, which
+  -- indicates that this character needs to be processed for "dealing damage"
+  -- next time a block is processed.
+  `friendlytargets` INTEGER NOT NULL,
+
   -- Any combat effects that apply to the character (or NULL if none).
   -- This is a serialised CombatEffects protocol buffer.  The effects
   -- are set by the combat damaging phase, and then in effect until
@@ -125,6 +130,8 @@ CREATE INDEX IF NOT EXISTS `characters_friendlyrange`
   ON `characters` (`friendlyrange`);
 CREATE INDEX IF NOT EXISTS `characters_canregen` ON `characters` (`canregen`);
 CREATE INDEX IF NOT EXISTS `characters_target` ON `characters` (`target`);
+CREATE INDEX IF NOT EXISTS `characters_friendlytargets`
+  ON `characters` (`friendlytargets`);
 CREATE INDEX IF NOT EXISTS `characters_effects` ON `characters` (`effects`);
 
 -- =============================================================================
@@ -170,6 +177,9 @@ CREATE TABLE IF NOT EXISTS `buildings` (
   -- The attacked target (if any), as a serialised TargetId proto.
   `target` BLOB NULL,
 
+  -- Whether or not friendlies are in range and processing needs to happen.
+  `friendlytargets` INTEGER NOT NULL,
+
   -- Any combat effects that apply to the building (or NULL if none).
   -- This is a serialised CombatEffects protocol buffer.
   `effects` BLOB NULL,
@@ -194,6 +204,8 @@ CREATE INDEX IF NOT EXISTS `buildings_friendlyrange`
   ON `buildings` (`friendlyrange`);
 CREATE INDEX IF NOT EXISTS `buildings_canregen` ON `buildings` (`canregen`);
 CREATE INDEX IF NOT EXISTS `buildings_target` ON `buildings` (`target`);
+CREATE INDEX IF NOT EXISTS `buildings_friendlytargets`
+  ON `buildings` (`friendlytargets`);
 CREATE INDEX IF NOT EXISTS `buildings_effects` ON `buildings` (`effects`);
 
 -- =============================================================================

--- a/database/target.hpp
+++ b/database/target.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -58,11 +58,13 @@ public:
   void operator= (const TargetFinder&) = delete;
 
   /**
-   * Finds all enemy targets in the given L1 range and executes the
-   * callback on each of the resulting Target instances.
+   * Finds all targets in the given L1 range and executes the
+   * callback on each of the resulting Target instances.  This function can
+   * be used to query for enemies, friendlies or all.
    */
   void ProcessL1Targets (const HexCoord& centre, HexCoord::IntT l1range,
-                         Faction action, const ProcessingFcn& cb);
+                         Faction faction, bool enemies, bool friendlies,
+                         const ProcessingFcn& cb);
 
 };
 

--- a/database/target_bench.cpp
+++ b/database/target_bench.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -56,6 +56,7 @@ InsertTestCharacters (Database& db, const unsigned n,
  *  - Characters in range
  *  - Characters outside range but on same x coordinate
  *  - Characters outside range but on same y coordinate
+ *  - Friendly characters on same position
  */
 void
 TargetFinding (benchmark::State& state)
@@ -67,10 +68,12 @@ TargetFinding (benchmark::State& state)
   const unsigned inRange = state.range (1);
   const unsigned sameX = state.range (2);
   const unsigned sameY = state.range (3);
+  const unsigned friendly = state.range (4);
 
   InsertTestCharacters (db, inRange, HexCoord (0, 0), Faction::GREEN);
   InsertTestCharacters (db, sameX, HexCoord (0, 2 * range), Faction::GREEN);
   InsertTestCharacters (db, sameY, HexCoord (2 * range, 0), Faction::GREEN);
+  InsertTestCharacters (db, friendly, HexCoord (0, 0), Faction::RED);
 
   TargetFinder finder(db);
   for (auto _ : state)
@@ -82,21 +85,25 @@ TargetFinding (benchmark::State& state)
           ++cnt;
         };
 
-      finder.ProcessL1Targets (HexCoord (0, 0), range, Faction::RED, cb);
+      finder.ProcessL1Targets (HexCoord (0, 0), range,
+                               Faction::RED, true, false,
+                               cb);
 
       CHECK_EQ (cnt, inRange);
     }
 }
 BENCHMARK (TargetFinding)
   ->Unit (benchmark::kMicrosecond)
-  ->Args ({10, 1, 0, 0})
-  ->Args ({10, 100, 0, 0})
-  ->Args ({10, 10000, 0, 0})
-  ->Args ({100, 1, 0, 0})
-  ->Args ({100, 100, 0, 0})
-  ->Args ({100, 10000, 0, 0})
-  ->Args ({10, 100, 10000, 0})
-  ->Args ({10, 100, 0, 10000});
+  ->Args ({10, 1, 0, 0, 0})
+  ->Args ({10, 100, 0, 0, 0})
+  ->Args ({10, 10000, 0, 0, 0})
+  ->Args ({100, 1, 0, 0, 0})
+  ->Args ({100, 100, 0, 0, 0})
+  ->Args ({100, 10000, 0, 0, 0})
+  ->Args ({100, 100, 0, 0, 100})
+  ->Args ({100, 100, 0, 0, 1000})
+  ->Args ({10, 100, 10000, 0, 0})
+  ->Args ({10, 100, 0, 10000, 0});
 
 } // anonymous namespace
 } // namespace pxd

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -19,6 +19,7 @@ REGTESTS = \
   combat_aoe.py \
   combat_damage.py \
   combat_effects.py \
+  combat_friendly.py \
   combat_targets.py \
   damage_lists.py \
   fame.py \

--- a/gametest/combat_friendly.py
+++ b/gametest/combat_friendly.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests friendly combat effects (ally shield projector).
+"""
+
+from pxtest import PXTest, offsetCoord
+
+
+class CombatFriendlyTest (PXTest):
+
+  def expectShield (self, charId, expected):
+    """
+    Expects that the shield HP (including the fractional part) of the
+    given character match the expected value.
+    """
+
+    c = self.getCharacters ()[charId]
+    actual = c.data["combat"]["hp"]["current"]["shield"]
+    self.assertEqual (round (1000 * actual), round (1000 * expected))
+
+  def run (self):
+    self.collectPremine ()
+
+    self.mainLogger.info ("Creating test characters...")
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob", 2)
+    self.generate (1)
+    self.changeCharacterVehicle ("domob", "light attacker")
+    self.changeCharacterVehicle ("domob 2", "light attacker",
+                                 ["lf allyreplenish"])
+
+    self.moveCharactersTo ({
+      "domob": {"x": 0, "y": 2},
+      "domob 2": {"x": 0, "y": 0},
+    })
+    self.setCharactersHP ({"domob": {"s": 0}})
+
+    self.mainLogger.info ("Regenerating out of range...")
+    self.generate (3)
+    self.expectShield ("domob", 1.5)
+
+    self.mainLogger.info ("Moving into range...")
+    self.moveCharactersTo ({
+      "domob": {"x": 0, "y": 1},
+    })
+    # Moving the character into range mines one block, which regenerates
+    # normally and applies targeting.  From then on, the boosted rate
+    # is applied.
+    self.generate (3)
+    self.expectShield ("domob", 2 + 3 * 0.5 * 1.15)
+
+    self.mainLogger.info ("Moving out of range again...")
+    self.moveCharactersTo ({
+      "domob": {"x": 1, "y": 1},
+    })
+    # Moving out of range mines a block during whose regeneration phase
+    # the effect is still in place (as the movement happens afterwards).
+    # Then only normal regeneration is active.
+    self.generate (5)
+    self.expectShield ("domob", 2 + 4 * 0.5 * 1.15 + 5 * 0.5)
+
+
+if __name__ == "__main__":
+  CombatFriendlyTest ().main ()

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -64,6 +64,9 @@ message CombatEffects
   /** Modification to the range.  */
   optional StatModifier range = 2;
 
+  /** Modification to the shield regeneration rate.  */
+  optional StatModifier shield_regen = 3;
+
 }
 
 /**
@@ -127,6 +130,12 @@ message Attack
    * added to the armour (if not full).
    */
   optional bool gain_hp = 5;
+
+  /**
+   * If true, then this attack affects friendlies instead of enemies.
+   * This is used for positive effects, like improved shield regeneration.
+   */
+  optional bool friendlies = 6;
 
 }
 

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -953,6 +953,31 @@ fungible_items:
 
 fungible_items:
 {
+    key: "lf allyreplenish"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: LIGHT
+            attack:
+              {
+                area: 1
+                friendlies: true
+                effects: { shield_regen: { percent: 15 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "lf rangered"
     value:
 	{

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -198,6 +198,7 @@ fungible_items:
             mining_rate: { min: 1 max: 1 }
             prospecting_blocks: 10
             size: LIGHT
+            equipment_slots: { key: "mid" value: 10 }
           }
       }
   }

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -263,6 +263,17 @@ private:
         return false;
       }
 
+    if (attack.friendlies () && attack.has_range ())
+      {
+        LOG (WARNING) << "Friendly-attack must not have a range";
+        return false;
+      }
+    if (attack.friendlies () && attack.has_damage ())
+      {
+        LOG (WARNING) << "Friendly-attack must not have any damage";
+        return false;
+      }
+
     return true;
   }
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -131,7 +131,7 @@ SelectTarget (TargetFinder& targets, xaya::Random& rnd, const Context& ctx,
       return;
     }
 
-  HexCoord::IntT range = f->GetAttackRange ();
+  HexCoord::IntT range = f->GetAttackRange (false);
   if (range == CombatEntity::NO_ATTACKS)
     {
       VLOG (1) << "Fighter at " << pos << " has no attacks";

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1056,8 +1056,12 @@ RegenerateFighterHP (FighterTable::Handle f)
       f->MutableHP ().mutable_mhp ()->set_armour (milli);
     }
 
+  const StatModifier shieldRegenMod(f->GetEffects ().shield_regen ());
+  const unsigned shieldRate
+      = shieldRegenMod (regen.regeneration_mhp ().shield ());
+
   if (RegenerateHpType (
-          regen.max_hp ().shield (), regen.regeneration_mhp ().shield (),
+          regen.max_hp ().shield (), shieldRate,
           hp.shield (), hp.mhp ().shield (), cur, milli))
     {
       f->MutableHP ().set_shield (cur);

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -149,7 +149,7 @@ SelectTarget (TargetFinder& targets, xaya::Random& rnd, const Context& ctx,
   HexCoord::IntT closestRange;
   std::vector<proto::TargetId> closestTargets;
 
-  targets.ProcessL1Targets (pos, range, f->GetFaction (),
+  targets.ProcessL1Targets (pos, range, f->GetFaction (), true, false,
     [&] (const HexCoord& c, const proto::TargetId& id)
     {
       if (ctx.Map ().SafeZones ().IsNoCombat (c))
@@ -569,7 +569,7 @@ DamageProcessor::DealDamage (FighterTable::Handle f, const bool forGainHp,
             centre = pos;
 
           targets.ProcessL1Targets (centre, mod.range (attack.area ()),
-                                    f->GetFaction (),
+                                    f->GetFaction (), true, false,
             [&] (const HexCoord& c, const proto::TargetId& id)
             {
               auto t = fighters.GetForTarget (id);
@@ -615,7 +615,8 @@ DamageProcessor::ProcessSelfDestructs (FighterTable::Handle f,
           << " of damage for self-destruct of "
           << f->GetIdAsTarget ().DebugString ();
 
-      targets.ProcessL1Targets (pos, mod.range (sd.area ()), f->GetFaction (),
+      targets.ProcessL1Targets (pos, mod.range (sd.area ()),
+                                f->GetFaction (), true, false,
         [&] (const HexCoord& c, const proto::TargetId& id)
         {
           auto t = fighters.GetForTarget (id);

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -2260,6 +2260,23 @@ TEST_F (RegenerateHpTests, InsideBuilding)
   EXPECT_EQ (c->GetHP ().shield (), 11);
 }
 
+TEST_F (RegenerateHpTests, RateModifierEffect)
+{
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  const auto id = c->GetId ();
+  c->MutableHP ().set_shield (10);
+  auto* regen = &c->MutableRegenData ();
+  regen->mutable_max_hp ()->set_shield (100);
+  regen->mutable_regeneration_mhp ()->set_shield (10'000);
+  c->MutableEffects ().mutable_shield_regen ()->set_percent (50);
+  c.reset ();
+
+  RegenerateHP (db);
+
+  c = characters.GetById (id);
+  EXPECT_EQ (c->GetHP ().shield (), 10 + 15);
+}
+
 /* ************************************************************************** */
 
 } // anonymous namespace

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -141,6 +141,8 @@ GetCombatJsonObject (const CombatEntity& h)
         obj["range"] = IntToJson (attack.range ());
       if (attack.has_area ())
         obj["area"] = IntToJson (attack.area ());
+      if (attack.friendlies ())
+        obj["friendlies"] = true;
 
       if (attack.has_damage ())
         {

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -242,14 +242,21 @@ TEST_F (CharacterJsonTests, Attacks)
 {
   auto c = tbl.CreateNew ("domob", Faction::RED);
   auto* cd = c->MutableProto ().mutable_combat_data ();
+
   auto* attack = cd->add_attacks ();
   attack->set_range (5);
   attack->mutable_damage ()->set_min (2);
   attack->mutable_damage ()->set_max (10);
+
   attack = cd->add_attacks ();
   attack->set_area (1);
   attack->mutable_damage ()->set_min (0);
   attack->mutable_damage ()->set_max (1);
+
+  attack = cd->add_attacks ();
+  attack->set_area (10);
+  attack->set_friendlies (true);
+
   c.reset ();
 
   ExpectStateJson (R"({
@@ -266,7 +273,12 @@ TEST_F (CharacterJsonTests, Attacks)
                   },
                   {
                     "area": 1,
+                    "friendlies": null,
                     "damage": {"min": 0, "max": 1}
+                  },
+                  {
+                    "area": 10,
+                    "friendlies": true
                   }
                 ]
             }


### PR DESCRIPTION
This extends the combat system to support "attacks" that affect friendlies (although only normal AoE type for now, as that is what we need).  We use this to implement the "ally shield projector" fitment (`allyreplenish`), which increases the shield regeneration rate of friendlies in a small AoE around the source.

For now, only the `lf` variant of the fitment has been defined; the others will be added in with an update for #142 before the competition start.