### PR TITLE
Support passing characters to findpath

### DIFF
--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -241,7 +241,7 @@ LeaveBuilding (BuildingsTable& buildings, Character& c,
       << " is leaving building " << b->GetId ()
       << " to location " << pos;
   c.SetPosition (pos);
-  dyn.AddVehicle (pos, c.GetFaction ());
+  CHECK (dyn.AddVehicle (pos, c.GetFaction ()));
 }
 
 } // namespace pxd

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -417,7 +417,7 @@ public:
 const std::map<std::string, RealCharonClient::RpcServer::NonStateMethod>
     RealCharonClient::RpcServer::NONSTATE_METHODS =
   {
-    {"setpathbuildings", &NonStateRpcServer::setpathbuildingsI},
+    {"setpathdata", &NonStateRpcServer::setpathdataI},
     {"findpath", &NonStateRpcServer::findpathI},
     {"encodewaypoints", &NonStateRpcServer::encodewaypointsI},
     {"getregionat", &NonStateRpcServer::getregionatI},

--- a/src/dynobstacles.hpp
+++ b/src/dynobstacles.hpp
@@ -98,9 +98,10 @@ public:
   bool IsFree (const HexCoord& c) const;
 
   /**
-   * Adds a new vehicle with the given faction and position.
+   * Adds a new vehicle with the given faction and position.  Returns false
+   * if it failed (e.g. because there is already something there on the map).
    */
-  void AddVehicle (const HexCoord& c, Faction f);
+  bool AddVehicle (const HexCoord& c, Faction f);
 
   /**
    * Removes a vehicle from the given position.

--- a/src/dynobstacles.tpp
+++ b/src/dynobstacles.tpp
@@ -51,12 +51,15 @@ DynObstacles::IsFree (const HexCoord& c) const
   return !buildings.Get (c) && !red.Get (c) && !green.Get (c) && !blue.Get (c);
 }
 
-inline void
+inline bool
 DynObstacles::AddVehicle (const HexCoord& c, const Faction f)
 {
   auto ref = FactionVehicles (f).Access (c);
-  CHECK (!ref);
+  if (ref)
+    return false;
+
   ref = true;
+  return true;
 }
 
 inline void

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -356,7 +356,7 @@ MoveInDynObstacles::~MoveInDynObstacles ()
       << "Adding back character " << character.GetId ()
       << " at position " << character.GetPosition ()
       << " to the dynamic obstacle map...";
-  dyn.AddVehicle (character.GetPosition (), character.GetFaction ());
+  CHECK (dyn.AddVehicle (character.GetPosition (), character.GetFaction ()));
 }
 
 namespace test

--- a/src/rpc-stubs/nonstate.json
+++ b/src/rpc-stubs/nonstate.json
@@ -1,9 +1,10 @@
 [
   {
-    "name": "setpathbuildings",
+    "name": "setpathdata",
     "params":
       {
-        "buildings": []
+        "buildings": [],
+        "characters": []
       },
     "returns": true
   },

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -88,10 +88,11 @@
   },
 
   {
-    "name": "setpathbuildings",
+    "name": "setpathdata",
     "params":
       {
-        "buildings": []
+        "buildings": [],
+        "characters": []
       },
     "returns": true
   },

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -123,7 +123,7 @@ SpawnCharacter (const std::string& owner, const Faction f,
 
   auto c = tbl.CreateNew (owner, f);
   c->SetPosition (pos);
-  dyn.AddVehicle (pos, f);
+  CHECK (dyn.AddVehicle (pos, f));
 
   switch (f)
     {


### PR DESCRIPTION
Extend the `setpathbuildings` RPC (renamed to `setpathdata`), so that also characters can be passed in and stored in the findpath map data.  This allows the frontend (and any other client) to also compute paths that avoid stationary characters on the map, not just buildings.

The character data passed must be a JSON array of objects, containing at least `faction` and `position`.  It can be the full result of `getcharacters`.