### PR TITLE
Hit/miss stats in roconfig and general fitment update

### DIFF
--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -18,13 +18,115 @@ fungible_items:
                   {
                     min: 5
                     max: 15
-                    armour_percent: 60
                     shield_percent: 140
+                    armour_percent: 60
+                    weapon_size: 30
                   }
               }
           }
       }
   }
+
+
+fungible_items:
+{
+    key: "mf beam"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 15
+                    max: 25
+                    shield_percent: 140
+                    armour_percent: 60
+                    weapon_size: 40
+                  }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf beam"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 25
+                    max: 75
+                    shield_percent: 140
+                    armour_percent: 60
+                    weapon_size: 60
+                  }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf beam"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 25
+                    max: 200
+                    shield_percent: 140
+                    armour_percent: 60
+                    weapon_size: 100
+                  }
+              }
+          }
+      }
+  }
+
 
 fungible_items:
 {
@@ -46,13 +148,115 @@ fungible_items:
                   {
                     min: 5
                     max: 15
-                    armour_percent: 140
                     shield_percent: 60
+                    armour_percent: 140
+                    weapon_size: 30
                   }
               }
           }
       }
   }
+
+
+fungible_items:
+{
+    key: "mf gun"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 15
+                    max: 25
+                    shield_percent: 60
+                    armour_percent: 140
+                    weapon_size: 40
+                  }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf gun"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 25
+                    max: 75
+                    shield_percent: 60
+                    armour_percent: 140
+                    weapon_size: 60
+                  }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf gun"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage:
+                  {
+                    min: 25
+                    max: 200
+                    shield_percent: 60
+                    armour_percent: 140
+                    weapon_size: 100
+                  }
+              }
+          }
+      }
+  }
+
 
 fungible_items:
 {
@@ -278,7 +482,7 @@ fungible_items:
             attack:
               {
                 area: 3
-                damage: { min: 3 max: 9 }
+                damage: { min: 3 max: 9 weapon_size: 30 }
               }
           }
       }
@@ -302,7 +506,7 @@ fungible_items:
             attack:
               {
                 area: 3
-                damage: { min: 6 max: 18 }
+                damage: { min: 6 max: 18 weapon_size: 40 }
               }
           }
       }
@@ -327,7 +531,7 @@ fungible_items:
             attack:
               {
                 area: 3
-                damage: { min: 17 max: 27 }
+                damage: { min: 17 max: 27 weapon_size: 60 }
               }
           }
       }
@@ -357,11 +561,12 @@ fungible_items:
             attack:
               {
                 area: 3
-                damage: { min: 25 max: 75 }
+                damage: { min: 25 max: 75 weapon_size: 100 }
               }
           }
       }
   }
+
 
 fungible_items:
 {
@@ -371,25 +576,103 @@ fungible_items:
         space: 1000
         complexity: 2
         with_blueprint: true
-        construction_resources: { key: "mat a" value: 25000 }
-        construction_resources: { key: "mat b" value: 25000 }
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
         fitment:
           {
             slot: "high"
             attack:
               {
                 range: 5
-                damage:
-                  {
-                    min: 3
-                    max: 9
-                    armour_percent: 0
-                  }
+                damage: { min: 3 max: 9 armour_percent: 0 weapon_size: 30 }
                 gain_hp: true
               }
           }
       }
   }
+
+
+fungible_items:
+{
+    key: "mf syphon"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage: { min: 6 max: 18 armour_percent: 0 weapon_size: 40 }
+                gain_hp: true
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf syphon"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage: { min: 17 max: 27 armour_percent: 0 weapon_size: 60 }
+                gain_hp: true
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf syphon"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                range: 5
+                damage: { min: 25 max: 75 armour_percent: 0 weapon_size: 100 }
+                gain_hp: true
+              }
+          }
+      }
+  }
+
 
 fungible_items:
 {
@@ -399,25 +682,103 @@ fungible_items:
         space: 1000
         complexity: 2
         with_blueprint: true
-        construction_resources: { key: "mat a" value: 25000 }
-        construction_resources: { key: "mat b" value: 25000 }
+        construction_resources: { key: "mat a" value: 2500 }
+        construction_resources: { key: "mat b" value: 2500 }
         fitment:
           {
             slot: "high"
             attack:
               {
                 area: 4
-                damage:
-                  {
-                    min: 1
-                    max: 5
-                    armour_percent: 0
-                  }
+                damage: { min: 1 max: 5 armour_percent: 0 weapon_size: 30 }
                 gain_hp: true
               }
           }
       }
   }
