### PR TITLE
Implement "unblock spawns" fork

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -25,6 +25,7 @@ REGTESTS = \
   damage_lists.py \
   fame.py \
   findpath.py \
+  fork_unblockspawns.py \
   getbuildingshape.py \
   getserviceinfo.py \
   getregionat.py \

--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -210,10 +210,6 @@ class FindPathTest (PXTest):
       [{"faction": "a", "position": coord}],
       [{"faction": "r", "position": "foo"}],
       [{"faction": "r", "position": {"x": 1}}],
-      [
-        {"faction": "r", "position": coord},
-        {"faction": "r", "position": coord},
-      ],
     ]:
       self.expectError (-1, "characters is invalid",
                         self.rpc.game.setpathdata,

--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -136,7 +136,8 @@ class FindPathTest (PXTest):
 
     self.testExbuildings ()
     self.testInvalidData ()
-    self.testWithData ()
+    self.testWithCharacterData ()
+    self.testWithBuildingData ()
 
   def testExbuildings (self):
     self.mainLogger.info ("Testing exbuildings...")
@@ -218,8 +219,43 @@ class FindPathTest (PXTest):
                         self.rpc.game.setpathdata,
                         buildings=[], characters=specs)
 
-  def testWithData (self):
-    self.mainLogger.info ("Testing with set data...")
+  def testWithCharacterData (self):
+    self.mainLogger.info ("Testing with character data...")
+
+    # Create some test characters that we can use as obstacles.
+    self.initAccount ("red", "r")
+    self.initAccount ("green", "g")
+    self.generate (1)
+    self.createCharacters ("red", 2)
+    self.createCharacters ("green")
+    self.generate (1)
+
+    # Place some characters on the map.  We then use the output of
+    # getcharacters to pass as findpath data, to ensure this works.
+    self.moveCharactersTo ({
+      "red": {"x": 0, "y": 0},
+      "green": {"x": 10, "y": 0},
+      "red 2": {"x": 0, "y": 10},
+    })
+    characters = self.getRpc ("getcharacters")
+    self.rpc.game.setpathdata (buildings=[], characters=characters)
+
+    moreArgs = {
+      "source": {"x": 0, "y": 0},
+      "faction": "r",
+      "l1range": 8000,
+    }
+
+    self.assertEqual (self.call (target={"x": 20, "y": 0}, **moreArgs)["dist"],
+                      20000)
+    self.assertEqual (self.call (target={"x": 0, "y": 20}, **moreArgs)["dist"],
+                      21000)
+    self.expectError (1, "no connection",
+                      self.call,
+                      target={"x": 0, "y": 10}, **moreArgs)
+
+  def testWithBuildingData (self):
+    self.mainLogger.info ("Testing with building data...")
 
     # This is a very long path, which takes a non-negligible amount of time
     # to compute.  We use this later to ensure that multiple calls are
@@ -247,57 +283,32 @@ class FindPathTest (PXTest):
     serialised = json.dumps (path["wp"], separators=(",", ":"))
     assert len (serialised) > 3000
 
-    # Create some test characters that we can use as obstacles.
-    self.initAccount ("red", "r")
-    self.initAccount ("green", "g")
-    self.generate (1)
-    self.createCharacters ("red", 3)
-    self.createCharacters ("green")
-
-    # Now place buildings and characters in two steps on the map, which make
-    # the path from longA to longB further.  We use the outputs of getbuildings
-    # and getcharacters itself, to ensure that it can be passed directly back
-    # to setpathdata.
+    # Now place buildings in two steps on the map, which make the path from
+    # longA to longB further.  We use the outputs of getbuildings itself, to
+    # ensure that it can be passed directly back to setpathdata.
     buildings = [[]]
-    characters = [[]]
 
+    self.build ("r rt", None,
+                offsetCoord (longA, {"x": 1, "y": 0}, False), rot=0)
     self.build ("r rt", None,
                 offsetCoord (longA, {"x": 1, "y": -1}, False), rot=0)
     self.build ("r rt", None,
                 offsetCoord (longA, {"x": 0, "y": 1}, False), rot=0)
-    self.moveCharactersTo ({
-      "red": longA,
-      "red 2": offsetCoord (longA, {"x": 1, "y": 0}, False),
-    })
-    bIds = [
-      b["id"]
-      for b in self.getRpc ("getbuildings")
-      if b["type"] == "r rt"
-    ]
-    self.getCharacters ()["red"].sendMove ({"eb": bIds[0]})
-    self.generate (1)
-    self.assertEqual (self.getCharacters ()["red"].isInBuilding (), True)
-
     buildings.append (self.getRpc ("getbuildings"))
-    characters.append (self.getRpc ("getcharacters"))
 
     self.build ("r rt", None,
                 offsetCoord (longA, {"x": 0, "y": -1}, False), rot=0)
-    self.moveCharactersTo ({
-      "red 3": offsetCoord (longA, {"x": -1, "y": 1}, False),
-      "green": offsetCoord (longA, {"x": -1, "y": 0}, False),
-    })
-
+    self.build ("r rt", None,
+                offsetCoord (longA, {"x": -1, "y": 1}, False), rot=0)
     buildings.append (self.getRpc ("getbuildings"))
-    characters.append (self.getRpc ("getcharacters"))
 
     # We do three calls now in parallel, with different sets of buildings.
     # All should be running concurrently and not block each other.  The total
     # time should be shorter than sequential execution.
     before = time.clock_gettime (time.CLOCK_MONOTONIC)
     calls = []
-    for b, c in zip (buildings, characters):
-      calls.append (AsyncFindPath (self.gamenode, b, c, **kwargs))
+    for b in buildings:
+      calls.append (AsyncFindPath (self.gamenode, b, [], **kwargs))
     [shortLen, midLen, longLen] = [c.finish ()["dist"] for c in calls]
     after = time.clock_gettime (time.CLOCK_MONOTONIC)
     threeDuration = after - before

--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -55,10 +55,11 @@ class AsyncFindPath (threading.Thread):
 
 class FindPathTest (PXTest):
 
