### PR TITLE
Support coin operations for uninitialised accounts

### DIFF
--- a/database/faction.cpp
+++ b/database/faction.cpp
@@ -73,6 +73,9 @@ BindFactionParameter (Database::Statement& stmt, const unsigned ind,
     case Faction::ANCIENT:
       stmt.Bind (ind, static_cast<int64_t> (f));
       return;
+    case Faction::INVALID:
+      stmt.BindNull (ind);
+      return;
     default:
       LOG (FATAL)
           << "Binding invalid faction to parameter: " << static_cast<int> (f);

--- a/database/faction.hpp
+++ b/database/faction.hpp
@@ -79,7 +79,16 @@ template <typename T>
   Faction GetFactionFromColumn (const Database::Result<T>& res);
 
 /**
- * Binds a faction value to a statement parameter.
+ * Retrieves a faction from a database column, which can also be NULL.
+ * In the case of NULL, Faction::INVALID is returned.  Any other
+ * value (i.e. non-matching integer values) will CHECK-fail.
+ */
+template <typename T>
+  Faction GetNullableFactionFromColumn (const Database::Result<T>& res);
+
+/**
+ * Binds a faction value to a statement parameter.  If f is Faction::INVALID,
+ * then a NULL will be bound instead.
  */
 void BindFactionParameter (Database::Statement& stmt, unsigned ind, Faction f);
 

--- a/database/faction.tpp
+++ b/database/faction.tpp
@@ -27,16 +27,28 @@ namespace pxd
 
 template <typename T>
   Faction
-  GetFactionFromColumn (const Database::Result<T>& res)
+  GetNullableFactionFromColumn (const Database::Result<T>& res)
 {
   static_assert (std::is_base_of<ResultWithFaction, T>::value,
-                 "GetFactionFromColumn needs a ResultWithFaction");
+                 "GetNullableFactionFromColumn needs a ResultWithFaction");
   
+  if (res.template IsNull<typename T::faction> ())
+    return Faction::INVALID;
+
   const auto val = res.template Get<typename T::faction> ();
   CHECK (val >= 1 && val <= 4)
       << "Invalid faction value from database: " << val;
 
   return static_cast<Faction> (val);
+}
+
+template <typename T>
+  Faction
+  GetFactionFromColumn (const Database::Result<T>& res)
+{
+  const Faction f = GetNullableFactionFromColumn (res);
+  CHECK (f != Faction::INVALID) << "Unexpected NULL faction";
+  return f;
 }
 
 } // namespace pxd

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -246,7 +246,10 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   `name` TEXT PRIMARY KEY,
 
   -- The faction (as integer corresponding to the Faction enum in C++).
-  `faction` INTEGER NOT NULL,
+  -- Can be null for accounts that are not yet initialised.  They are
+  -- not allowed to properly play in the game, but they can hold and
+  -- transfer vCHI.
+  `faction` INTEGER NULL,
 
   -- Additional data for the account as a serialised Account proto.
   `proto` BLOB NOT NULL

--- a/gametest/accounts.py
+++ b/gametest/accounts.py
@@ -33,6 +33,13 @@ class AccountsTest (PXTest):
     accounts = self.getAccounts ()
     self.assertEqual (accounts, {})
 
+    self.mainLogger.info ("Accounts are created with any moves...")
+    self.sendMove ("domob", {"x": "foobar"})
+    self.generate (1)
+    accounts = self.getAccounts ()
+    self.assertEqual (accounts["domob"].getFaction (), None)
+    assert "andy" not in accounts
+
     self.mainLogger.info ("Initialising basic accounts...")
     self.initAccount ("domob", "r")
     self.initAccount ("domob", "g")

--- a/gametest/coinops.py
+++ b/gametest/coinops.py
@@ -33,16 +33,18 @@ class CoinOpsTest (PXTest):
 
     acc = self.getAccounts ()
     for k, v in expected.items ():
-      self.assertEqual (acc[k].getBalance (), v)
+      if k not in acc:
+        self.assertEqual (v, 0)
+      else:
+        self.assertEqual (acc[k].getBalance (), v)
 
   def run (self):
     self.collectPremine ()
     self.splitPremine ()
 
-    self.mainLogger.info ("Creating test accounts...")
-    self.initAccount ("domob", "r")
-    self.initAccount ("andy", "g")
-    self.initAccount ("daniel", "b")
+    self.mainLogger.info ("Setting up test situation...")
+    # No need to initialise accounts.  Coin operations also work
+    # without a chosen faction.
     self.generate (1)
     self.giftCoins ({"domob": 100})
 

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -29,8 +29,6 @@ class GodModeTest (PXTest):
     self.collectPremine ()
 
     self.initAccount ("domob", "r")
