### PR TITLE
Hit/miss chance for combat

### DIFF
--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -123,6 +123,12 @@ message Attack
 
     /** The factor (as percent) that this attack does damage to shields.  */
     optional uint32 shield_percent = 4;
+
+    /**
+     * "Size" of the attack's weapon for hit/miss chance computation.
+     * See target_size on CombatData.
+     */
+    optional uint32 weapon_size = 5;
   }
 
   /** If this attack does damage, the stats for it.  */
@@ -243,5 +249,14 @@ message CombatData
    * upgrade fitment).
    */
   optional StatModifier received_damage_modifier = 4;
+
+  /**
+   * "Size" of the fighter as a target, i.e. for hit/miss chance
+   * computation.  If this is missing or at least as large as the
+   * corresponding size of the attack, then the base chance (without any
+   * modifiers) is 100%.  If the target size is lower, the chance is
+   * proportionally lowered.
+   */
+  optional uint32 target_size = 5;
 
 }

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -251,12 +251,18 @@ message CombatData
   optional StatModifier received_damage_modifier = 4;
 
   /**
+   * Modification (e.g. boost) to the hit chance of any attacks made by
+   * this fighter.
+   */
+  optional StatModifier hit_chance_modifier = 5;
+
+  /**
    * "Size" of the fighter as a target, i.e. for hit/miss chance
    * computation.  If this is missing or at least as large as the
    * corresponding size of the attack, then the base chance (without any
    * modifiers) is 100%.  If the target size is lower, the chance is
    * proportionally lowered.
    */
-  optional uint32 target_size = 5;
+  optional uint32 target_size = 6;
 
 }

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -64,8 +64,11 @@ message CombatEffects
   /** Modification to the range.  */
   optional StatModifier range = 2;
 
+  /** Modification to the hit chance of attacks from this fighter.  */
+  optional StatModifier hit_chance = 3;
+
   /** Modification to the shield regeneration rate.  */
-  optional StatModifier shield_regen = 3;
+  optional StatModifier shield_regen = 4;
 
   /**
    * If set, then the affected fighter ignores the friendly/enemy
@@ -73,7 +76,7 @@ message CombatEffects
    * both normal and friendly attacks (and similarly affects everyone
    * with AoE attacks of either type).
    */
-  optional bool mentecon = 4;
+  optional bool mentecon = 5;
 
 }
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -189,26 +189,29 @@ message FitmentData
   /** Modification to the received damage (e.g. armour hardening).  */
   optional StatModifier received_damage = 12;
 
+  /** Modification to the self hit chance.  */
+  optional StatModifier hit_chance = 13;
+
   /** Modification to the vehicle's allowed fitment complexity.  */
-  optional StatModifier complexity = 13;
+  optional StatModifier complexity = 14;
 
   /**
    * Modification to the vehicle's prospecting blocks.  Since a larger number
    * of blocks is worse, a fitment will likely have a negative modifier here.
    */
-  optional StatModifier prospecting_blocks = 14;
+  optional StatModifier prospecting_blocks = 15;
 
   /** MOdification to the vehicle's mining rate (min and max).  */
-  optional StatModifier mining_rate = 15;
+  optional StatModifier mining_rate = 16;
 
   /** Low-HP-boost this fitment provides (if any).  */
-  optional LowHpBoost low_hp_boost = 16;
+  optional LowHpBoost low_hp_boost = 17;
 
   /** Self-destruct ability of this fitment (if any).  */
-  optional SelfDestruct self_destruct = 17;
+  optional SelfDestruct self_destruct = 18;
 
   /** If this is a mobile refinery, the stats for it.  */