-  def call (self, source, target, l1range, faction="r", exbuildings=[]):
+  def call (self, source, target, l1range,
+            faction="r", exbuildings=[], height=0):
     return self.rpc.game.findpath (source=source, target=target,
                                    faction=faction, l1range=l1range,
-                                   exbuildings=exbuildings)
+                                   exbuildings=exbuildings, height=height)
 
   def strip (self, val):
     """
@@ -242,6 +243,7 @@ class FindPathTest (PXTest):
       "l1range": 8000,
     }
 
+    moreArgs["height"] = 0
     self.assertEqual (self.call (target={"x": 20, "y": 0}, **moreArgs)["dist"],
                       20000)
     self.assertEqual (self.call (target={"x": 0, "y": 20}, **moreArgs)["dist"],
@@ -249,6 +251,16 @@ class FindPathTest (PXTest):
     self.expectError (1, "no connection",
                       self.call,
                       target={"x": 0, "y": 10}, **moreArgs)
+
+    moreArgs["height"] = 500
+    self.assertEqual (self.call (target={"x": 20, "y": 0}, **moreArgs)["dist"],
+                      21000)
+    self.assertEqual (self.call (target={"x": 0, "y": 20}, **moreArgs)["dist"],
+                      21000)
+    self.assertEqual (self.call (target={"x": 10, "y": 0}, **moreArgs)["dist"],
+                      17000)
+    self.assertEqual (self.call (target={"x": 0, "y": 10}, **moreArgs)["dist"],
+                      17000)
 
   def testWithBuildingData (self):
     self.mainLogger.info ("Testing with building data...")
@@ -264,6 +276,7 @@ class FindPathTest (PXTest):
       "faction": "r",
       "l1range": 8000,
       "exbuildings": [],
+      "height": 0,
     }
     before = time.clock_gettime (time.CLOCK_MONOTONIC)
     path = self.call (**kwargs)

--- a/gametest/fork_unblockspawns.py
+++ b/gametest/fork_unblockspawns.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Integration test the "unblock spawns" fork.
+"""
+
+from pxtest import PXTest
+
+FORK_HEIGHT = 500
+
+
+class UnblockSpawnsForkTest (PXTest):
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.initAccount ("red", "r")
+    self.initAccount ("green", "g")
+    self.initAccount ("blue", "b")
+    self.generate (1)
+
+    # Remember a block before the fork is active, which we will later
+    # reorg to and check that the fork is then still inactive.
+    self.generate (100)
+    reorgBlock = self.rpc.xaya.getbestblockhash ()
+
+    # Advance until almost the fork height.
+    self.advanceToHeight (FORK_HEIGHT - 2)
+
+    self.mainLogger.info ("Creating characters before the fork...")
+    for nm in ["red", "green", "blue"]:
+      self.createCharacters (nm)
+    self.generate (1)
+    chars = self.getCharacters ()
+    for nm in ["red", "green", "blue"]:
+      self.assertEqual (chars[nm].isInBuilding (), False)
+
+    self.mainLogger.info ("Creating characters after the fork...")
+    for nm in ["red", "green", "blue"]:
+      self.createCharacters (nm)
+    self.generate (1)
+    self.assertEqual (self.rpc.xaya.getblockcount (), FORK_HEIGHT)
+    chars = self.getCharacters ()
+    buildings = self.getBuildings ()
+    for nm, t in [("red", "r ss"), ("green", "g ss"), ("blue", "b ss")]:
+      c = chars["%s 2" % nm]
+      self.assertEqual (c.isInBuilding (), True)
+      self.assertEqual (buildings[c.getBuildingId ()].getType (), t)
+
+    # Test a reorg back to before the fork.
+    self.mainLogger.info ("Testing reorg to before the fork...")
+    oldState = self.getGameState ()
+
+    self.rpc.xaya.invalidateblock (reorgBlock)
+    self.initAccount ("reorg", "r")
+    self.generate (1)
+    self.createCharacters ("reorg")
+    self.generate (1)
+    self.assertEqual (self.getCharacters ()["reorg"].isInBuilding (), False)
+
+    self.rpc.xaya.reconsiderblock (reorgBlock)
+    self.expectGameState (oldState)
+
+
+if __name__ == "__main__":
+  UnblockSpawnsForkTest ().main ()

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -32,7 +32,6 @@ class GodModeTest (PXTest):
     self.createCharacters ("domob")
     self.generate (1)
     c = self.getCharacters ()["domob"]
-    pos = c.getPosition ()
     charIdStr = c.getIdStr ()
 
     self.mainLogger.info ("Testing build...")
@@ -94,7 +93,6 @@ class GodModeTest (PXTest):
 
     self.mainLogger.info ("Testing teleport...")
     target = {"x": 28, "y": 9}
-    assert pos != target
     self.adminCommand ({"god": {"teleport": {charIdStr: target}}})
     self.generate (1)
     self.assertEqual (self.getCharacters ()["domob"].getPosition (), target)

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -65,6 +65,14 @@ class MovementTest (PXTest):
 
     return pos, None
 
+  def expectPosition (self, owner, expected):
+    """
+    Expects the position of the given character to be the given value.
+    """
+
+    pos, _ = self.getMovement (owner)
+    self.assertEqual (pos, expected)
+
   def expectMovement (self, owner, wp):
     """
     Expects that the given character moves along the set of waypoints
@@ -160,6 +168,7 @@ class MovementTest (PXTest):
 
     self.testChosenSpeed ()
     self.testBlockingBuilding ()
+    self.testConvoy ()
     self.testReorg ()
 
   def testChosenSpeed (self):
@@ -255,6 +264,91 @@ class MovementTest (PXTest):
     pos, mv = self.getMovement ("domob")
     self.assertEqual (pos, {"x": 0, "y": 0})
     self.assertEqual (mv, None)
+
+  def testConvoy (self):
+    """
+    Tests movement of multiple characters in a "convoy", with semantics
+    after the unblock-spawns fork.
+    """
+
+    self.mainLogger.info ("Testing convoy movement...")
+
+    # We should already be beyond the fork height, but check that.
+    assert self.rpc.xaya.getblockcount () > 500
+
+    # Set up three test characters around a common centre, and then
+    # send them to move with the same path.  They will "collidate" on the
+    # initial step, but due to the slowdown on entering a coordinate with
+    # another vehicle on it, should just split out into a convoy over time.
+    self.createCharacters ("domob", 2)
+    self.generate (1)
+    self.moveCharactersTo ({
+      "domob": offsetCoord ({"x": 1, "y": -1}, self.offset, False),
+      "domob 2": offsetCoord ({"x": 1, "y": 0}, self.offset, False),
+      "domob 3": offsetCoord ({"x": 0, "y": 1}, self.offset, False),
+    })
+
+    wp = [{"x": 0, "y": 0}, {"x": -10, "y": 0}]
+    self.setWaypoints ("domob 3", wp, speed=1000)
+    self.setWaypoints ("domob 2", wp, speed=1000)
+    self.setWaypoints ("domob", wp, speed=1000)
+
+    self.generate (1)
+    self.expectPosition ("domob", {"x": 0, "y": 0})
+    self.expectPosition ("domob 2", {"x": 1, "y": 0})
+    self.expectPosition ("domob 3", {"x": 0, "y": 1})
+
+    self.generate (1)
+    self.expectPosition ("domob", {"x": -1, "y": 0})
+    self.expectPosition ("domob 2", {"x": 0, "y": 0})
+    self.expectPosition ("domob 3", {"x": 0, "y": 1})
+
+    self.generate (1)
+    self.expectPosition ("domob", {"x": -2, "y": 0})
+    self.expectPosition ("domob 2", {"x": -1, "y": 0})
+    self.expectPosition ("domob 3", {"x": 0, "y": 0})
+
+    self.generate (5)
+    self.expectPosition ("domob", {"x": -7, "y": 0})
+    self.expectPosition ("domob 2", {"x": -6, "y": 0})
+    self.expectPosition ("domob 3", {"x": -5, "y": 0})
+
+    # Let them move onto the target tile and collect up there together.
+    # Then move back off, which should again be as a convoy.
+    self.generate (20)
+    self.expectPosition ("domob", {"x": -10, "y": 0})
+    self.expectPosition ("domob 2", {"x": -10, "y": 0})
+    self.expectPosition ("domob 3", {"x": -10, "y": 0})
+
+    wp = [{"x": 0, "y": 0}]
+    self.setWaypoints ("domob 3", wp, speed=1000)
+    self.setWaypoints ("domob 2", wp, speed=1000)
+    self.setWaypoints ("domob", wp, speed=1000)
+
+    self.generate (1)
+    self.expectPosition ("domob", {"x": -9, "y": 0})
+    self.expectPosition ("domob 2", {"x": -10, "y": 0})
+    self.expectPosition ("domob 3", {"x": -10, "y": 0})
+
+    self.generate (1)
+    self.expectPosition ("domob", {"x": -8, "y": 0})
+    self.expectPosition ("domob 2", {"x": -9, "y": 0})
+    self.expectPosition ("domob 3", {"x": -10, "y": 0})
+
+    self.generate (1)
+    self.expectPosition ("domob", {"x": -7, "y": 0})
+    self.expectPosition ("domob 2", {"x": -8, "y": 0})
+    self.expectPosition ("domob 3", {"x": -9, "y": 0})
+
+    self.generate (7)
+    self.expectPosition ("domob", {"x": 0, "y": 0})
+    self.expectPosition ("domob 2", {"x": -1, "y": 0})
+    self.expectPosition ("domob 3", {"x": -2, "y": 0})
+
+    self.generate (20)
+    self.expectPosition ("domob", {"x": 0, "y": 0})
+    self.expectPosition ("domob 2", {"x": 0, "y": 0})
+    self.expectPosition ("domob 3", {"x": 0, "y": 0})
 
   def testReorg (self):
     """

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -312,6 +312,19 @@ class PXTest (XayaGameTest):
       self.rpc.xaya.sendtoaddress (self.rpc.xaya.getnewaddress (), 100)
     self.generate (1)
 