+
+
+fungible_items:
+{
+    key: "mf syphonaoe"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                area: 4
+                damage: { min: 3 max: 9 armour_percent: 0 weapon_size: 40 }
+                gain_hp: true
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf syphonaoe"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                area: 4
+                damage: { min: 10 max: 14 armour_percent: 0 weapon_size: 60 }
+                gain_hp: true
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf syphonaoe"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "high"
+            attack:
+              {
+                area: 4
+                damage: { min: 20 max: 40 armour_percent: 0 weapon_size: 100 }
+                gain_hp: true
+              }
+          }
+      }
+  }
+
 
 fungible_items:
 {
@@ -436,7 +797,7 @@ fungible_items:
               {
                 range: 6
                 area: 2
-                damage: { min: 1 max: 5 }
+                damage: { min: 1 max: 5 weapon_size: 30 }
               }
           }
       }
@@ -461,7 +822,7 @@ fungible_items:
               {
                 range: 6
                 area: 2
-                damage: { min: 3 max: 9 }
+                damage: { min: 3 max: 9 weapon_size: 40 }
               }
           }
       }
@@ -487,7 +848,7 @@ fungible_items:
               {
                 range: 6
                 area: 2
-                damage: { min: 10 max: 14 }
+                damage: { min: 10 max: 14 weapon_size: 60 }
               }
           }
       }
@@ -518,7 +879,7 @@ fungible_items:
               {
                 range: 6
                 area: 2
-                damage: { min: 20 max: 40 }
+                damage: { min: 20 max: 40 weapon_size: 100 }
               }
           }
       }
@@ -580,7 +941,7 @@ fungible_items:
               {
                 range: 5
                 area: 3
-                damage: { min: 3 max: 7 }
+                damage: { min: 3 max: 7 weapon_size: 30 }
               }
           }
       }
@@ -605,7 +966,7 @@ fungible_items:
               {
                 range: 5
                 area: 3
-                damage: { min: 8 max: 12 }
+                damage: { min: 8 max: 12 weapon_size: 40 }
               }
           }
       }
@@ -631,7 +992,7 @@ fungible_items:
               {
                 range: 5
                 area: 3
-                damage: { min: 15 max: 25 }
+                damage: { min: 15 max: 25 weapon_size: 60 }
               }
           }
       }
@@ -662,7 +1023,7 @@ fungible_items:
               {
                 range: 5
                 area: 3
-                damage: { min: 30 max: 60 }
+                damage: { min: 30 max: 60 weapon_size: 100 }
               }
           }
       }
@@ -685,7 +1046,7 @@ fungible_items:
             self_destruct:
               {
                 area: 5
-                damage: { min: 30 max: 50 }
+                damage: { min: 30 max: 50 weapon_size: 30 }
               }
           }
       }
@@ -709,7 +1070,7 @@ fungible_items:
             self_destruct:
               {
                 area: 5
-                damage: { min: 150 max: 250 }
+                damage: { min: 150 max: 250 weapon_size: 40 }
               }
           }
       }
@@ -734,7 +1095,7 @@ fungible_items:
             self_destruct:
               {
                 area: 5
-                damage: { min: 300 max: 700 }
+                damage: { min: 300 max: 700 weapon_size: 60 }
               }
           }
       }
@@ -764,7 +1125,7 @@ fungible_items:
             self_destruct:
               {
                 area: 5
-                damage: { min: 1500 max: 2500 }
+                damage: { min: 1500 max: 2500 weapon_size: 100 }
               }
           }
       }