-  optional MobileRefinery refining = 18;
+  optional MobileRefinery refining = 19;
 
 }
 

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1178,6 +1178,26 @@ fungible_items:
 
 fungible_items:
 {
+    key: "lf hitext"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: LIGHT
+            hit_chance: { percent: 10 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "vhf mentecon"
     value:
 	{

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -1198,6 +1198,29 @@ fungible_items:
 
 fungible_items:
 {
+    key: "lf hitred"
+    value:
+	{
+        space: 1000
+        complexity: 2
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
+        fitment:
+          {
+            slot: "mid"
+            attack:
+              {
+                area: 3
+                effects: { hit_chance: { percent: -2 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "vhf mentecon"
     value:
 	{

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -92,8 +92,10 @@ ComputeModifier (const CombatEntity& f, CombatModifier& mod)
       mod.range += b.range ();
     }
 
-  mod.range += f.GetEffects ().range ();
+  const auto& eff = f.GetEffects ();
+  mod.range += eff.range ();
   mod.hitChance += cd.hit_chance_modifier ();
+  mod.hitChance += eff.hit_chance ();
 }
 
 } // anonymous namespace
@@ -661,6 +663,8 @@ DamageProcessor::ApplyEffects (const proto::Attack& attack,
     *targetEffects.mutable_speed () += attackEffects.speed ();
   if (attackEffects.has_range ())
     *targetEffects.mutable_range () += attackEffects.range ();
+  if (attackEffects.has_hit_chance ())
+    *targetEffects.mutable_hit_chance () += attackEffects.hit_chance ();
   if (attackEffects.has_shield_regen ())
     *targetEffects.mutable_shield_regen () += attackEffects.shield_regen ();
   if (attackEffects.mentecon ())

--- a/src/combat.hpp
+++ b/src/combat.hpp
@@ -66,6 +66,13 @@ public:
 void FindCombatTargets (Database& db, xaya::Random& rnd, const Context& ctx);
 
 /**
+ * Computes the base (without stat modifiers) hit/miss chance for a given
+ * target and applied damage.  Returned is the chance to hit in percent.
+ */
+unsigned BaseHitChance (const proto::CombatData& target,
+                        const proto::Attack::Damage& dmg);
+
+/**
  * Deals damage from combat and returns the target IDs of all fighters
  * that are now dead (and need to be handled accordingly).  This also
  * applies non-damage effects like slowing.

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -156,6 +156,7 @@ ApplyFitments (Character& c, const Context& ctx)
   StatModifier shieldRegen, armourRegen;
   StatModifier range, damage;
   StatModifier recvDamage;
+  StatModifier hitChance;
 
   /* Mobile refinery (if any).  */
   bool hasRefinery = false;
@@ -205,12 +206,18 @@ ApplyFitments (Character& c, const Context& ctx)
       range += fitment.range ();
       damage += fitment.damage ();
       recvDamage += fitment.received_damage ();
+      hitChance += fitment.hit_chance ();
     }
 
   if (recvDamage.IsNeutral ())
     cd->clear_received_damage_modifier ();
   else
     *cd->mutable_received_damage_modifier () = recvDamage.ToProto ();
+
+  if (hitChance.IsNeutral ())
+    cd->clear_hit_chance_modifier ();
+  else
+    *cd->mutable_hit_chance_modifier () = hitChance.ToProto ();
 
   pb.set_cargo_space (cargo (pb.cargo_space ()));
   pb.set_speed (speed (pb.speed ()));

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -247,14 +247,16 @@ TEST_F (DeriveCharacterStatsTests, RangeDamage)
   EXPECT_EQ (a->area (), 11);
 }
 
-TEST_F (DeriveCharacterStatsTests, ReceivedDamage)
+TEST_F (DeriveCharacterStatsTests, ReceivedDamageAndHitChance)
 {
   auto c = Derive ("chariot", {});
   EXPECT_FALSE (c->GetProto ().combat_data ().has_received_damage_modifier ());
+  EXPECT_FALSE (c->GetProto ().combat_data ().has_hit_chance_modifier ());
 
-  c = Derive ("chariot", {"lf dmgred", "lf dmgred"});
+  c = Derive ("chariot", {"lf dmgred", "lf dmgred", "lf hitext"});
   const auto& cd = c->GetProto ().combat_data ();
   EXPECT_EQ (cd.received_damage_modifier ().percent (), -10);
+  EXPECT_EQ (cd.hit_chance_modifier ().percent (), 10);
 }
 
 TEST_F (DeriveCharacterStatsTests, StackingButNotCompounding)


### PR DESCRIPTION
This introduces the concept of a "hit chance" for combat.  It has a base chance, which is based on new stats for weapons and targets.  Essentially, if a "small" weapon is used against a "large" target, the hit chance is 100%.  If a "large" weapon is used against a "small" target, it is proportional to the size ratio.

In addition, this also defines two new fitments, `hitext` (which boosts the hit chance for your own attacks) and `hitred`, which reduces the hit chance of enemies in an AoE with a new combat effect.  Both fitments are defined in the light variant only for now, and the full data will be added as part of #142.

Also there is not yet any real data for the actual weapon and vehicle sizes.