+  def advanceToHeight (self, targetHeight):
+    """
+    Mines blocks until we are exactly at the given target height.
+    """
+
+    n = targetHeight - self.rpc.xaya.getblockcount ()
+
+    assert n >= 0
+    if n > 0:
+      self.generate (n)
+
+    self.assertEqual (self.rpc.xaya.getblockcount (), targetHeight)
+
   def getRpc (self, method, *args, **kwargs):
     """
     Calls the given "read-type" RPC method on the game daemon and returns

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -130,10 +130,12 @@ class Character (object):
     target, and returns it as encoded string suitable for a "wp" move.
     """
 
+    nextHeight = self.test.rpc.xaya.getblockcount () + 1
     path = self.test.rpc.game.findpath (source=self.getPosition (),
                                         target=target,
                                         faction=self.data["faction"],
                                         l1range=1000,
+                                        height=nextHeight,
                                         exbuildings=[])
     return path["encoded"]
 

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -425,24 +425,33 @@ class PXTest (XayaGameTest):
   def changeCharacterVehicle (self, char, vehicleType, fitments=[]):
     """
     Changes the vehicle of the given character to the given type.  This is
-    done through god-mode, by dropping the vehicle type into an ancient
-    building and changing there.
+    done through god-mode, by dropping the vehicle type into some of the
+    initial buildings and changing there.
+
+    If the character is already inside some building (e.g. after
+    spawn), we will do it directly there instead.
     """
 
-    b = self.getBuildings ()[1]
-    self.assertEqual (b.getFaction (), "a")
-    pos = offsetCoord (b.getCentre (), {"x": 30, "y": 0}, False)
-    self.moveCharactersTo ({char: pos})
-
     c = self.getCharacters ()[char]
-    c.sendMove ({"eb": b.getId ()})
+    if c.isInBuilding ():
+      bId = c.getBuildingId ()
+    else:
+      b = self.getBuildings ()[1]
+      bId = b.getId ()
+      self.assertEqual (b.getFaction (), "a")
+      pos = offsetCoord (b.getCentre (), {"x": 30, "y": 0}, False)
+      self.moveCharactersTo ({char: pos})
+
+      c = self.getCharacters ()[char]
+      c.sendMove ({"eb": bId})
+
     inv = {vehicleType: 1}
     for f in fitments:
       if f in inv:
         ++inv[f]
       else:
         inv[f] = 1
-    self.dropIntoBuilding (b.getId (), c.getOwner (), inv)
+    self.dropIntoBuilding (bId, c.getOwner (), inv)
 
     # Make sure that we can change vehicle and fitments by maxing the
     # character's HP (just in case).

--- a/gametest/safezones.py
+++ b/gametest/safezones.py
@@ -50,7 +50,8 @@ class SafeZonesTest (PXTest):
 
     self.mainLogger.info ("Testing findpath...")
     def findpath (**kwargs):
-      path = self.rpc.game.findpath (exbuildings=[], l1range=1000, wpdist=1000,
+      path = self.rpc.game.findpath (exbuildings=[], height=0,
+                                     l1range=1000, wpdist=1000,
                                      **kwargs)
       return path["dist"]
     self.expectError (1, "no connection",

--- a/mapdata/Makefile.am
+++ b/mapdata/Makefile.am
@@ -31,6 +31,7 @@ noinst_HEADERS = \
   dyntiles.hpp dyntiles.tpp \
   regionmap.hpp \
   safezones.hpp safezones.tpp \
+  sparsemap.hpp sparsemap.tpp \
   tiledata.hpp \
   \
   benchutils.hpp \
@@ -55,6 +56,7 @@ tests_SOURCES = \
   dyntiles_tests.cpp \
   regionmap_tests.cpp \
   safezones_tests.cpp \
+  sparsemap_tests.cpp \
   \
   dataio.cpp
 

--- a/mapdata/sparsemap.hpp
+++ b/mapdata/sparsemap.hpp
@@ -1,0 +1,83 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MAPDATA_SPARSEMAP_HPP
+#define MAPDATA_SPARSEMAP_HPP
+
+#include "dyntiles.hpp"
+
+#include "hexagonal/coord.hpp"
+
+#include <unordered_map>
+
+namespace pxd
+{
+
+/**
+ * Sparse map from hex coordinates to some associated value.  This uses an
+ * underlying bitmap for each tile to quickly determine whether or not
+ * a given tile is actually in the map or not, and only looks up the actual
+ * value if it is.
+ */
+template <typename T>
+  class SparseTileMap
+{
+
+private:
+
+  /** The default value, which corresponds to missing entries.  */
+  const T defaultValue;
+
+  /** The density map.  */
+  DynTiles<bool> density;
+
+  /** The actual map from existing tiles to values.  */
+  std::unordered_map<HexCoord, T> values;
+
+  friend class SparseMapTests;
+
+public:
+
+  /**
+   * Constructs the map with all elements set to the given value.
+   */
+  explicit SparseTileMap (const T& val);
+
+  SparseTileMap () = delete;
+  SparseTileMap (const SparseTileMap&) = delete;
+  void operator= (const SparseTileMap&) = delete;
+
+  /**
+   * Returns the value associated with a coordinate (or the default value
+   * if the coordinate is not set).
+   */
+  const T& Get (const HexCoord& c) const;
+
+  /**
+   * Sets the value associated with a coordinate.  If the value we are setting
+   * to is the default value, removes the element entirely.
+   */
+  void Set (const HexCoord& c, const T& val);
+
+};
+
+} // namespace pxd
+
+#include "sparsemap.tpp"
+
+#endif // MAPDATA_SPARSEMAP_HPP

--- a/mapdata/sparsemap.tpp
+++ b/mapdata/sparsemap.tpp
@@ -1,0 +1,54 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Template implementation code for sparsemap.hpp.  */
+
+namespace pxd
+{
+
+template <typename T>
+  SparseTileMap<T>::SparseTileMap (const T& val)
+  : defaultValue(val), density(false)
+{}
+
+template <typename T>
+  const T&
+  SparseTileMap<T>::Get (const HexCoord& c) const
+{
+  if (!density.Get (c))
+    return defaultValue;
+
+  return values.at (c);
+}
+
+template <typename T>
+  void
+  SparseTileMap<T>::Set (const HexCoord& c, const T& val)
+{
+  if (val == defaultValue)
+    {
+      values.erase (c);
+      density.Access (c) = false;
+      return;
+    }
+
+  density.Access (c) = true;
+  values[c] = val;
+}
+
+} // namespace pxd

--- a/mapdata/sparsemap_tests.cpp
+++ b/mapdata/sparsemap_tests.cpp
@@ -1,0 +1,80 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "sparsemap.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+
+class SparseMapTests : public testing::Test
+{
+
+protected:
+
+  static constexpr HexCoord COORD[] = {HexCoord (10, -20), HexCoord (-42, 0)};
+
+  SparseTileMap<int> map;
+
+  SparseMapTests ()
+    : map(0)
+  {}
+
+  /**
+   * Returns the size of the non-sparse entry map.
+   */
+  size_t
+  GetNumEntries () const
+  {
+    return map.values.size ();
+  }
+
+};
+
+constexpr HexCoord SparseMapTests::COORD[];
+
+namespace
+{
+
+TEST_F (SparseMapTests, BasicAccess)
+{
+  EXPECT_EQ (map.Get (COORD[0]), 0);
+  map.Set (COORD[0], 42);
+  EXPECT_EQ (map.Get (COORD[0]), 42);
+  EXPECT_EQ (map.Get (COORD[1]), 0);
+  map.Set (COORD[1], 10);
+  EXPECT_EQ (map.Get (COORD[0]), 42);
+  EXPECT_EQ (map.Get (COORD[1]), 10);
+  map.Set (COORD[0], 0);
+  EXPECT_EQ (map.Get (COORD[0]), 0);
+  EXPECT_EQ (map.Get (COORD[1]), 10);
+}
+
+TEST_F (SparseMapTests, EntriesClearedAgain)
+{
+  map.Set (COORD[0], 42);
+  EXPECT_EQ (map.Get (COORD[0]), 42);
+  EXPECT_EQ (GetNumEntries (), 1);
+  map.Set (COORD[0], 0);
+  EXPECT_EQ (map.Get (COORD[0]), 0);
+  EXPECT_EQ (GetNumEntries (), 0);
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -462,7 +462,7 @@ message SafeZone
 /* ************************************************************************** */
 
 /**
- * Definition of a spawn area.
+ * Definition of a spawn area / location.
  */
 message SpawnArea
 {
@@ -472,6 +472,12 @@ message SpawnArea
 
   /** The L1 radius around the centre.  */
   optional uint32 radius = 2;
+
+  /**
+   * The building ID into which new characters are spawned after the
+   * UnblockSpawns fork.
+   */
+  optional uint64 building_id = 3;
 
 }
 

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -31,6 +31,7 @@ params:
           {
             centre: { x: 1960 y: -2601 }
             radius: 50
+            building_id: 6
           }
       }
     spawn_areas:
@@ -40,6 +41,7 @@ params:
           {
             centre: { x: -3472 y: 1824 }
             radius: 50
+            building_id: 4
           }
       }
     spawn_areas:
@@ -49,6 +51,7 @@ params:
           {
             centre: { x: 547 y: 2497 }
             radius: 50
+            building_id: 5
           }
       }
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,7 @@ libtaurion_la_SOURCES = \
   dynobstacles.cpp \
   fame.cpp \
   fitments.cpp \
+  forks.cpp \
   gamestatejson.cpp \
   jsonutils.cpp \
   logic.cpp \
@@ -50,6 +51,7 @@ libtaurionheaders = \
   dynobstacles.hpp dynobstacles.tpp \
   fame.hpp \
   fitments.hpp \
+  forks.hpp \
   gamestatejson.hpp \
   jsonutils.hpp \
   logic.hpp \
@@ -126,6 +128,7 @@ tests_SOURCES = \
   dynobstacles_tests.cpp \
   fame_tests.cpp \
   fitments_tests.cpp \
+  forks_tests.cpp \
   gamestatejson_tests.cpp \
   jsonutils_tests.cpp \
   logic_tests.cpp \

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -234,7 +234,7 @@ LeaveBuilding (BuildingsTable& buildings, Character& c,
 
   const auto radius = ctx.RoConfig ().Building (b->GetType ()).enter_radius ();
   const auto pos = ChooseSpawnLocation (b->GetCentre (), radius,
-                                        c.GetFaction (), rnd, dyn, ctx.Map ());
+                                        c.GetFaction (), rnd, dyn, ctx);
 
   LOG (INFO)
       << "Character " << c.GetId ()

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -241,7 +241,7 @@ LeaveBuilding (BuildingsTable& buildings, Character& c,
       << " is leaving building " << b->GetId ()
       << " to location " << pos;
   c.SetPosition (pos);
-  CHECK (dyn.AddVehicle (pos, c.GetFaction ()));
+  dyn.AddVehicle (pos, c.GetFaction ());
 }
 
 } // namespace pxd

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -338,7 +338,7 @@ TEST_F (ProcessEnterBuildingsTests, EnteringEffects)
   c.reset ();
 
   DynObstacles dyn(db, ctx);