@@ -978,6 +1339,91 @@ fungible_items:
 
 fungible_items:
 {
+    key: "mf allyreplenish"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: MEDIUM
+            attack:
+              {
+                area: 1
+                friendlies: true
+                effects: { shield_regen: { percent: 15 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf allyreplenish"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: HEAVY
+            attack:
+              {
+                area: 1
+                friendlies: true
+                effects: { shield_regen: { percent: 15 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf allyreplenish"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: VERY_HEAVY
+            attack:
+              {
+                area: 1
+                friendlies: true
+                effects: { shield_regen: { percent: 15 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "lf rangered"
     value:
 	{
@@ -988,8 +1434,90 @@ fungible_items:
         construction_resources: { key: "mat b" value: 2500 }
         fitment:
           {
-            slot: "high"
+            slot: "mid"
             vehicle_size: LIGHT
+            attack:
+              {
+                area: 3
+                effects: { range: { percent: -15 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "mf rangered"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: MEDIUM
+            attack:
+              {
+                area: 3
+                effects: { range: { percent: -15 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf rangered"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: HEAVY
+            attack:
+              {
+                area: 3
+                effects: { range: { percent: -15 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf rangered"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: VERY_HEAVY
             attack:
               {
                 area: 3
@@ -1198,6 +1726,76 @@ fungible_items:
 
 fungible_items:
 {
+    key: "mf hitext"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: MEDIUM
+            hit_chance: { percent: 10 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf hitext"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: HEAVY
+            hit_chance: { percent: 8 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf hitext"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "mid"
+            vehicle_size: VERY_HEAVY
+            hit_chance: { percent: 8 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
     key: "lf hitred"
     value:
 	{
@@ -1213,6 +1811,85 @@ fungible_items:
               {
                 area: 3
                 effects: { hit_chance: { percent: -2 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "mf hitred"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "mid"
+            attack:
+              {
+                area: 3
+                effects: { hit_chance: { percent: -4 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf hitred"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "mid"
+            attack:
+              {
+                area: 3
+                effects: { hit_chance: { percent: -6 } }
+              }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf hitred"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "mid"
+            attack:
+              {
+                area: 3
+                effects: { hit_chance: { percent: -8 } }
               }
           }
       }
@@ -1353,6 +2030,76 @@ fungible_items:
           {
             slot: "low"
             vehicle_size: LIGHT
+            received_damage: { percent: -5 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "mf dmgred"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: MEDIUM
+            received_damage: { percent: -5 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf dmgred"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: HEAVY
+            received_damage: { percent: -5 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf dmgred"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: VERY_HEAVY
             received_damage: { percent: -5 }
           }
       }
@@ -1554,6 +2301,76 @@ fungible_items:
             slot: "low"
             vehicle_size: LIGHT
             armour_regen: { absolute: 2000 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "mf armourregen"
+    value:
+	{
+        space: 1000
+        complexity: 40
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 4500 }
+        construction_resources: { key: "mat b" value: 4500 }
+        construction_resources: { key: "mat f" value: 1000 }
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: MEDIUM
+            armour_regen: { absolute: 4000 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "hf armourregen"
+    value:
+	{
+        space: 1000
+        complexity: 100
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 24000 }
+        construction_resources: { key: "mat b" value: 24000 }
+        construction_resources: { key: "mat f" value: 9000 }
+        construction_resources: { key: "mat g" value: 3000 }
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: HEAVY
+            armour_regen: { absolute: 8000 }
+          }
+      }
+  }
+
+
+fungible_items:
+{
+    key: "vhf armourregen"
+    value:
+	{
+        space: 1000
+        complexity: 400
+        with_blueprint: true
+        construction_resources: { key: "mat a" value: 36000 }
+        construction_resources: { key: "mat b" value: 36000 }
+        construction_resources: { key: "mat c" value: 6000 }
+        construction_resources: { key: "mat d" value: 6000 }
+        construction_resources: { key: "mat e" value: 6000 }
+        construction_resources: { key: "mat f" value: 18000 }
+        construction_resources: { key: "mat g" value: 6000 }
+        construction_resources: { key: "mat h" value: 4800 }
+        construction_resources: { key: "mat i" value: 1200 }
+        fitment:
+          {
+            slot: "low"
+            vehicle_size: VERY_HEAVY
+            armour_regen: { absolute: 14000 }
           }
       }
   }

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -194,6 +194,7 @@ fungible_items:
                     range: 10
                     damage: { min: 1 max: 10 }
                   }
+                target_size: 1000
               }
             mining_rate: { min: 1 max: 1 }
             prospecting_blocks: 10
@@ -234,6 +235,7 @@ fungible_items:
                     area: 10
                     damage: { min: 1 max: 10 }
                   }
+                target_size: 1000
               }
             mining_rate: { min: 10 max: 100 }
             prospecting_blocks: 10
@@ -264,7 +266,7 @@ fungible_items:
                 max_hp: { armour: 1000 shield: 100 }
                 regeneration_mhp: { shield: 1000 }
               }
-            combat_data: {}
+            combat_data: { target_size: 1000 }
             size: HEAVY
             equipment_slots: { key: "high" value: 10 }
             equipment_slots: { key: "mid" value: 10 }

--- a/proto/roconfig/items/vehicles_others.pb.text
+++ b/proto/roconfig/items/vehicles_others.pb.text
@@ -10,7 +10,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 22500 }
         vehicle:
           {
-            cargo_space: 1000000
+            cargo_space: 3600000
             speed: 3000
             regen_data:
               {
@@ -23,6 +23,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -40,7 +41,7 @@ fungible_items:
         construction_resources: { key: "mat c" value: 40000 }
         vehicle:
           {
-            cargo_space: 3600000
+            cargo_space: 11500000
             speed: 2000
             regen_data:
               {
@@ -53,6 +54,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 3 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -71,7 +73,7 @@ fungible_items:
         construction_resources: { key: "mat f" value: 42500 }
         vehicle:
           {
-            cargo_space: 11500000
+            cargo_space: 27600000
             speed: 1000
             regen_data:
               {
@@ -84,6 +86,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 4 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 4 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -113,6 +116,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 0 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -130,7 +134,7 @@ fungible_items:
         construction_resources: { key: "mat c" value: 100000 }
         vehicle:
           {
-            cargo_space: 0
+            cargo_space: 125000000
             speed: 2000
             regen_data:
               {
@@ -143,6 +147,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -164,7 +169,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 136000 }
         vehicle:
           {
-            cargo_space: 125000000
+            cargo_space: 350000000
             speed: 1000
             regen_data:
               {
@@ -177,6 +182,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 3 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -200,7 +206,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 150000 }
         vehicle:
           {
-            cargo_space: 350000000
+            cargo_space: 2600000000
             speed: 500
             regen_data:
               {
@@ -213,6 +219,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 2 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 90 }
           }
       }
   }
@@ -229,7 +236,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 150000 }
         vehicle:
           {
-            cargo_space: 2600000000
+            cargo_space: 5600000
             speed: 3000
             regen_data:
               {
@@ -242,6 +249,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 3 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -263,7 +271,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 150000 }
         vehicle:
           {
-            cargo_space: 5600000
+            cargo_space: 25000000
             speed: 2000
             regen_data:
               {
@@ -276,6 +284,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 5 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -299,7 +308,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 100000 }
         vehicle:
           {
-            cargo_space: 25000000
+            cargo_space: 105000000
             speed: 1500
             regen_data:
               {
@@ -312,6 +321,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 6 }
             equipment_slots: { key: "mid" value: 4 }
             equipment_slots: { key: "low" value: 4 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -335,7 +345,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 5000000 }
         vehicle:
           {
-            cargo_space: 105000000
+            cargo_space: 285000000
             speed: 1000
             regen_data:
               {
@@ -348,6 +358,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 8 }
             equipment_slots: { key: "mid" value: 6 }
             equipment_slots: { key: "low" value: 6 }
+            combat_data: { target_size: 90 }
           }
       }
   }
@@ -364,7 +375,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 22500 }
         vehicle:
           {
-            cargo_space: 1000000
+            cargo_space: 3600000
             speed: 3000
             regen_data:
               {
@@ -377,6 +388,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 1 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -394,7 +406,7 @@ fungible_items:
         construction_resources: { key: "mat c" value: 40000 }
         vehicle:
           {
-            cargo_space: 3600000
+            cargo_space: 11500000
             speed: 2000
             regen_data:
               {
@@ -407,6 +419,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 2 }
             equipment_slots: { key: "mid" value: 3 }
             equipment_slots: { key: "low" value: 1 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -425,7 +438,7 @@ fungible_items:
         construction_resources: { key: "mat f" value: 42500 }
         vehicle:
           {
-            cargo_space: 11500000
+            cargo_space: 27600000
             speed: 1000
             regen_data:
               {
@@ -438,6 +451,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 3 }
             equipment_slots: { key: "mid" value: 4 }
             equipment_slots: { key: "low" value: 3 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -467,6 +481,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 0 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 1 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -484,7 +499,7 @@ fungible_items:
         construction_resources: { key: "mat c" value: 100000 }
         vehicle:
           {
-            cargo_space: 0
+            cargo_space: 125000000
             speed: 2000
             regen_data:
               {
@@ -497,6 +512,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 1 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -518,7 +534,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 136000 }
         vehicle:
           {
-            cargo_space: 125000000
+            cargo_space: 350000000
             speed: 1000
             regen_data:
               {
@@ -531,6 +547,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 3 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -554,7 +571,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 150000 }
         vehicle:
           {
-            cargo_space: 350000000
+            cargo_space: 2600000000
             speed: 500
             regen_data:
               {
@@ -567,6 +584,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 5 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 90 }
           }
       }
   }
@@ -583,7 +601,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 150000 }
         vehicle:
           {
-            cargo_space: 2600000000
+            cargo_space: 5600000
             speed: 3000
             regen_data:
               {
@@ -596,6 +614,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 2 }
             equipment_slots: { key: "mid" value: 3 }
             equipment_slots: { key: "low" value: 1 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -617,7 +636,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 150000 }
         vehicle:
           {
-            cargo_space: 5600000
+            cargo_space: 25000000
             speed: 2000
             regen_data:
               {
@@ -630,6 +649,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 4 }
             equipment_slots: { key: "mid" value: 4 }
             equipment_slots: { key: "low" value: 1 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -653,7 +673,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 100000 }
         vehicle:
           {
-            cargo_space: 25000000
+            cargo_space: 105000000
             speed: 1500
             regen_data:
               {
@@ -666,6 +686,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 5 }
             equipment_slots: { key: "mid" value: 6 }
             equipment_slots: { key: "low" value: 3 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -689,7 +710,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 5000000 }
         vehicle:
           {
-            cargo_space: 105000000
+            cargo_space: 285000000
             speed: 1000
             regen_data:
               {
@@ -702,6 +723,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 7 }
             equipment_slots: { key: "mid" value: 8 }
             equipment_slots: { key: "low" value: 4 }
+            combat_data: { target_size: 90 }
           }
       }
   }
@@ -718,7 +740,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 22500 }
         vehicle:
           {
-            cargo_space: 1000000
+            cargo_space: 3600000
             speed: 3000
             regen_data:
               {
@@ -731,6 +753,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -748,7 +771,7 @@ fungible_items:
         construction_resources: { key: "mat c" value: 40000 }
         vehicle:
           {
-            cargo_space: 3600000
+            cargo_space: 11500000
             speed: 2000
             regen_data:
               {
@@ -761,6 +784,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 2 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 3 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -779,7 +803,7 @@ fungible_items:
         construction_resources: { key: "mat f" value: 42500 }
         vehicle:
           {
-            cargo_space: 11500000
+            cargo_space: 27600000
             speed: 1000
             regen_data:
               {
@@ -792,6 +816,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 2 }
             equipment_slots: { key: "mid" value: 3 }
             equipment_slots: { key: "low" value: 5 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -821,6 +846,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 0 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -838,7 +864,7 @@ fungible_items:
         construction_resources: { key: "mat c" value: 100000 }
         vehicle:
           {
-            cargo_space: 0
+            cargo_space: 125000000
             speed: 2000
             regen_data:
               {
@@ -851,6 +877,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 0 }
             equipment_slots: { key: "mid" value: 1 }
             equipment_slots: { key: "low" value: 3 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -872,7 +899,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 136000 }
         vehicle:
           {
-            cargo_space: 125000000
+            cargo_space: 350000000
             speed: 1000
             regen_data:
               {
@@ -885,6 +912,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 0 }
             equipment_slots: { key: "mid" value: 3 }
             equipment_slots: { key: "low" value: 3 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -908,7 +936,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 150000 }
         vehicle:
           {
-            cargo_space: 350000000
+            cargo_space: 2600000000
             speed: 500
             regen_data:
               {
@@ -921,6 +949,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 1 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 5 }
+            combat_data: { target_size: 90 }
           }
       }
   }
@@ -937,7 +966,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 150000 }
         vehicle:
           {
-            cargo_space: 2600000000
+            cargo_space: 5600000
             speed: 3000
             regen_data:
               {
@@ -950,6 +979,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 2 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 2 }
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -971,7 +1001,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 150000 }
         vehicle:
           {
-            cargo_space: 5600000
+            cargo_space: 25000000
             speed: 2000
             regen_data:
               {
@@ -984,6 +1014,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 3 }
             equipment_slots: { key: "mid" value: 2 }
             equipment_slots: { key: "low" value: 4 }
+            combat_data: { target_size: 30 }
           }
       }
   }
@@ -1007,7 +1038,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 100000 }
         vehicle:
           {
-            cargo_space: 25000000
+            cargo_space: 105000000
             speed: 1500
             regen_data:
               {
@@ -1020,6 +1051,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 5 }
             equipment_slots: { key: "mid" value: 3 }
             equipment_slots: { key: "low" value: 6 }
+            combat_data: { target_size: 50 }
           }
       }
   }
@@ -1043,7 +1075,7 @@ fungible_items:
         construction_resources: { key: "mat i" value: 5000000 }
         vehicle:
           {
-            cargo_space: 105000000
+            cargo_space: 285000000
             speed: 1000
             regen_data:
               {
@@ -1056,6 +1088,7 @@ fungible_items:
             equipment_slots: { key: "high" value: 6 }
             equipment_slots: { key: "mid" value: 5 }
             equipment_slots: { key: "low" value: 8 }
+            combat_data: { target_size: 90 }
           }
       }
   }

--- a/proto/roconfig/items/vehicles_starter.pb.text
+++ b/proto/roconfig/items/vehicles_starter.pb.text
@@ -3,11 +3,11 @@ fungible_items:
     key: "rv st"
     value:
       {
-        space: 4030000
+        space: 4032000
         complexity: 1
         vehicle:
           {
-            cargo_space: 1008000
+            cargo_space: 1000000
             speed: 3000
             regen_data:
               {
@@ -17,29 +17,7 @@ fungible_items:
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 10
             size: STARTER
-          }
-      }
-  }
-
-fungible_items:
-  {
-    key: "gv st"
-    value:
-      {
-        space: 4030000
-        complexity: 1
-        vehicle:
-          {
-            cargo_space: 1008000
-            speed: 3000
-            regen_data:
-              {
-                max_hp: { armour: 20 shield: 10 }
-                regeneration_mhp: { shield: 1000 }
-              }
-            mining_rate: { min: 0 max: 2000000 }
-            prospecting_blocks: 10
-            size: STARTER
+            combat_data: { target_size: 20 }
           }
       }
   }
@@ -49,11 +27,11 @@ fungible_items:
     key: "bv st"
     value:
       {
-        space: 4030000
+        space: 4032000
         complexity: 1
         vehicle:
           {
-            cargo_space: 1008000
+            cargo_space: 1000000
             speed: 3000
             regen_data:
               {
@@ -63,6 +41,31 @@ fungible_items:
             mining_rate: { min: 0 max: 2000000 }
             prospecting_blocks: 10
             size: STARTER
+            combat_data: { target_size: 20 }
+          }
+      }
+  }
+
+fungible_items:
+  {
+    key: "gv st"
+    value:
+      {
+        space: 4032000
+        complexity: 1
+        vehicle:
+          {
+            cargo_space: 1000000
+            speed: 3000
+            regen_data:
+              {
+                max_hp: { armour: 20 shield: 10 }
+                regeneration_mhp: { shield: 1000 }
+              }
+            mining_rate: { min: 0 max: 2000000 }
+            prospecting_blocks: 10
+            size: STARTER
+            combat_data: { target_size: 20 }
           }
       }
   }

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -417,6 +417,13 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
               << "Building construction data is invalid for " << entry.first;
           return false;
         }
+
+      if (b.foundation ().combat_data ().has_target_size ()
+            || b.full_building ().combat_data ().has_target_size ())
+        {
+          LOG (WARNING) << "Building has a target size: " << entry.first;
+          return false;
+        }
     }
 
   for (const auto& area : cfg->resource_dist ().areas ())

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -351,10 +351,19 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
             }
         }
 
-      if (i.has_vehicle () && !i.vehicle ().has_size ())
+      if (i.has_vehicle ())
         {
-          LOG (WARNING) << "Vehicle has no size defined: " << entry.first;
-          return false;
+          if (!i.vehicle ().has_size ())
+            {
+              LOG (WARNING) << "Vehicle has no size defined: " << entry.first;
+              return false;
+            }
+
+          if (!i.vehicle ().combat_data ().has_target_size ())
+            {
+              LOG (WARNING) << "Vehicle has no target size: " << entry.first;
+              return false;
+            }
         }
 
       for (const auto& s : i.vehicle ().equipment_slots ())


### PR DESCRIPTION
This updates the vehicle and fitment roconfig data.  In particular, we add in the hit/miss chance stats (fixing #161).  Also includes a general update to the fitment data from the data sheets, fixing #142.