-    self.initAccount ("daniel", "r")
-    self.initAccount ("andy", "b")
     self.createCharacters ("domob")
     self.generate (1)
     c = self.getCharacters ()["domob"]
@@ -158,6 +156,7 @@ class GodModeTest (PXTest):
     acc = self.getAccounts ()
     self.assertEqual (acc["andy"].getBalance (), 42)
     self.assertEqual (acc["daniel"].getBalance (), 50)
+    self.assertEqual (acc["daniel"].getFaction (), None)
     
 
 if __name__ == "__main__":

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -246,7 +246,9 @@ class Account (object):
     return self.data["name"]
 
   def getFaction (self):
-    return self.data["faction"]
+    if "faction" in self.data:
+      return self.data["faction"]
+    return None
 
   def getBalance (self):
     return self.data["balance"]

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -55,8 +55,8 @@ InsertCharacters (Database& db, const unsigned numIdle,
   AccountsTable acc(db);
   CharacterTable tbl(db);
 
-  acc.CreateNew ("red", Faction::RED);
-  acc.CreateNew ("green", Faction::GREEN);
+  acc.CreateNew ("red")->SetFaction (Faction::RED);
+  acc.CreateNew ("green")->SetFaction (Faction::GREEN);
 
   for (unsigned i = 0; i < numIdle; ++i)
     {

--- a/src/combat_target_bench.cpp
+++ b/src/combat_target_bench.cpp
@@ -53,7 +53,7 @@ InsertCharacters (Database& db, const Context& ctx, const Faction f,
   CharacterTable tbl(db);
 
   const std::string nm = FactionToString (f);
-  acc.CreateNew (nm, f);
+  acc.CreateNew (nm)->SetFaction (f);
 
   for (unsigned r = 0; r < rows; ++r)
     for (unsigned c = 0; c < cols; ++c)

--- a/src/fame_tests.cpp
+++ b/src/fame_tests.cpp
@@ -126,7 +126,7 @@ protected:
   {
     auto a = accounts.GetByName (owner);
     if (a == nullptr)
-      accounts.CreateNew (owner, Faction::RED);
+      accounts.CreateNew (owner)->SetFaction (Faction::RED);
 
     return characters.CreateNew (owner, Faction::RED)->GetId ();
   }

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -304,12 +304,16 @@ template <>
 {
   Json::Value res(Json::objectValue);
   res["name"] = a.GetName ();
-  res["faction"] = FactionToString (a.GetFaction ());
   res["balance"] = IntToJson (a.GetBalance ());
 
-  const auto& pb = a.GetProto ();
-  res["kills"] = IntToJson (pb.kills ());
-  res["fame"] = IntToJson (pb.fame ());
+  if (a.IsInitialised ())
+    {
+      res["faction"] = FactionToString (a.GetFaction ());
+
+      const auto& pb = a.GetProto ();
+      res["kills"] = IntToJson (pb.kills ());
+      res["fame"] = IntToJson (pb.fame ());
+    }
 
   return res;
 }
@@ -520,7 +524,7 @@ Json::Value
 GameStateJson::Accounts ()
 {
   AccountsTable tbl(db);
-  return ResultsAsArray (tbl, tbl.QueryInitialised ());
+  return ResultsAsArray (tbl, tbl.QueryAll ());
 }
 
 Json::Value

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -538,8 +538,15 @@ protected:
 
 TEST_F (AccountJsonTests, KillsAndFame)
 {
-  tbl.CreateNew ("foo", Faction::RED)->MutableProto ().set_kills (10);
-  tbl.CreateNew ("bar", Faction::BLUE)->MutableProto ().set_fame (42);
+  auto a = tbl.CreateNew ("foo");
+  a->SetFaction (Faction::RED);
+  a->MutableProto ().set_kills (10);
+  a.reset ();
+
+  a = tbl.CreateNew ("bar");
+  a->SetFaction (Faction::BLUE);
+  a->MutableProto ().set_fame (42);
+  a.reset ();
 
   ExpectStateJson (R"({
     "accounts":
@@ -552,8 +559,12 @@ TEST_F (AccountJsonTests, KillsAndFame)
 
 TEST_F (AccountJsonTests, Balance)
 {
-  tbl.CreateNew ("foo", Faction::RED);
-  tbl.CreateNew ("bar", Faction::BLUE)->AddBalance (42);
+  tbl.CreateNew ("foo")->SetFaction (Faction::RED);
+
+  auto a = tbl.CreateNew ("bar");
+  a->SetFaction (Faction::BLUE);
+  a->AddBalance (42);
+  a.reset ();
 
   ExpectStateJson (R"({
     "accounts":

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -557,19 +557,15 @@ TEST_F (AccountJsonTests, KillsAndFame)
   })");
 }
 
-TEST_F (AccountJsonTests, Balance)
+TEST_F (AccountJsonTests, UninitialisedBalance)
 {
   tbl.CreateNew ("foo")->SetFaction (Faction::RED);
-
-  auto a = tbl.CreateNew ("bar");
-  a->SetFaction (Faction::BLUE);
-  a->AddBalance (42);
-  a.reset ();
+  tbl.CreateNew ("bar")->AddBalance (42);
 
   ExpectStateJson (R"({
     "accounts":
       [
-        {"name": "bar", "faction": "b", "balance": 42},
+        {"name": "bar", "faction": null, "balance": 42},
         {"name": "foo", "faction": "r", "balance": 0}
       ]
   })");

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -107,7 +107,10 @@ protected:
   {
     auto a = accounts.GetByName (name);
     if (a == nullptr)
-      a = accounts.CreateNew (name, f);
+      {
+        a = accounts.CreateNew (name);
+        a->SetFaction (f);
+      }
 
     CHECK (a->GetFaction () == f);
     return characters.CreateNew (name, f);
@@ -1135,7 +1138,7 @@ using ValidateStateTests = PXLogicTests;
 
 TEST_F (ValidateStateTests, AncientAccountFaction)
 {
-  accounts.CreateNew ("domob", Faction::ANCIENT);
+  accounts.CreateNew ("domob")->SetFaction (Faction::ANCIENT);
   EXPECT_DEATH (ValidateState (), "has invalid faction");
 }
 
@@ -1146,10 +1149,10 @@ TEST_F (ValidateStateTests, CharacterFactions)
   c.reset ();
   EXPECT_DEATH (ValidateState (), "owned by uninitialised account");
 
-  accounts.CreateNew ("domob", Faction::GREEN);
+  accounts.CreateNew ("domob")->SetFaction (Faction::GREEN);
   EXPECT_DEATH (ValidateState (), "Faction mismatch");
 
-  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
   characters.GetById (id)->SetOwner ("andy");
   ValidateState ();
 }
@@ -1163,18 +1166,18 @@ TEST_F (ValidateStateTests, BuildingFactions)
   h.reset ();
   EXPECT_DEATH (ValidateState (), "owned by uninitialised account");
 
-  accounts.CreateNew ("domob", Faction::GREEN);
+  accounts.CreateNew ("domob")->SetFaction (Faction::GREEN);
   EXPECT_DEATH (ValidateState (), "Faction mismatch");
 
-  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
   buildings.GetById (id)->SetOwner ("andy");
   ValidateState ();
 }
 
 TEST_F (ValidateStateTests, CharacterLimit)
 {
-  accounts.CreateNew ("domob", Faction::RED);
-  accounts.CreateNew ("andy", Faction::GREEN);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::GREEN);
   for (unsigned i = 0; i < ctx.RoConfig ()->params ().character_limit (); ++i)
     {
       characters.CreateNew ("domob", Faction::RED);
@@ -1189,8 +1192,8 @@ TEST_F (ValidateStateTests, CharacterLimit)
 
 TEST_F (ValidateStateTests, CharactersInBuildings)
 {
-  accounts.CreateNew ("domob", Faction::RED);
-  accounts.CreateNew ("andy", Faction::BLUE);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::BLUE);
 
   const auto idAncient
       = buildings.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId ();
@@ -1218,12 +1221,12 @@ TEST_F (ValidateStateTests, CharactersInBuildings)
 TEST_F (ValidateStateTests, BuildingInventories)
 {
   db.SetNextId (10);
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
 
   inv.Get (10, "andy")->GetInventory ().SetFungibleCount ("foo", 1);
   EXPECT_DEATH (ValidateState (), "non-existant account");
-  accounts.CreateNew ("andy", Faction::GREEN);
+  accounts.CreateNew ("andy")->SetFaction (Faction::GREEN);
   ValidateState ();
 
   inv.Get (11, "domob")->GetInventory ().SetFungibleCount ("foo", 1);
@@ -1247,7 +1250,7 @@ TEST_F (ValidateStateTests, BuildingInventories)
 
 TEST_F (ValidateStateTests, OngoingsToCharacterLink)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   db.SetNextId (101);
 
   auto op = ongoings.CreateNew (1);
@@ -1266,7 +1269,7 @@ TEST_F (ValidateStateTests, OngoingsToCharacterLink)
 
 TEST_F (ValidateStateTests, CharacterToOngoingsLink)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   db.SetNextId (101);
 
   auto c = characters.CreateNew ("domob", Faction::RED);
@@ -1285,7 +1288,7 @@ TEST_F (ValidateStateTests, CharacterToOngoingsLink)
 
 TEST_F (ValidateStateTests, OngoingsToBuildingLink)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   db.SetNextId (101);
 
   auto op = ongoings.CreateNew (1);
@@ -1304,7 +1307,7 @@ TEST_F (ValidateStateTests, OngoingsToBuildingLink)
 
 TEST_F (ValidateStateTests, BuildingToOngoingsLink)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   db.SetNextId (101);
 
   auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);

--- a/src/movement_bench.cpp
+++ b/src/movement_bench.cpp
@@ -52,7 +52,7 @@ void
 InitialiseAccount (Database& db)
 {
   AccountsTable tbl(db);
-  tbl.CreateNew ("domob", Faction::RED);
+  tbl.CreateNew ("domob")->SetFaction (Faction::RED);
 }
 
 /**

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -2082,7 +2082,7 @@ MoveProcessor::MaybeInitAccount (const std::string& name,
       return;
     }
 
-  accounts.CreateNew (name, faction);
+  accounts.CreateNew (name)->SetFaction (faction);
   LOG (INFO)
       << "Created account " << name << " of faction "
       << FactionToString (faction);

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -186,7 +186,7 @@ TEST_F (AccountUpdateTests, InvalidInitialisation)
 
 TEST_F (AccountUpdateTests, InitialisationOfExistingAccount)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   Process (R"([
     {"name": "domob", "move": {"a": {"init": {"faction": "b"}}}}
@@ -240,8 +240,12 @@ protected:
 
 TEST_F (CoinOperationTests, Invalid)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
-  accounts.CreateNew ("other", Faction::RED);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
+  accounts.CreateNew ("other")->SetFaction (Faction::RED);
 
   Process (R"([
     {"name": "domob", "move": {"vc": 42}},
@@ -265,9 +269,13 @@ TEST_F (CoinOperationTests, Invalid)
 
 TEST_F (CoinOperationTests, BurnAndTransfer)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
-  accounts.CreateNew ("second", Faction::RED);
-  accounts.CreateNew ("third", Faction::RED);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
+  accounts.CreateNew ("second")->SetFaction (Faction::RED);
+  accounts.CreateNew ("third")->SetFaction (Faction::RED);
 
   /* Some of the burns and transfers are invalid.  They should just be ignored,
      without affecting the rest of the operation (valid parts).  */
@@ -295,7 +303,11 @@ TEST_F (CoinOperationTests, BurnAndTransfer)
 
 TEST_F (CoinOperationTests, BurnAll)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
   Process (R"([
     {"name": "domob", "move": {"vc": {"b": 100}}}
   ])");
@@ -304,8 +316,13 @@ TEST_F (CoinOperationTests, BurnAll)
 
 TEST_F (CoinOperationTests, TransferAll)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
-  accounts.CreateNew ("other", Faction::RED);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
+  accounts.CreateNew ("other")->SetFaction (Faction::RED);
+
   Process (R"([
     {"name": "domob", "move": {"vc": {"t": {"other": 100}}}}
   ])");
@@ -314,8 +331,13 @@ TEST_F (CoinOperationTests, TransferAll)
 
 TEST_F (CoinOperationTests, SelfTransfer)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
-  accounts.CreateNew ("other", Faction::GREEN);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
+  accounts.CreateNew ("other")->SetFaction (Faction::GREEN);
+
   Process (R"([
     {"name": "domob", "move": {"vc": {"t": {"domob": 90, "other": 20}}}}
   ])");
@@ -324,8 +346,12 @@ TEST_F (CoinOperationTests, SelfTransfer)
 
 TEST_F (CoinOperationTests, BurnBeforeTransfer)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
-  accounts.CreateNew ("other", Faction::RED);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
+  accounts.CreateNew ("other")->SetFaction (Faction::RED);
 
   Process (R"([
     {"name": "domob", "move": {"vc":
@@ -344,10 +370,14 @@ TEST_F (CoinOperationTests, BurnBeforeTransfer)
 
 TEST_F (CoinOperationTests, TransferOrder)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
-  accounts.CreateNew ("a", Faction::RED);
-  accounts.CreateNew ("middle", Faction::RED);
-  accounts.CreateNew ("z", Faction::RED);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
+  accounts.CreateNew ("a")->SetFaction (Faction::RED);
+  accounts.CreateNew ("middle")->SetFaction (Faction::RED);
+  accounts.CreateNew ("z")->SetFaction (Faction::RED);
 
   Process (R"([
     {"name": "domob", "move": {"vc":
@@ -383,7 +413,7 @@ protected:
 
 TEST_F (CharacterCreationTests, InvalidCommands)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   ProcessWithDevPayment (R"([
     {"name": "domob", "move": {}},
@@ -407,8 +437,8 @@ TEST_F (CharacterCreationTests, AccountNotInitialised)
 
 TEST_F (CharacterCreationTests, ValidCreation)
 {
-  accounts.CreateNew ("domob", Faction::RED);
-  accounts.CreateNew ("andy", Faction::BLUE);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::BLUE);
 
   ProcessWithDevPayment (R"([
     {"name": "domob", "move": {"nc": []}},
@@ -433,8 +463,8 @@ TEST_F (CharacterCreationTests, ValidCreation)
 
 TEST_F (CharacterCreationTests, VChiAirdrop)
 {
-  accounts.CreateNew ("domob", Faction::RED);
-  accounts.CreateNew ("andy", Faction::BLUE);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::BLUE);
 
   ProcessWithDevPayment (R"([
     {"name": "domob", "move": {"nc": [{}, {}]}},
@@ -448,8 +478,8 @@ TEST_F (CharacterCreationTests, VChiAirdrop)
 
 TEST_F (CharacterCreationTests, DevPayment)
 {
-  accounts.CreateNew ("domob", Faction::RED);
-  accounts.CreateNew ("andy", Faction::GREEN);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::GREEN);
 
   Process (R"([
     {"name": "domob", "move": {"nc": [{}]}}
@@ -471,7 +501,7 @@ TEST_F (CharacterCreationTests, DevPayment)
 
 TEST_F (CharacterCreationTests, Multiple)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   ProcessWithDevPayment (R"([
     {
@@ -500,7 +530,7 @@ TEST_F (CharacterCreationTests, CharacterLimit)
 {
   const unsigned limit = ctx.RoConfig ()->params ().character_limit ();
 
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   for (unsigned i = 0; i < limit - 1; ++i)
     tbl.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (i, 0));
 
@@ -556,7 +586,7 @@ protected:
   SetupCharacter (const Database::IdT id, const std::string& owner)
   {
     if (accounts.GetByName (owner) == nullptr)
-      accounts.CreateNew (owner, Faction::RED);
+      accounts.CreateNew (owner)->SetFaction (Faction::RED);
 
     db.SetNextId (id);
     /* We have to place the character on a spot not yet taken by another,
@@ -593,8 +623,8 @@ protected:
 
 TEST_F (CharacterUpdateTests, CreationAndUpdate)
 {
-  accounts.CreateNew ("daniel", Faction::RED);
-  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("daniel")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
 
   ProcessWithDevPayment (R"([{
     "name": "domob",
@@ -639,10 +669,10 @@ TEST_F (CharacterUpdateTests, MultipleCharacters)
   SetupCharacter (13, "domob");
   SetupCharacter (14, "domob");
 
-  accounts.CreateNew ("andy", Faction::RED);
-  accounts.CreateNew ("bob", Faction::RED);
-  accounts.CreateNew ("charly", Faction::RED);
-  accounts.CreateNew ("mallory", Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
+  accounts.CreateNew ("bob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("charly")->SetFaction (Faction::RED);
+  accounts.CreateNew ("mallory")->SetFaction (Faction::RED);
 
   /* This whole command is invalid, because an ID is specified twice in it.  */
   Process (R"([{
@@ -691,7 +721,7 @@ TEST_F (CharacterUpdateTests, MultipleCharacters)
 
 TEST_F (CharacterUpdateTests, ValidTransfer)
 {
-  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
 
   EXPECT_EQ (GetTest ()->GetOwner (), "domob");
   Process (R"([{
@@ -703,11 +733,11 @@ TEST_F (CharacterUpdateTests, ValidTransfer)
 
 TEST_F (CharacterUpdateTests, InvalidTransfer)
 {
-  accounts.CreateNew ("at limit", Faction::RED);
+  accounts.CreateNew ("at limit")->SetFaction (Faction::RED);
   for (unsigned i = 0; i < ctx.RoConfig ()->params ().character_limit (); ++i)
     tbl.CreateNew ("at limit", Faction::RED)->SetPosition (HexCoord (i, 0));
 
-  accounts.CreateNew ("wrong faction", Faction::GREEN);
+  accounts.CreateNew ("wrong faction")->SetFaction (Faction::GREEN);
 
   Process (R"([
     {
@@ -747,7 +777,7 @@ TEST_F (CharacterUpdateTests, OwnerCheck)
 
 TEST_F (CharacterUpdateTests, InvalidUpdate)
 {
-  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
 
   /* We want to test that one invalid update still allows for other
      updates (i.e. other characters) to be done successfully in the same
@@ -2709,7 +2739,7 @@ TEST_F (ProspectingMoveTests, NoProspectingAbility)
 
 TEST_F (ProspectingMoveTests, MultipleCharacters)
 {
-  accounts.CreateNew ("foo", Faction::GREEN);
+  accounts.CreateNew ("foo")->SetFaction (Faction::GREEN);
 
   auto c = tbl.CreateNew ("foo", Faction::GREEN);
   ASSERT_EQ (c->GetId (), 2);
@@ -2944,8 +2974,8 @@ protected:
   BuildingUpdateTests ()
     : buildings(db)
   {
-    accounts.CreateNew ("domob", Faction::RED);
-    accounts.CreateNew ("andy", Faction::RED);
+    accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+    accounts.CreateNew ("andy")->SetFaction (Faction::RED);
 
     db.SetNextId (100);
 
@@ -3079,7 +3109,10 @@ protected:
   ServicesMoveTests ()
     : buildings(db), inv(db), characters(db)
   {
-    accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+    auto a = accounts.CreateNew ("domob");
+    a->SetFaction (Faction::RED);
+    a->AddBalance (100);
+    a.reset ();
 
     db.SetNextId (100);
     buildings.CreateNew ("ancient1", "", Faction::ANCIENT)
@@ -3209,7 +3242,7 @@ protected:
 
 TEST_F (GodModeTests, InvalidTeleport)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   const auto id = tbl.CreateNew ("domob", Faction::RED)->GetId ();
   ASSERT_EQ (id, 1);
 
@@ -3225,7 +3258,7 @@ TEST_F (GodModeTests, InvalidTeleport)
 
 TEST_F (GodModeTests, Teleport)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   auto c = tbl.CreateNew ("domob", Faction::RED);
   const auto id = c->GetId ();
   ASSERT_EQ (id, 1);
@@ -3253,7 +3286,7 @@ TEST_F (GodModeTests, Teleport)
 
 TEST_F (GodModeTests, SetHp)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   auto c = tbl.CreateNew ("domob", Faction::RED);
   const auto id = c->GetId ();
   ASSERT_EQ (id, 1);
@@ -3324,7 +3357,7 @@ TEST_F (GodModeTests, SetHp)
 
 TEST_F (GodModeTests, Build)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   /* This is entirely invalid (not even an array).  */
   ProcessAdmin (R"([{"cmd": {"god": {"build": {"foo": "bar"}}}}])");
@@ -3478,8 +3511,8 @@ TEST_F (GodModeTests, ValidDropLoot)
 
 TEST_F (GodModeTests, GiftCoins)
 {
-  accounts.CreateNew ("andy", Faction::RED);
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   ProcessAdmin (R"([{"cmd": {
     "god":
@@ -3536,7 +3569,7 @@ protected:
 
 TEST_F (GodModeDisabledTests, Teleport)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   const auto id = tbl.CreateNew ("domob", Faction::RED)->GetId ();
   ASSERT_EQ (id, 1);
 
@@ -3549,7 +3582,7 @@ TEST_F (GodModeDisabledTests, Teleport)
 
 TEST_F (GodModeDisabledTests, SetHp)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   auto c = tbl.CreateNew ("domob", Faction::RED);
   const auto id = c->GetId ();
   ASSERT_EQ (id, 1);

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -521,6 +521,12 @@ PendingStateUpdater::ProcessMove (const Json::Value& moveObj)
   if (ParseCoinTransferBurn (*a, mv, coinOps))
     state.AddCoinTransferBurn (*a, coinOps);
 
+  /* If the account is not initialised yet, any other action is invalid anyway.
+     If this is the init move itself, they would be actually fine, but we
+     ignore this edge case for pending processing.  */
+  if (!a->IsInitialised ())
+    return;
+
   TryCharacterUpdates (name, mv);
   TryCharacterCreation (name, mv, paidToDev);
 

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -91,7 +91,8 @@ TEST_F (PendingStateTests, Empty)
 
 TEST_F (PendingStateTests, Clear)
 {
-  auto a = accounts.CreateNew ("domob", Faction::RED);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
   CoinTransferBurn coinOp;
   coinOp.burnt = 10;
   coinOp.transfers["andy"] = 20;
@@ -551,7 +552,8 @@ TEST_F (PendingStateTests, CharacterCreation)
 
 TEST_F (PendingStateTests, CoinTransferBurn)
 {
-  auto a = accounts.CreateNew ("domob", Faction::RED);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
 
   CoinTransferBurn coinOp;
   coinOp.burnt = 5;
@@ -588,8 +590,15 @@ TEST_F (PendingStateTests, CoinTransferBurn)
 
 TEST_F (PendingStateTests, ServiceOperations)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (30);
-  accounts.CreateNew ("andy", Faction::GREEN)->AddBalance (30);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (30);
+  a.reset ();
+
+  a = accounts.CreateNew ("andy");
+  a->SetFaction (Faction::GREEN);
+  a->AddBalance (30);
+  a.reset ();
 
   db.SetNextId (100);
   buildings.CreateNew ("ancient1", "", Faction::ANCIENT);
@@ -713,9 +722,9 @@ TEST_F (PendingStateUpdaterTests, AccountNotInitialised)
 
 TEST_F (PendingStateUpdaterTests, InvalidCreation)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
-  accounts.CreateNew ("at limit", Faction::BLUE);
+  accounts.CreateNew ("at limit")->SetFaction (Faction::BLUE);
   for (unsigned i = 0; i < ctx.RoConfig ()->params ().character_limit (); ++i)
     characters.CreateNew ("at limit", Faction::BLUE)
         ->SetPosition (HexCoord (i, 1));
@@ -745,8 +754,8 @@ TEST_F (PendingStateUpdaterTests, InvalidCreation)
 
 TEST_F (PendingStateUpdaterTests, ValidCreations)
 {
-  accounts.CreateNew ("domob", Faction::RED);
-  accounts.CreateNew ("andy", Faction::GREEN);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::GREEN);
 
   ProcessWithDevPayment ("domob", 2 * characterCost, R"({
     "nc": [{}, {}, {}]
@@ -781,8 +790,8 @@ TEST_F (PendingStateUpdaterTests, ValidCreations)
 
 TEST_F (PendingStateUpdaterTests, InvalidUpdate)
 {
-  accounts.CreateNew ("domob", Faction::RED);
-  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
 
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
 
@@ -805,7 +814,7 @@ TEST_F (PendingStateUpdaterTests, InvalidUpdate)
 
 TEST_F (PendingStateUpdaterTests, Waypoints)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 1));
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 2));
@@ -846,7 +855,7 @@ TEST_F (PendingStateUpdaterTests, Waypoints)
 
 TEST_F (PendingStateUpdaterTests, EnterBuilding)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, -1));
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 0));
@@ -895,7 +904,7 @@ TEST_F (PendingStateUpdaterTests, EnterBuilding)
 
 TEST_F (PendingStateUpdaterTests, ExitBuilding)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   auto c = characters.CreateNew ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
@@ -940,7 +949,7 @@ TEST_F (PendingStateUpdaterTests, ExitBuilding)
 
 TEST_F (PendingStateUpdaterTests, DropPickup)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 0));
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (1, 0));
 
@@ -983,7 +992,7 @@ TEST_F (PendingStateUpdaterTests, DropPickup)
 
 TEST_F (PendingStateUpdaterTests, PickupInFoundation)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
   const auto bId = b->GetId ();
   b->MutableProto ().set_foundation (true);
@@ -1006,7 +1015,7 @@ TEST_F (PendingStateUpdaterTests, PickupInFoundation)
 
 TEST_F (PendingStateUpdaterTests, Prospecting)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   const HexCoord pos(456, -789);
   auto h = characters.CreateNew ("domob", Faction::RED);
@@ -1047,7 +1056,7 @@ TEST_F (PendingStateUpdaterTests, Prospecting)
 
 TEST_F (PendingStateUpdaterTests, Mining)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   const HexCoord pos(456, -789);
   constexpr Database::IdT regionId = 345'820;
@@ -1086,7 +1095,7 @@ TEST_F (PendingStateUpdaterTests, Mining)
 
 TEST_F (PendingStateUpdaterTests, FoundBuilding)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   auto c = characters.CreateNew ("domob", Faction::RED);
   c->GetInventory ().AddFungibleCount ("foo", 10);
@@ -1132,7 +1141,7 @@ TEST_F (PendingStateUpdaterTests, FoundBuilding)
 
 TEST_F (PendingStateUpdaterTests, ChangeVehicle)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   auto c = characters.CreateNew ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
@@ -1198,7 +1207,7 @@ TEST_F (PendingStateUpdaterTests, ChangeVehicle)
 
 TEST_F (PendingStateUpdaterTests, Fitments)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   auto c = characters.CreateNew ("domob", Faction::RED);
   ASSERT_EQ (c->GetId (), 1);
@@ -1266,7 +1275,7 @@ TEST_F (PendingStateUpdaterTests, Fitments)
 
 TEST_F (PendingStateUpdaterTests, CreationAndUpdateTogether)
 {
-  accounts.CreateNew ("domob", Faction::RED);
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   CHECK_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 1);
 
@@ -1291,8 +1300,15 @@ TEST_F (PendingStateUpdaterTests, CreationAndUpdateTogether)
 
 TEST_F (PendingStateUpdaterTests, CoinTransferBurn)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
-  accounts.CreateNew ("andy", Faction::GREEN)->AddBalance (100);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
+  a = accounts.CreateNew ("andy");
+  a->SetFaction (Faction::GREEN);
+  a->AddBalance (100);
+  a.reset ();
 
   Process ("domob", R"({
     "abc": "foo",
@@ -1339,7 +1355,10 @@ TEST_F (PendingStateUpdaterTests, CoinTransferBurn)
 
 TEST_F (PendingStateUpdaterTests, ServiceOperations)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
 
   db.SetNextId (100);
   buildings.CreateNew ("ancient1", "", Faction::ANCIENT)
@@ -1379,7 +1398,10 @@ TEST_F (PendingStateUpdaterTests, ServiceOperations)
 
 TEST_F (PendingStateUpdaterTests, MobileRefining)
 {
-  accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+  auto a = accounts.CreateNew ("domob");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
 
   db.SetNextId (101);
   auto c = characters.CreateNew ("domob", Faction::RED);

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -67,7 +67,10 @@ protected:
     : accounts(db), buildings(db), inv(db), characters(db),
       itemCounts(db), ongoings(db)
   {
-    accounts.CreateNew ("domob", Faction::RED)->AddBalance (100);
+    auto a = accounts.CreateNew ("domob");
+    a->SetFaction (Faction::RED);
+    a->AddBalance (100);
+    a.reset ();
 
     db.SetNextId (ANCIENT_BUILDING);
     auto b = buildings.CreateNew ("ancient1", "", Faction::ANCIENT);
@@ -239,7 +242,7 @@ TEST_F (ServicesTests, InsufficientFunds)
 
 TEST_F (ServicesTests, PendingJson)
 {
-  accounts.CreateNew ("andy", Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
 
   auto b = buildings.CreateNew ("ancient1", "andy", Faction::RED);
   ASSERT_EQ (b->GetId (), 101);
@@ -275,7 +278,10 @@ protected:
     /* For some fee tests, we need an account with just enough balance
        for the base cost.  This will be "andy" (as opposed to "domob" who
        has 100 coins).  */
-    accounts.CreateNew ("andy", Faction::RED)->AddBalance (10);
+    auto a = accounts.CreateNew ("andy");
+    a->SetFaction (Faction::RED);
+    a->AddBalance (10);
+    a.reset ();
 
     CHECK_EQ (buildings.CreateNew ("ancient1", "andy", Faction::RED)
                 ->GetId (), 101);
@@ -716,7 +722,11 @@ TEST_F (RepairTests, NonExistantCharacter)
 
 TEST_F (RepairTests, NonOwnedCharacter)
 {
-  accounts.CreateNew ("andy", Faction::RED)->AddBalance (100);
+  auto a = accounts.CreateNew ("andy");
+  a->SetFaction (Faction::RED);
+  a->AddBalance (100);
+  a.reset ();
+
   EXPECT_FALSE (Process ("andy", R"({
     "t": "fix",
     "b": 100,


### PR DESCRIPTION
This allows accounts to be in the database without having chosen a faction ("uninitialised").  Those accounts are not able to do any of the proper game operations, but they can transfer vCHI.  Even accounts not yet in the database at all can receive vCHI.

This makes vCHI a "real" cryptocurrency, which is not necessarily tied to the game itself (of course it is in the sense that it is useful in Taurion, but it can be sent and held without having to actively play Taurion).