-  ASSERT_FALSE (dyn.IsPassable (HexCoord (5, 0), Faction::RED));
+  ASSERT_TRUE (dyn.HasVehicle (HexCoord (5, 0), Faction::RED));
 
   ProcessEnter (dyn);
 
@@ -349,7 +349,7 @@ TEST_F (ProcessEnterBuildingsTests, EnteringEffects)
   EXPECT_FALSE (c->HasTarget ());
   EXPECT_FALSE (c->GetProto ().has_movement ());
   EXPECT_FALSE (c->GetProto ().mining ().active ());
-  EXPECT_TRUE (dyn.IsPassable (HexCoord (5, 0), Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (HexCoord (5, 0), Faction::RED));
 }
 
 TEST_F (ProcessEnterBuildingsTests, MultipleCharacters)
@@ -439,8 +439,8 @@ TEST_F (LeaveBuildingTests, Basic)
   DynObstacles dyn(db, ctx);
   const auto pos = Leave (dyn);
   EXPECT_TRUE (ctx.Map ().IsPassable (pos));
-  EXPECT_TRUE (originalDyn.IsPassable (pos, Faction::RED));
-  EXPECT_FALSE (dyn.IsPassable (pos, Faction::RED));
+  EXPECT_FALSE (originalDyn.HasVehicle (pos, Faction::RED));
+  EXPECT_TRUE (dyn.HasVehicle (pos, Faction::RED));
   EXPECT_LE (HexCoord::DistanceL1 (pos, centre), radius);
 }
 
@@ -453,7 +453,7 @@ TEST_F (LeaveBuildingTests, WhenAllBlocked)
 
   const auto pos = Leave ();
   EXPECT_TRUE (ctx.Map ().IsPassable (pos));
-  EXPECT_TRUE (originalDyn.IsPassable (pos, Faction::RED));
+  EXPECT_FALSE (originalDyn.HasVehicle (pos, Faction::RED));
   EXPECT_GT (HexCoord::DistanceL1 (pos, centre), radius);
 }
 

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -444,8 +444,10 @@ TEST_F (LeaveBuildingTests, Basic)
   EXPECT_LE (HexCoord::DistanceL1 (pos, centre), radius);
 }
 
-TEST_F (LeaveBuildingTests, WhenAllBlocked)
+TEST_F (LeaveBuildingTests, WhenAllBlockedPreFork)
 {
+  ASSERT_FALSE (ctx.Forks ().IsActive (Fork::UnblockSpawns));
+
   for (HexCoord::IntT r = 0; r <= radius; ++r)
     for (const auto& c : L1Ring (centre, r))
       characters.CreateNew ("domob", Faction::RED)->SetPosition (c);
@@ -454,6 +456,37 @@ TEST_F (LeaveBuildingTests, WhenAllBlocked)
   const auto pos = Leave ();
   EXPECT_TRUE (ctx.Map ().IsPassable (pos));
   EXPECT_FALSE (originalDyn.HasVehicle (pos, Faction::RED));
+  EXPECT_GT (HexCoord::DistanceL1 (pos, centre), radius);
+}
+
+TEST_F (LeaveBuildingTests, BlockedByOtherFactionPreFork)
+{
+  ASSERT_FALSE (ctx.Forks ().IsActive (Fork::UnblockSpawns));
+
+  for (HexCoord::IntT r = 0; r <= radius; ++r)
+    for (const auto& c : L1Ring (centre, r))
+      characters.CreateNew ("domob", Faction::GREEN)->SetPosition (c);
+  DynObstacles originalDyn(db, ctx);
+
+  const auto pos = Leave ();
+  EXPECT_TRUE (ctx.Map ().IsPassable (pos));
+  EXPECT_FALSE (originalDyn.IsFree (pos));
+  EXPECT_LE (HexCoord::DistanceL1 (pos, centre), radius);
+}
+
+TEST_F (LeaveBuildingTests, WhenAllBlockedPostFork)
+{
+  ctx.SetHeight (500);
+  ASSERT_TRUE (ctx.Forks ().IsActive (Fork::UnblockSpawns));
+
+  for (HexCoord::IntT r = 0; r <= radius; ++r)
+    for (const auto& c : L1Ring (centre, r))
+      characters.CreateNew ("domob", Faction::GREEN)->SetPosition (c);
+  DynObstacles originalDyn(db, ctx);
+
+  const auto pos = Leave ();
+  EXPECT_TRUE (ctx.Map ().IsPassable (pos));
+  EXPECT_TRUE (originalDyn.IsFree (pos));
   EXPECT_GT (HexCoord::DistanceL1 (pos, centre), radius);
 }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -31,10 +31,18 @@ Context::Context (const xaya::Chain c)
 Context::Context (const xaya::Chain c, const BaseMap& m,
                   const unsigned h, const int64_t ts)
   : map(&m), chain(c),
-    params(new pxd::Params (chain)),
-    cfg(new pxd::RoConfig (chain)),
     height(h), timestamp(ts)
-{}
+{
+  RefreshInstances ();
+}
+
+void
+Context::RefreshInstances ()
+{
+  params = std::make_unique<pxd::Params> (chain);
+  cfg = std::make_unique<pxd::RoConfig> (chain);
+  forks = std::make_unique<ForkHandler> (chain, height);
+}
 
 unsigned
 Context::Height () const

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -19,6 +19,7 @@
 #ifndef PXD_CONTEXT_HPP
 #define PXD_CONTEXT_HPP
 
