### PR TITLE
Implement "mentecon" effect and fitment

### DIFF
--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -67,6 +67,14 @@ message CombatEffects
   /** Modification to the shield regeneration rate.  */
   optional StatModifier shield_regen = 3;
 
+  /**
+   * If set, then the affected fighter ignores the friendly/enemy
+   * classification and just considers everyone a valid target for
+   * both normal and friendly attacks (and similarly affects everyone
+   * with AoE attacks of either type).
+   */
+  optional bool mentecon = 4;
+
 }
 
 /**

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1178,6 +1178,36 @@ fungible_items:
 
 fungible_items:
 {
+    key: "vhf mentecon"
+    value:
+	{
+        space: 1000
+        complexity: 500
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "mid"
+            attack:
+              {
+                range: 4
+                effects: { mentecon: true }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "lf expander"
     value:
 	{

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -118,6 +118,8 @@ namespace
  * Wrapper around ProcessL1Targets, which filters out targets in a no-combat
  * safe zone as well as the fighter itself.  If enemies is true, it will look
  * for enemies and not friendlies; if enemies is false, the other way round.
+ * If the fighter is affected by a mentecon, it will instead just ignore the
+ * enemies flag and always look for enemies and friendlies alike.
  */
 void
 ProcessCombatTargets (TargetFinder& targets, const Context& ctx,
@@ -128,8 +130,9 @@ ProcessCombatTargets (TargetFinder& targets, const Context& ctx,
 {
   const TargetKey myId(f.GetIdAsTarget ());
 
-  const bool lookForEnemies = enemies;
-  const bool lookForFriendlies = !enemies;
+  const bool mentecon = f.GetEffects ().mentecon ();
+  const bool lookForEnemies = enemies || mentecon;
+  const bool lookForFriendlies = !enemies || mentecon;
 
   targets.ProcessL1Targets (centre, range, f.GetFaction (),
                             lookForEnemies, lookForFriendlies,

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -591,6 +591,8 @@ DamageProcessor::ApplyEffects (const proto::Attack& attack,
     *targetEffects.mutable_range () += attackEffects.range ();
   if (attackEffects.has_shield_regen ())
     *targetEffects.mutable_shield_regen () += attackEffects.shield_regen ();
+  if (attackEffects.mentecon ())
+    targetEffects.set_mentecon (true);
 }
 
 void


### PR DESCRIPTION
This implements the "mentecon" effect and associated fitment `vhf mentecon` (there are no lighter variants).  If someone is affected by it, it will treat enemies and friendlies alike.  In other words, it may and damage friendlies with AoE and directed attacks, and friendly effects will also benefit enemies in range.