### PR TITLE
RPC to get GSP version

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -26,8 +26,9 @@ REGTESTS = \
   fame.py \
   findpath.py \
   getbuildingshape.py \
-  getserviceinfo.py \
   getregionat.py \
+  getserviceinfo.py \
+  getversion.py \
   godmode.py \
   loot.py \
   mining.py \

--- a/gametest/charon.py
+++ b/gametest/charon.py
@@ -156,6 +156,13 @@ class CharonTest (PXTest):
       self.mainLogger.info ("Testing RPC through Charon...")
       self.assertEqual (client.rpc.getaccounts (), self.rpc.game.getaccounts ())
 
+      self.mainLogger.info ("Testing getversion...")
+      res = client.rpc.getversion ()
+      self.assertEqual (res["server"], self.rpc.game.getversion ())
+      srv = res["server"]
+      del res["server"]
+      self.assertEqual (res, srv)
+
       self.mainLogger.info ("Testing invalid Charon method call...")
       self.expectError (-32602, ".*Invalid method parameters.*",
                         client.rpc.getregions, 42)

--- a/gametest/getversion.py
+++ b/gametest/getversion.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests the getversion RPC command.
+"""
+
+from pxtest import PXTest
+
+
+class GetVersionTest (PXTest):
+
+  def run (self):
+    res = self.rpc.game.getversion ()
+    assert "package" in res
+    assert "git" in res
+
+    self.mainLogger.info ("Package version: %s\nGit version: %s"
+        % (res["package"], res["git"]))
+
+
+if __name__ == "__main__":
+  GetVersionTest ().main ()

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,4 +1,5 @@
 tauriond
 benchmarks
 tests
+version.cpp
 *.trs

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 noinst_LTLIBRARIES = libtaurion.la
 bin_PROGRAMS = tauriond
+dist_noinst_SCRIPTS = update-version.sh
 
 EXTRA_DIST = \
   rpc-stubs/nonstate.json \
@@ -8,8 +9,10 @@ EXTRA_DIST = \
 RPC_STUBS = \
   rpc-stubs/nonstaterpcserverstub.h \
   rpc-stubs/pxrpcserverstub.h
-BUILT_SOURCES = $(RPC_STUBS)
+BUILT_SOURCES = $(RPC_STUBS) version.cpp
 CLEANFILES = $(RPC_STUBS)
+
+.PHONY: getversion
 
 libtaurion_la_CXXFLAGS = \
   -I$(top_srcdir) \
@@ -80,10 +83,12 @@ tauriond_LDADD = \
   $(GLOG_LIBS) $(GFLAGS_LIBS) $(PROTOBUF_LIBS)
 tauriond_SOURCES = main.cpp \
   charon.cpp \
-  pxrpcserver.cpp
+  pxrpcserver.cpp \
+  version.cpp
 tauriondheaders = \
   charon.hpp \
   pxrpcserver.hpp \
+  version.hpp \
   \
   rpc-stubs/nonstaterpcserverstub.h \
   rpc-stubs/pxrpcserverstub.h
@@ -169,3 +174,9 @@ rpc-stubs/nonstaterpcserverstub.h: $(srcdir)/rpc-stubs/nonstate.json
           --cpp-server=NonStateRpcServerStub --cpp-server-file="$@"
 rpc-stubs/pxrpcserverstub.h: $(srcdir)/rpc-stubs/pxd.json
 	jsonrpcstub "$<" --cpp-server=PXRpcServerStub --cpp-server-file="$@"
+
+version.cpp: getversion
+getversion:
+	$(srcdir)/update-version.sh \
+          $(builddir)/version.cpp \
+          $(srcdir)/version.cpp

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -114,6 +114,8 @@ const std::map<std::string, PXRpcMethod> CHARON_METHODS = {
 
   {"getserviceinfo", &PXRpcServer::getserviceinfoI},
 
+  {"getversion", &PXRpcServer::getversionI},
+
   /* FIXME: Instead of handling that through Charon, use an HTTP server to
      download the bootstrap data.
 
@@ -453,6 +455,16 @@ RealCharonClient::RpcServer::HandleMethodCall (jsonrpc::Procedure& proc,
     {
       VLOG (1) << "Forwarding method " << method << " through Charon";
       result = parent.client.ForwardMethod (method, params);
+
+      /* getversion is a special case, where we want to return both the
+         result of the server and the local one from nonstate.  */
+      if (method == "getversion")
+        {
+          const Json::Value serverResult = result;
+          nonstate.getversionI (params, result);
+          result["server"] = serverResult;
+        }
+
       return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "logic.hpp"
 #include "pending.hpp"
 #include "pxrpcserver.hpp"
+#include "version.hpp"
 
 #include <xayagame/defaultmain.hpp>
 #include <xayagame/game.hpp>
@@ -111,6 +112,10 @@ main (int argc, char** argv)
   gflags::SetUsageMessage ("Run Taurion game daemon");
   gflags::SetVersionString (PACKAGE_VERSION);
   gflags::ParseCommandLineFlags (&argc, &argv, true);
+
+  LOG (INFO)
+      << "Runing Taurion version " << PACKAGE_VERSION
+      << " (" << GIT_VERSION << ")";
 
 #ifdef ENABLE_SLOW_ASSERTS
   LOG (WARNING)

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -18,10 +18,13 @@
 
 #include "pxrpcserver.hpp"
 
+#include "config.h"
+
 #include "buildings.hpp"
 #include "jsonutils.hpp"
 #include "movement.hpp"
 #include "services.hpp"
+#include "version.hpp"
 
 #include "database/itemcounts.hpp"
 #include "proto/roconfig.hpp"
@@ -456,6 +459,18 @@ NonStateRpcServer::getbuildingshape (const Json::Value& centre, const int rot,
   Json::Value res(Json::arrayValue);
   for (const auto& t : GetBuildingShape (type, trafo, c, chain))
     res.append (CoordToJson (t));
+
+  return res;
+}
+
+Json::Value
+NonStateRpcServer::getversion ()
+{
+  LOG (INFO) << "RPC method called: getversion";
+
+  Json::Value res(Json::objectValue);
+  res["package"] = PACKAGE_VERSION;
+  res["git"] = GIT_VERSION;
 
   return res;
 }

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -158,6 +158,7 @@ public:
   Json::Value getregionat (const Json::Value& coord) override;
   Json::Value getbuildingshape (const Json::Value& centre, int rot,
                                 const std::string& type) override;
+  Json::Value getversion () override;
 
 };
 
@@ -244,6 +245,12 @@ public:
                     const std::string& type) override
   {
     return nonstate.getbuildingshape (centre, rot, type);
+  }
+
+  Json::Value
+  getversion () override
+  {
+    return nonstate.getversion ();
   }
 
 };

--- a/src/rpc-stubs/nonstate.json
+++ b/src/rpc-stubs/nonstate.json
@@ -45,5 +45,10 @@
         "rot": 42
       },
     "returns": []
+  },
+  {
+    "name": "getversion",
+    "params": {},
+    "returns": {}
   }
 ]

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -133,5 +133,10 @@
         "rot": 42
       },
     "returns": []
+  },
+  {
+    "name": "getversion",
+    "params": {},
+    "returns": {}
   }
 ]

--- a/src/update-version.sh
+++ b/src/update-version.sh
@@ -1,0 +1,52 @@
+#!/bin/sh -e
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# This is a simple script that tries to extract the current git commit
+# using "git describe" and write it to a generated source file (so it
+# can be accessed and logged from the GSP).
+#
+# If this cannot be done, e.g. because we have a non-git source tree from
+# a released distribution archive, then the file is left alone (and should
+# already be there with the release version in it).
+#
+# This command expects one or more arguments.  If the output matches any
+# of the listed files already, nothing is done.  Else the new version data
+# is written to the first argument.
+
+version=$(git describe --dirty --always 2>/dev/null || true)
+if [ -z "${version}" ]
+then
+  exit
+fi
+
+# First write to a temporary file.
+out=$(mktemp)
+printf "const char* GIT_VERSION = \"${version}\";\\n" >${out}
+
+# If the output matches any of the arguments already, nothing needs to be done.
+for f in $@
+do
+  if cmp -s ${out} $f
+  then
+    rm -f ${out}
+    exit
+  fi
+done
+
+# Write the output file.
+mv -f ${out} $1

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,0 +1,25 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_VERSION_HPP
+#define PXD_VERSION_HPP
+
+/** Auto-generated string from the current git commit.  */
+extern const char* GIT_VERSION;
+
+#endif // PXD_VERSION_HPP


### PR DESCRIPTION
This adds a script to auto-generate a version string from `git describe` and compile it into the binary, so that the exact commit is known to the GSP.  It is logged on startup, and also returned by the new `getversion` RPC method.  For Charon clients, the RPC method returns both the client and server version (i.e. it forwards the call to the server, but then extends the result also with the local version information).