+#include "forks.hpp"
 #include "params.hpp"
 
 #include "mapdata/basemap.hpp"
@@ -56,6 +57,9 @@ private:
   /** RoConfig instance dependant on the chain.  */
   std::unique_ptr<pxd::RoConfig> cfg;
 
+  /** Fork handler based on chain and height.  */
+  std::unique_ptr<ForkHandler> forks;
+
   /**
    * The current block's height.  This is set to the confirmed height plus
    * one for processing pending moves, as that corresponds to the expected
@@ -74,6 +78,14 @@ private:
    * used with ContextForTesting.
    */
   explicit Context (xaya::Chain c);
+
+  /**
+   * Sets up all instances that are based on the basic state, like the
+   * Params or RoConfig one.  This is usually just done as part of the
+   * constructor, but in tests, we use it to refresh them when we explicitly
+   * change values.
+   */
+  void RefreshInstances ();
 
   friend class ContextForTesting;
 
@@ -112,6 +124,12 @@ public:
   RoConfig () const
   {
     return *cfg;
+  }
+
+  const ForkHandler&
+  Forks () const
+  {
+    return *forks;
   }
 
   /**

--- a/src/dynobstacles.hpp
+++ b/src/dynobstacles.hpp
@@ -26,7 +26,7 @@
 #include "database/faction.hpp"
 #include "hexagonal/coord.hpp"
 #include "mapdata/basemap.hpp"
-#include "mapdata/dyntiles.hpp"
+#include "mapdata/sparsemap.hpp"
 #include "proto/building.pb.h"
 
 namespace pxd
@@ -47,11 +47,11 @@ private:
   const xaya::Chain chain;
 
   /** Vehicles of the red faction on the map.  */
-  DynTiles<bool> red;
+  SparseTileMap<unsigned> red;
   /** Vehicles of the green faction on the map.  */
-  DynTiles<bool> green;
+  SparseTileMap<unsigned> green;
   /** Vehicles of the blue faction on the map.  */
-  DynTiles<bool> blue;
+  SparseTileMap<unsigned> blue;
 
   /** Buildings in general.  */
   DynTiles<bool> buildings;
@@ -59,9 +59,9 @@ private:
   /**
    * Returns the obstacle map responsible for the given faction.
    */
-  DynTiles<bool>& FactionVehicles (Faction f);
+  SparseTileMap<unsigned>& FactionVehicles (Faction f);
 
-  const DynTiles<bool>&
+  const SparseTileMap<unsigned>&
   FactionVehicles (const Faction f) const
   {
     return const_cast<DynObstacles*> (this)->FactionVehicles (f);
@@ -96,16 +96,20 @@ public:
   bool HasVehicle (const HexCoord& c, Faction f) const;
 
   /**
+   * Checks if the given tile has any vehicle.
+   */
+  bool HasVehicle (const HexCoord& c) const;
+
+  /**
    * Checks whether the given tile is entirely free (which is needed to
    * place buildings).
    */
   bool IsFree (const HexCoord& c) const;
 
   /**
-   * Adds a new vehicle with the given faction and position.  Returns false
-   * if it failed (e.g. because there is already something there on the map).
+   * Adds a new vehicle with the given faction and position.
    */
-  bool AddVehicle (const HexCoord& c, Faction f);
+  void AddVehicle (const HexCoord& c, Faction f);
 
   /**
    * Removes a vehicle from the given position.

--- a/src/dynobstacles.hpp
+++ b/src/dynobstacles.hpp
@@ -86,10 +86,14 @@ public:
   void operator= (const DynObstacles&) = delete;
 
   /**
-   * Checks whether the given tile is passable to a vehicle of the given
-   * faction.  This must only be called for tiles on the map.
+   * Checks if the given tile is blocked by a building.
    */
-  bool IsPassable (const HexCoord& c, Faction f) const;
+  bool IsBuilding (const HexCoord& c) const;
+
+  /**
+   * Checks if the given tile has a vehicle of the given faction.
+   */
+  bool HasVehicle (const HexCoord& c, Faction f) const;
 
   /**
    * Checks whether the given tile is entirely free (which is needed to

--- a/src/dynobstacles.tpp
+++ b/src/dynobstacles.tpp
@@ -23,7 +23,7 @@
 namespace pxd
 {
 
-inline DynTiles<bool>&
+inline SparseTileMap<unsigned>&
 DynObstacles::FactionVehicles (const Faction f)
 {
   switch (f)
@@ -48,32 +48,35 @@ DynObstacles::IsBuilding (const HexCoord& c) const
 inline bool
 DynObstacles::HasVehicle (const HexCoord& c, const Faction f) const
 {
-  return FactionVehicles (f).Get (c);
+  return FactionVehicles (f).Get (c) > 0;
+}
+
+inline bool
+DynObstacles::HasVehicle (const HexCoord& c) const
+{
+  return red.Get (c) > 0 || green.Get (c) > 0 || blue.Get (c) > 0;
 }
 
 inline bool
 DynObstacles::IsFree (const HexCoord& c) const
 {
-  return !buildings.Get (c) && !red.Get (c) && !green.Get (c) && !blue.Get (c);
+  return !buildings.Get (c) && !HasVehicle (c);
 }
 
-inline bool
+inline void
 DynObstacles::AddVehicle (const HexCoord& c, const Faction f)
 {
-  auto ref = FactionVehicles (f).Access (c);
-  if (ref)
-    return false;
-
-  ref = true;
-  return true;
+  auto& fv = FactionVehicles (f);
+  fv.Set (c, fv.Get (c) + 1);
 }
 
 inline void
 DynObstacles::RemoveVehicle (const HexCoord& c, const Faction f)
 {
-  auto ref = FactionVehicles (f).Access (c);
-  CHECK (ref);
-  ref = false;
+  auto& fv = FactionVehicles (f);
+  const auto cnt = fv.Get (c);
+  CHECK_GT (cnt, 0);
+  fv.Set (c, cnt - 1);
 }
 
 } // namespace pxd

--- a/src/dynobstacles.tpp
+++ b/src/dynobstacles.tpp
@@ -40,9 +40,15 @@ DynObstacles::FactionVehicles (const Faction f)
 }
 
 inline bool
-DynObstacles::IsPassable (const HexCoord& c, const Faction f) const
+DynObstacles::IsBuilding (const HexCoord& c) const
 {
-  return !buildings.Get (c) && !FactionVehicles (f).Get (c);
+  return buildings.Get (c);
+}
+
+inline bool
+DynObstacles::HasVehicle (const HexCoord& c, const Faction f) const
+{
+  return FactionVehicles (f).Get (c);
 }
 
 inline bool

--- a/src/dynobstacles_tests.cpp
+++ b/src/dynobstacles_tests.cpp
@@ -57,17 +57,17 @@ TEST_F (DynObstaclesTests, VehiclesFromDb)
 
   DynObstacles dyn(db, ctx);
 
-  EXPECT_FALSE (dyn.IsPassable (c1, Faction::RED));
-  EXPECT_FALSE (dyn.IsPassable (c1, Faction::GREEN));
-  EXPECT_TRUE (dyn.IsPassable (c1, Faction::BLUE));
+  EXPECT_TRUE (dyn.HasVehicle (c1, Faction::RED));
+  EXPECT_TRUE (dyn.HasVehicle (c1, Faction::GREEN));
+  EXPECT_FALSE (dyn.HasVehicle (c1, Faction::BLUE));
 
-  EXPECT_TRUE (dyn.IsPassable (c2, Faction::RED));
-  EXPECT_TRUE (dyn.IsPassable (c2, Faction::GREEN));
-  EXPECT_FALSE (dyn.IsPassable (c2, Faction::BLUE));
+  EXPECT_FALSE (dyn.HasVehicle (c2, Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (c2, Faction::GREEN));
+  EXPECT_TRUE (dyn.HasVehicle (c2, Faction::BLUE));
 
-  EXPECT_TRUE (dyn.IsPassable (c3, Faction::RED));
-  EXPECT_TRUE (dyn.IsPassable (c3, Faction::GREEN));
-  EXPECT_TRUE (dyn.IsPassable (c3, Faction::BLUE));
+  EXPECT_FALSE (dyn.HasVehicle (c3, Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (c3, Faction::GREEN));
+  EXPECT_FALSE (dyn.HasVehicle (c3, Faction::BLUE));
 }
 
 TEST_F (DynObstaclesTests, BuildingsFromDb)
@@ -76,13 +76,8 @@ TEST_F (DynObstaclesTests, BuildingsFromDb)
 
   DynObstacles dyn(db, ctx);
 
-  EXPECT_FALSE (dyn.IsPassable (HexCoord (0, 2), Faction::RED));
-  EXPECT_FALSE (dyn.IsPassable (HexCoord (0, 2), Faction::GREEN));
-  EXPECT_FALSE (dyn.IsPassable (HexCoord (0, 2), Faction::BLUE));
-
-  EXPECT_TRUE (dyn.IsPassable (HexCoord (2, 0), Faction::RED));
-  EXPECT_TRUE (dyn.IsPassable (HexCoord (2, 0), Faction::GREEN));
-  EXPECT_TRUE (dyn.IsPassable (HexCoord (2, 0), Faction::BLUE));
+  EXPECT_TRUE (dyn.IsBuilding (HexCoord (0, 2)));
+  EXPECT_FALSE (dyn.IsBuilding (HexCoord (2, 0)));
 }
 
 TEST_F (DynObstaclesTests, Modifications)
@@ -90,20 +85,20 @@ TEST_F (DynObstaclesTests, Modifications)
   const HexCoord c(42, 0);
   DynObstacles dyn(db, ctx);
 
-  EXPECT_TRUE (dyn.IsPassable (c, Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::RED));
 
   dyn.AddVehicle (c, Faction::RED);
-  EXPECT_FALSE (dyn.IsPassable (c, Faction::RED));
-  EXPECT_TRUE (dyn.IsPassable (c, Faction::GREEN));
+  EXPECT_TRUE (dyn.HasVehicle (c, Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::GREEN));
 
   dyn.RemoveVehicle (c, Faction::RED);
-  EXPECT_TRUE (dyn.IsPassable (c, Faction::RED));
-  EXPECT_TRUE (dyn.IsPassable (c, Faction::BLUE));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::BLUE));
 
   auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
-  EXPECT_TRUE (dyn.IsPassable (HexCoord (1, 0), Faction::RED));
+  EXPECT_FALSE (dyn.IsBuilding (HexCoord (1, 0)));
   dyn.AddBuilding (*b);
-  EXPECT_FALSE (dyn.IsPassable (HexCoord (1, 0), Faction::RED));
+  EXPECT_TRUE (dyn.IsBuilding (HexCoord (1, 0)));
 }
 
 TEST_F (DynObstaclesTests, AddingBuildings)

--- a/src/dynobstacles_tests.cpp
+++ b/src/dynobstacles_tests.cpp
@@ -60,14 +60,17 @@ TEST_F (DynObstaclesTests, VehiclesFromDb)
   EXPECT_TRUE (dyn.HasVehicle (c1, Faction::RED));
   EXPECT_TRUE (dyn.HasVehicle (c1, Faction::GREEN));
   EXPECT_FALSE (dyn.HasVehicle (c1, Faction::BLUE));
+  EXPECT_TRUE (dyn.HasVehicle (c1));
 
   EXPECT_FALSE (dyn.HasVehicle (c2, Faction::RED));
   EXPECT_FALSE (dyn.HasVehicle (c2, Faction::GREEN));
   EXPECT_TRUE (dyn.HasVehicle (c2, Faction::BLUE));
+  EXPECT_TRUE (dyn.HasVehicle (c2));
 
   EXPECT_FALSE (dyn.HasVehicle (c3, Faction::RED));
   EXPECT_FALSE (dyn.HasVehicle (c3, Faction::GREEN));
   EXPECT_FALSE (dyn.HasVehicle (c3, Faction::BLUE));
+  EXPECT_FALSE (dyn.HasVehicle (c3));
 }
 
 TEST_F (DynObstaclesTests, BuildingsFromDb)
@@ -86,14 +89,17 @@ TEST_F (DynObstaclesTests, Modifications)
   DynObstacles dyn(db, ctx);
 
   EXPECT_FALSE (dyn.HasVehicle (c, Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (c));
 
   dyn.AddVehicle (c, Faction::RED);
   EXPECT_TRUE (dyn.HasVehicle (c, Faction::RED));
   EXPECT_FALSE (dyn.HasVehicle (c, Faction::GREEN));
+  EXPECT_TRUE (dyn.HasVehicle (c));
 
   dyn.RemoveVehicle (c, Faction::RED);
   EXPECT_FALSE (dyn.HasVehicle (c, Faction::RED));
   EXPECT_FALSE (dyn.HasVehicle (c, Faction::BLUE));
+  EXPECT_FALSE (dyn.HasVehicle (c));
 
   auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
   EXPECT_FALSE (dyn.IsBuilding (HexCoord (1, 0)));
@@ -127,6 +133,33 @@ TEST_F (DynObstaclesTests, AddingBuildings)
                                    b1->GetProto ().shape_trafo (),
                                    b1->GetCentre (), shape));
   }
+}
+
+TEST_F (DynObstaclesTests, MultipleVehicles)
+{
+  const HexCoord c(10, 0);
+  DynObstacles dyn(db, ctx);
+
+  dyn.AddVehicle (c, Faction::RED);
+  dyn.AddVehicle (c, Faction::RED);
+  dyn.AddVehicle (c, Faction::GREEN);
+  EXPECT_TRUE (dyn.HasVehicle (c, Faction::RED));
+  EXPECT_TRUE (dyn.HasVehicle (c, Faction::GREEN));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::BLUE));
+  EXPECT_TRUE (dyn.HasVehicle (c));
+
+  dyn.RemoveVehicle (c, Faction::RED);
+  dyn.RemoveVehicle (c, Faction::GREEN);
+  EXPECT_TRUE (dyn.HasVehicle (c, Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::GREEN));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::BLUE));
+  EXPECT_TRUE (dyn.HasVehicle (c));
+
+  dyn.RemoveVehicle (c, Faction::RED);
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::RED));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::GREEN));
+  EXPECT_FALSE (dyn.HasVehicle (c, Faction::BLUE));
+  EXPECT_FALSE (dyn.HasVehicle (c));
 }
 
 TEST_F (DynObstaclesTests, IsFree)

--- a/src/forks.cpp
+++ b/src/forks.cpp
@@ -1,0 +1,64 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "forks.hpp"
+
+#include <glog/logging.h>
+
+#include <unordered_map>
+
+namespace pxd
+{
+
+namespace
+{
+
+/** Activation heights by chain for a given fork.  */
+using ActivationHeights = std::unordered_map<xaya::Chain, unsigned>;
+
+/** The activation heights for our forks.  */
+const std::unordered_map<Fork, ActivationHeights> FORK_HEIGHTS =
+  {
+    {
+      Fork::Dummy,
+      {
+        {xaya::Chain::MAIN, 3'000'000},
+        {xaya::Chain::TEST, 150'000},
+        {xaya::Chain::REGTEST, 100},
+      },
+    },
+  };
+
+} // anonymous namespace
+
+bool
+ForkHandler::IsActive (const Fork f) const
+{
+  const auto mit = FORK_HEIGHTS.find (f);
+  CHECK (mit != FORK_HEIGHTS.end ())
+      << "Fork height not defined for " << static_cast<int> (f);
+
+  const auto mit2 = mit->second.find (chain);
+  CHECK (mit2 != mit->second.end ())
+      << "Fork " << static_cast<int> (f)
+      << " does not define height for chain " << static_cast<int> (chain);
+
+  return height >= mit2->second;
+}
+
+} // namespace pxd

--- a/src/forks.cpp
+++ b/src/forks.cpp
@@ -42,6 +42,14 @@ const std::unordered_map<Fork, ActivationHeights> FORK_HEIGHTS =
         {xaya::Chain::REGTEST, 100},
       },
     },
+    {
+      Fork::UnblockSpawns,
+      {
+        {xaya::Chain::MAIN, 2'159'000},
+        {xaya::Chain::TEST, 0},
+        {xaya::Chain::REGTEST, 500},
+      },
+    },
   };
 
 } // anonymous namespace

--- a/src/forks.hpp
+++ b/src/forks.hpp
@@ -36,6 +36,15 @@ enum class Fork
    */
   Dummy,
 
+  /**
+   * Fork on the 0.3 competition rules to fix issues with blocked spawn
+   * areas (from abused starter packs):  New characters will be spawned
+   * inside the starter-city building, rather than outside.  Also, vehicles
+   * of the same faction are no longer hard obstacles, but instead just
+   * slow down movement drastically (but can be passed with enough patience).
+   */
+  UnblockSpawns,
+
 };
 
 /**

--- a/src/forks.hpp
+++ b/src/forks.hpp
@@ -1,0 +1,75 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_FORKS_HPP
+#define PXD_FORKS_HPP
+
+#include <xayagame/gamelogic.hpp>
+
+namespace pxd
+{
+
+/**
+ * Hardforks that are done on the Taurion game world.
+ */
+enum class Fork
+{
+
+  /**
+   * Test fork that does nothing, but is used in unit tests and such
+   * for the fork system itself.
+   */
+  Dummy,
+
+};
+
+/**
+ * Helper class that exposes the state of forks on the network with
+ * respect to the current block height and/or block time.
+ */
+class ForkHandler
+{
+
+private:
+
+  /** The chain we are running on.  */
+  const xaya::Chain chain;
+
+  /** The block height this is for.  */
+  const unsigned height;
+
+public:
+
+  explicit ForkHandler (const xaya::Chain c, const unsigned h)
+    : chain(c), height(h)
+  {}
+
+  ForkHandler () = delete;
+  ForkHandler (const ForkHandler&) = delete;
+  void operator= (const ForkHandler&) = delete;
+
+  /**
+   * Returns true if the given fork should be considered active.
+   */
+  bool IsActive (Fork f) const;
+
+};
+
+} // namespace pxd
+
+#endif // PXD_FORKS_HPP

--- a/src/forks_tests.cpp
+++ b/src/forks_tests.cpp
@@ -1,0 +1,59 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "forks.hpp"
+
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+class ForksTests : public testing::Test
+{
+
+protected:
+
+  ContextForTesting ctx;
+
+  ForksTests ()
+  {}
+
+};
+
+TEST_F (ForksTests, IsActive)
+{
+  ctx.SetChain (xaya::Chain::REGTEST);
+  ctx.SetHeight (99);
+  EXPECT_FALSE (ctx.Forks ().IsActive (Fork::Dummy));
+  ctx.SetHeight (100);
+  EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
+  ctx.SetHeight (101);
+  EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
+
+  ctx.SetChain (xaya::Chain::MAIN);
+  EXPECT_FALSE (ctx.Forks ().IsActive (Fork::Dummy));
+  ctx.SetHeight (3'000'000);
+  EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -359,7 +359,7 @@ MoveInDynObstacles::~MoveInDynObstacles ()
       << "Adding back character " << character.GetId ()
       << " at position " << character.GetPosition ()
       << " to the dynamic obstacle map...";
-  CHECK (dyn.AddVehicle (character.GetPosition (), character.GetFaction ()));
+  dyn.AddVehicle (character.GetPosition (), character.GetFaction ());
 }
 
 namespace test

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -137,7 +137,10 @@ template <typename Fcn>
 
   const auto res = baseEdges (from, to);
 
-  if (res == PathFinder::NO_CONNECTION || !dyn.IsPassable (to, f))
+  if (res == PathFinder::NO_CONNECTION)
+    return PathFinder::NO_CONNECTION;
+
+  if (dyn.IsBuilding (to) || dyn.HasVehicle (to, f))
     return PathFinder::NO_CONNECTION;
 
   return res;

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -127,7 +127,7 @@ namespace
 template <typename Fcn>
   inline PathFinder::DistanceT
   FullMovementEdgeWeight (const Fcn& baseEdges, const DynObstacles& dyn,
-                          const Faction f,
+                          const Context& ctx, const Faction f,
                           const HexCoord& from, const HexCoord& to)
 {
   /* With dynamic obstacles, we do not handle the situation well if from and
@@ -135,13 +135,23 @@ template <typename Fcn>
      seen as obstacle (which it should not).  */
   CHECK_NE (from, to);
 
-  const auto res = baseEdges (from, to);
-
+  auto res = baseEdges (from, to);
   if (res == PathFinder::NO_CONNECTION)
     return PathFinder::NO_CONNECTION;
 
-  if (dyn.IsBuilding (to) || dyn.HasVehicle (to, f))
+  if (dyn.IsBuilding (to))
     return PathFinder::NO_CONNECTION;
+
+  if (ctx.Forks ().IsActive (Fork::UnblockSpawns))
+    {
+      if (dyn.HasVehicle (to))
+        res *= MULTI_VEHICLE_SLOWDOWN;
+    }
+  else
+    {
+      if (dyn.HasVehicle (to, f))
+        return PathFinder::NO_CONNECTION;
+    }
 
   return res;
 }
@@ -336,7 +346,7 @@ ProcessAllMovement (Database& db, DynObstacles& dyn, const Context& ctx)
                                                       const HexCoord& to)
         {
 
-          return FullMovementEdgeWeight (baseEdges, dyn, f, from, to);
+          return FullMovementEdgeWeight (baseEdges, dyn, ctx, f, from, to);
         };
 
       CharacterMovement (*c, ctx, edges);
@@ -367,10 +377,10 @@ namespace test
 
 PathFinder::DistanceT
 MovementEdgeWeight (const EdgeWeightFcn& baseEdges, const DynObstacles& dyn,
-                    const Faction f,
+                    const Context& ctx, const Faction f,
                     const HexCoord& from, const HexCoord& to)
 {
-  return FullMovementEdgeWeight (baseEdges, dyn, f, from, to);
+  return FullMovementEdgeWeight (baseEdges, dyn, ctx, f, from, to);
 }
 
 void

--- a/src/movement.hpp
+++ b/src/movement.hpp
@@ -37,6 +37,12 @@ namespace pxd
 {
 
 /**
+ * Slowdown factor when entering a tile that has already other vehicles
+ * on it (after the "unblock spawns" fork).
+ */
+static constexpr PathFinder::DistanceT MULTI_VEHICLE_SLOWDOWN = 8;
+
+/**
  * Encodes a list of hex coordinates (waypoints) into a compressed string
  * that is used for moves.  Returns true on success, and false if it failed.
  * This may be the case e.g. when the final size is too large for our
@@ -115,8 +121,8 @@ using EdgeWeightFcn
  * and additionally excluding movement to locations where a dynamic obstacle is.
  */
 PathFinder::DistanceT MovementEdgeWeight (
-    const EdgeWeightFcn& baseEdges, const DynObstacles& dyn, Faction f,
-    const HexCoord& from, const HexCoord& to);
+    const EdgeWeightFcn& baseEdges, const DynObstacles& dyn, const Context& ctx,
+    Faction f, const HexCoord& from, const HexCoord& to);
 
 /**
  * Processes movement (if any) for the given character handle and edge weights.

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -319,18 +319,20 @@ NonStateRpcServer::findpath (const Json::Value& exbuildings,
       if (base == PathFinder::NO_CONNECTION)
         return PathFinder::NO_CONNECTION;
 
-      if (dynCopy->obstacles.IsPassable (to, f))
-        return base;
+      /* If the path is blocked by a building, look closer to see if it is one
+         of the buildings we want to ignore or not.  */
+      if (dynCopy->obstacles.IsBuilding (to))
+        {
+          const auto mitTiles = dynCopy->buildingIds.find (to);
+          if (mitTiles == dynCopy->buildingIds.end ()
+                || exBuildingIds.count (mitTiles->second) == 0)
+            return PathFinder::NO_CONNECTION;
+        }
 
-      /* If the path is blocked by a dynamic obstacle (building), look
-         closer to see if it is one of the buildings we want to ignore
-         or not.  */
-      const auto mitTiles = dynCopy->buildingIds.find (to);
-      if (mitTiles != dynCopy->buildingIds.end ()
-            && exBuildingIds.count (mitTiles->second) > 0)
-        return base;
+      if (dynCopy->obstacles.HasVehicle (to, f))
+        return PathFinder::NO_CONNECTION;
 
-      return PathFinder::NO_CONNECTION;
+      return base;
     };
   const PathFinder::DistanceT dist = finder.Compute (edges, sourceCoord,
                                                      l1range);

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -210,8 +210,7 @@ NonStateRpcServer::AddCharactersFromJson (const Json::Value& characters,
           break;
         }
 
-      if (!dyn.obstacles.AddVehicle (pos, faction))
-        return false;
+      dyn.obstacles.AddVehicle (pos, faction);
     }
 
   return true;

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -151,7 +151,7 @@ public:
   bool setpathdata (const Json::Value& buildings,
                     const Json::Value& characters) override;
   Json::Value findpath (const Json::Value& exbuildings,
-                        const std::string& faction,
+                        const std::string& faction, int height,
                         int l1range, const Json::Value& source,
                         const Json::Value& target) override;
   std::string encodewaypoints (const Json::Value& wp) override;
@@ -221,10 +221,11 @@ public:
 
   Json::Value
   findpath (const Json::Value& exbuildings, const std::string& faction,
-            int l1range, const Json::Value& source,
+            const int height, const int l1range, const Json::Value& source,
             const Json::Value& target) override
   {
-    return nonstate.findpath (exbuildings, faction, l1range, source, target);
+    return nonstate.findpath (exbuildings, faction, height, l1range,
+                              source, target);
   }
 
   std::string

--- a/src/rpc-stubs/nonstate.json
+++ b/src/rpc-stubs/nonstate.json
@@ -16,6 +16,7 @@
         "target": {},
         "faction": "",
         "l1range": 100,
+        "height": 42,
         "exbuildings": [1, 2, 3]
       },
     "returns": {}

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -104,6 +104,7 @@
         "target": {},
         "faction": "",
         "l1range": 100,
+        "height": 42,
         "exbuildings": [1, 2, 3]
       },
     "returns": {}

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -158,7 +158,7 @@ SpawnCharacter (const std::string& owner, const Faction f,
                                  spawn.radius (),
                                  f, rnd, dyn, ctx.Map ());
       c->SetPosition (pos);
-      CHECK (dyn.AddVehicle (pos, f));
+      dyn.AddVehicle (pos, f);
     }
 
   return c;

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -115,15 +115,7 @@ SpawnCharacter (const std::string& owner, const Faction f,
       << "Spawning new character for " << owner
       << " in faction " << FactionToString (f) << "...";
 
-  const auto& spawn
-      = ctx.RoConfig ()->params ().spawn_areas ().at (FactionToString (f));
-  const HexCoord pos
-      = ChooseSpawnLocation (CoordFromProto (spawn.centre ()), spawn.radius (),
-                             f, rnd, dyn, ctx.Map ());
-
   auto c = tbl.CreateNew (owner, f);
-  c->SetPosition (pos);
-  CHECK (dyn.AddVehicle (pos, f));
 
   switch (f)
     {
@@ -145,6 +137,21 @@ SpawnCharacter (const std::string& owner, const Faction f,
   c->MutableProto ().add_fitments ("lf gun");
 
   DeriveCharacterStats (*c, ctx);
+
+  const auto& spawn
+      = ctx.RoConfig ()->params ().spawn_areas ().at (FactionToString (f));
+
+  if (ctx.Forks ().IsActive (Fork::UnblockSpawns))
+    c->SetBuildingId (spawn.building_id ());
+  else
+    {
+      const HexCoord pos
+          = ChooseSpawnLocation (CoordFromProto (spawn.centre ()),
+                                 spawn.radius (),
+                                 f, rnd, dyn, ctx.Map ());
+      c->SetPosition (pos);
+      CHECK (dyn.AddVehicle (pos, f));
+    }
 
   return c;
 }

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -94,8 +94,16 @@ ChooseSpawnLocation (const HexCoord& centre, const HexCoord::IntT radius,
             continue;
           foundOnMap = true;
 
-          if (map.IsPassable (pos) && dyn.IsPassable (pos, f))
-            return pos;
+          if (!map.IsPassable (pos))
+            continue;
+
+          if (dyn.IsBuilding (pos))
+            continue;
+
+          if (dyn.HasVehicle (pos, f))
+            continue;
+
+          return pos;
         }
 
       /* If no coordinate on the current ring was even on the map, then we

--- a/src/spawn.hpp
+++ b/src/spawn.hpp
@@ -41,7 +41,7 @@ namespace pxd
  */
 HexCoord ChooseSpawnLocation (const HexCoord& centre, HexCoord::IntT radius,
                               const Faction f, xaya::Random& rnd,
-                              const DynObstacles& dyn, const BaseMap& map);
+                              const DynObstacles& dyn, const Context& ctx);
 
 /**
  * Spawns a new character in the world.  This takes care of initialising the

--- a/src/spawn.hpp
+++ b/src/spawn.hpp
@@ -34,19 +34,18 @@ namespace pxd
 {
 
 /**
- * Chooses the actual spawn location for a new character of the given faction.
+ * Chooses a location for spawning a of the given faction.
  * This places them randomly within the given radius around the centre,
- * displacing them as needed to find an accessible spot.  This function is
- * also used for leaving buildings.
+ * displacing them as needed to find an accessible spot.
+ * This is used for leaving buildings.
  */
 HexCoord ChooseSpawnLocation (const HexCoord& centre, HexCoord::IntT radius,
                               const Faction f, xaya::Random& rnd,
                               const DynObstacles& dyn, const BaseMap& map);
 
 /**
- * Spawns a new character on the map.  This takes care of initialising the
- * character accordingly (including determining the exact spawn position)
- * and updating the database as needed.
+ * Spawns a new character in the world.  This takes care of initialising the
+ * character accordingly and updating the database as needed.
  *
  * This function returns a handle to the newly created character.
  */

--- a/src/spawn_tests.cpp
+++ b/src/spawn_tests.cpp
@@ -155,7 +155,7 @@ protected:
   SpawnLocation (const HexCoord& centre, const HexCoord::IntT radius,
                  const Faction f)
   {
-    return ChooseSpawnLocation (centre, radius, f, rnd, dyn, ctx.Map ());
+    return ChooseSpawnLocation (centre, radius, f, rnd, dyn, ctx);
   }
 
 };

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -88,8 +88,7 @@ ContextForTesting::SetChain (const xaya::Chain c)
   LOG (INFO) << "Setting context chain to " << xaya::ChainToString (c);
   chain = c;
   map = &dynamic_cast<const BaseMapInstances*> (maps)->Get (c);
-  params = std::make_unique<pxd::Params> (chain);
-  cfg = std::make_unique<pxd::RoConfig> (chain);
+  RefreshInstances ();
 }
 
 void
@@ -97,6 +96,7 @@ ContextForTesting::SetHeight (const unsigned h)
 {
   LOG (INFO) << "Setting context height to " << h;
   height = h;
+  RefreshInstances ();
 }
 
 void
@@ -104,6 +104,7 @@ ContextForTesting::SetTimestamp (const int64_t ts)
 {
   LOG (INFO) << "Setting context timestamp to " << ts;
   timestamp = ts;
+  RefreshInstances ();
 }
 
 Json::Value


### PR DESCRIPTION
This implements a planned hardfork for the 0.3 (3rd competition) test world, which serves two main purposes:  First, to actually test doing a fork in practice.  Second, to get rid of the issue of spawn areas currently blocked up with idle characters (mostly from people who abused the f2p as a CHI faucet and never intended to actually play Taurion).

Starting at a signal height, the rules will be changed as such:
- New characters will spawn inside the starter-city building rather than on the map.
- When leaving a building, a location that is entirely free will be chosen, including free of vehicles of other factions.
- Vehicles (independent of their faction) are no longer hard obstacles; instead, moving onto a tile that is already occupied is possible, but takes 8x longer.  Moving off such a tile into a free space is fast (which allows moving in a convoy nicely).

To facilitate the change in movement edge weights, the `findpath` RPC method now has a new (mandatory) `height` argument, which should be the block height for which the path should be calculated (e.g. current height + 1).