### PR TITLE
Implement forking system and "game start" fork

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -25,6 +25,7 @@ REGTESTS = \
   damage_lists.py \
   fame.py \
   findpath.py \
+  fork_gamestart.py \
   getbuildingshape.py \
   getregionat.py \
   getserviceinfo.py \

--- a/gametest/fork_gamestart.py
+++ b/gametest/fork_gamestart.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests the "game start" fork:  Before, the burnsale and coin operations
+should already be working.  After, the game itself starts (e.g. choosing
+factions, creating characters).
+"""
+
+from pxtest import PXTest
+
+
+class ForkGameStartTest (PXTest):
+
+  def run (self):
+    self.recreateGameDaemon (extraArgs=["-fork_height_gamestart=100"])
+    self.collectPremine ()
+
+    self.sendMove ("domob", {
+      "vc": {"m": {}, "b": 10, "t": {"daniel": 100}}
+    }, burn=1)
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob")
+    self.generate (1)
+
+    assert self.rpc.xaya.getblockcount () < 100
+
+    accounts = self.getAccounts ()
+    self.assertEqual (accounts["domob"].getBalance (), 10_000 - 10 - 100)
+    self.assertEqual (accounts["daniel"].getBalance (), 100)
+    self.assertEqual (accounts["domob"].getFaction (), None)
+    self.assertEqual (self.getCharacters (), {})
+
+    self.advanceToHeight (99)
+    self.initAccount ("domob", "r")
+    self.createCharacters ("domob")
+    self.generate (1)
+
+    self.assertEqual (self.getAccounts ()["domob"].getFaction (), "r")
+    chars = self.getCharacters ()
+    self.assertEqual (len (chars), 1)
+    assert "domob" in chars
+
+
+if __name__ == "__main__":
+  ForkGameStartTest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -309,6 +309,19 @@ class PXTest (XayaGameTest):
       self.rpc.xaya.sendtoaddress (self.rpc.xaya.getnewaddress (), 100)
     self.generate (1)
 
+  def advanceToHeight (self, targetHeight):
+    """
+    Mines blocks until we are exactly at the given target height.
+    """
+
+    n = targetHeight - self.rpc.xaya.getblockcount ()
+
+    assert n >= 0
+    if n > 0:
+      self.generate (n)
+
+    self.assertEqual (self.rpc.xaya.getblockcount (), targetHeight)
+
   def getRpc (self, method, *args, **kwargs):
     """
     Calls the given "read-type" RPC method on the game daemon and returns

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,6 +30,7 @@ libtaurion_la_SOURCES = \
   dynobstacles.cpp \
   fame.cpp \
   fitments.cpp \
+  forks.cpp \
   gamestatejson.cpp \
   jsonutils.cpp \
   logic.cpp \
@@ -53,6 +54,7 @@ libtaurionheaders = \
   dynobstacles.hpp dynobstacles.tpp \
   fame.hpp \
   fitments.hpp \
+  forks.hpp \
   gamestatejson.hpp \
   jsonutils.hpp \
   logic.hpp \
@@ -133,6 +135,7 @@ tests_SOURCES = \
   dynobstacles_tests.cpp \
   fame_tests.cpp \
   fitments_tests.cpp \
+  forks_tests.cpp \
   gamestatejson_tests.cpp \
   jsonutils_tests.cpp \
   logic_tests.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,12 +16,14 @@ CLEANFILES = $(RPC_STUBS)
 
 libtaurion_la_CXXFLAGS = \
   -I$(top_srcdir) \
-  $(XAYAGAME_CFLAGS) $(JSON_CFLAGS) $(GLOG_CFLAGS) $(PROTOBUF_CFLAGS)
+  $(XAYAGAME_CFLAGS) $(JSON_CFLAGS) \
+  $(GLOG_CFLAGS) $(GFLAGS_CFLAGS) $(PROTOBUF_CFLAGS)
 libtaurion_la_LIBADD = \
   $(top_builddir)/database/libdatabase.la \
   $(top_builddir)/hexagonal/libhexagonal.la \
   $(top_builddir)/proto/libpxproto.la \
-  $(XAYAGAME_LIBS) $(JSON_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
+  $(XAYAGAME_LIBS) $(JSON_LIBS) \
+  $(GLOG_LIBS) $(GFLAGS_LIBS) $(PROTOBUF_LIBS)
 libtaurion_la_SOURCES = \
   buildings.cpp \
   burnsale.cpp \
@@ -117,7 +119,8 @@ libtestutils_la_SOURCES = \
 tests_CXXFLAGS = \
   -I$(top_srcdir) \
   $(GTEST_MAIN_CFLAGS) \
-  $(JSON_CFLAGS) $(GTEST_CFLAGS) $(GLOG_CFLAGS) $(PROTOBUF_CFLAGS)
+  $(JSON_CFLAGS) $(GTEST_CFLAGS) \
+  $(GLOG_CFLAGS) $(GFLAGS_CFLAGS) $(PROTOBUF_CFLAGS)
 tests_LDADD = \
   $(builddir)/libtaurion.la \
   $(builddir)/libtestutils.la \
@@ -127,7 +130,8 @@ tests_LDADD = \
   $(top_builddir)/mapdata/libmapdata.la \
   $(top_builddir)/proto/libpxproto.la \
   $(GTEST_MAIN_LIBS) \
-  $(JSON_LIBS) $(GTEST_LIBS) $(GLOG_LIBS) $(PROTOBUF_LIBS)
+  $(JSON_LIBS) $(GTEST_LIBS) \
+  $(GLOG_LIBS) $(GFLAGS_LIBS) $(PROTOBUF_LIBS)
 tests_SOURCES = \
   buildings_tests.cpp \
   burnsale_tests.cpp \

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -31,10 +31,18 @@ Context::Context (const xaya::Chain c)
 Context::Context (const xaya::Chain c, const BaseMap& m,
                   const unsigned h, const int64_t ts)
   : map(&m), chain(c),
-    params(new pxd::Params (chain)),
-    cfg(new pxd::RoConfig (chain)),
     height(h), timestamp(ts)
-{}
+{
+  RefreshInstances ();
+}
+
+void
+Context::RefreshInstances ()
+{
+  params = std::make_unique<pxd::Params> (chain);
+  cfg = std::make_unique<pxd::RoConfig> (chain);
+  forks = std::make_unique<ForkHandler> (chain, height);
+}
 
 unsigned
 Context::Height () const

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -19,6 +19,7 @@
 #ifndef PXD_CONTEXT_HPP
 #define PXD_CONTEXT_HPP
 
+#include "forks.hpp"
 #include "params.hpp"
 
 #include "mapdata/basemap.hpp"
@@ -56,6 +57,9 @@ private:
   /** RoConfig instance dependant on the chain.  */
   std::unique_ptr<pxd::RoConfig> cfg;
 
+  /** Fork handler based on chain and height.  */
+  std::unique_ptr<ForkHandler> forks;
+
   /**
    * The current block's height.  This is set to the confirmed height plus
    * one for processing pending moves, as that corresponds to the expected
@@ -74,6 +78,14 @@ private:
    * used with ContextForTesting.
    */
   explicit Context (xaya::Chain c);
+
+  /**
+   * Sets up all instances that are based on the basic state, like the
+   * Params or RoConfig one.  This is usually just done as part of the
+   * constructor, but in tests, we use it to refresh them when we explicitly
+   * change values.
+   */
+  void RefreshInstances ();
 
   friend class ContextForTesting;
 
@@ -112,6 +124,12 @@ public:
   RoConfig () const
   {
     return *cfg;
+  }
+
+  const ForkHandler&
+  Forks () const
+  {
+    return *forks;
   }
 
   /**

--- a/src/forks.cpp
+++ b/src/forks.cpp
@@ -1,0 +1,64 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "forks.hpp"
+
+#include <glog/logging.h>
+
+#include <unordered_map>
+
+namespace pxd
+{
+
+namespace
+{
+
+/** Activation heights by chain for a given fork.  */
+using ActivationHeights = std::unordered_map<xaya::Chain, unsigned>;
+
+/** The activation heights for our forks.  */
+const std::unordered_map<Fork, ActivationHeights> FORK_HEIGHTS =
+  {
+    {
+      Fork::Dummy,
+      {
+        {xaya::Chain::MAIN, 3'000'000},
+        {xaya::Chain::TEST, 150'000},
+        {xaya::Chain::REGTEST, 100},
+      },
+    },
+  };
+
+} // anonymous namespace
+
+bool
+ForkHandler::IsActive (const Fork f) const
+{
+  const auto mit = FORK_HEIGHTS.find (f);
+  CHECK (mit != FORK_HEIGHTS.end ())
+      << "Fork height not defined for " << static_cast<int> (f);
+
+  const auto mit2 = mit->second.find (chain);
+  CHECK (mit2 != mit->second.end ())
+      << "Fork " << static_cast<int> (f)
+      << " does not define height for chain " << static_cast<int> (chain);
+
+  return height >= mit2->second;
+}
+
+} // namespace pxd

--- a/src/forks.cpp
+++ b/src/forks.cpp
@@ -26,6 +26,11 @@
 namespace pxd
 {
 
+/* The flags are not in an anonymous namespace, as we will need to DECLARE
+   and access (modify) them for unit tests.  */
+DEFINE_int32 (fork_height_gamestart, -1,
+              "if set, override the fork height for \"game start\"");
+
 namespace
 {
 
@@ -58,6 +63,17 @@ const std::unordered_map<Fork, ForkData> FORK_HEIGHTS =
           {xaya::Chain::REGTEST, 100},
         },
         nullptr,
+      }
+    },
+    {
+      Fork::GameStart,
+      {
+        {
+          {xaya::Chain::MAIN, 2'250'000},
+          {xaya::Chain::TEST, 112'000},
+          {xaya::Chain::REGTEST, 0},
+        },
+        &FLAGS_fork_height_gamestart,
       }
     },
   };

--- a/src/forks.hpp
+++ b/src/forks.hpp
@@ -36,6 +36,13 @@ enum class Fork
    */
   Dummy,
 
+  /**
+   * Fork at which we enable the actual gameplay.  Before this takes place,
+   * only Cubit operations are enabled (which are live with the burnsale
+   * since the third competition and won't be reset).
+   */
+  GameStart,
+
 };
 
 /**

--- a/src/forks.hpp
+++ b/src/forks.hpp
@@ -1,0 +1,75 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_FORKS_HPP
+#define PXD_FORKS_HPP
+
+#include <xayagame/gamelogic.hpp>
+
+namespace pxd
+{
+
+/**
+ * Hardforks that are done on the Taurion game world.
+ */
+enum class Fork
+{
+
+  /**
+   * Test fork that does nothing, but is used in unit tests and such
+   * for the fork system itself.
+   */
+  Dummy,
+
+};
+
+/**
+ * Helper class that exposes the state of forks on the network with
+ * respect to the current block height and/or block time.
+ */
+class ForkHandler
+{
+
+private:
+
+  /** The chain we are running on.  */
+  const xaya::Chain chain;
+
+  /** The block height this is for.  */
+  const unsigned height;
+
+public:
+
+  explicit ForkHandler (const xaya::Chain c, const unsigned h)
+    : chain(c), height(h)
+  {}
+
+  ForkHandler () = delete;
+  ForkHandler (const ForkHandler&) = delete;
+  void operator= (const ForkHandler&) = delete;
+
+  /**
+   * Returns true if the given fork should be considered active.
+   */
+  bool IsActive (Fork f) const;
+
+};
+
+} // namespace pxd
+
+#endif // PXD_FORKS_HPP

--- a/src/forks_tests.cpp
+++ b/src/forks_tests.cpp
@@ -1,0 +1,59 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "forks.hpp"
+
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+class ForksTests : public testing::Test
+{
+
+protected:
+
+  ContextForTesting ctx;
+
+  ForksTests ()
+  {}
+
+};
+
+TEST_F (ForksTests, IsActive)
+{
+  ctx.SetChain (xaya::Chain::REGTEST);
+  ctx.SetHeight (99);
+  EXPECT_FALSE (ctx.Forks ().IsActive (Fork::Dummy));
+  ctx.SetHeight (100);
+  EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
+  ctx.SetHeight (101);
+  EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
+
+  ctx.SetChain (xaya::Chain::MAIN);
+  EXPECT_FALSE (ctx.Forks ().IsActive (Fork::Dummy));
+  ctx.SetHeight (3'000'000);
+  EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -21,6 +21,7 @@
 #include "buildings.hpp"
 #include "burnsale.hpp"
 #include "fitments.hpp"
+#include "forks.hpp"
 #include "jsonutils.hpp"
 #include "mining.hpp"
 #include "movement.hpp"
@@ -1158,6 +1159,12 @@ MoveProcessor::ProcessOne (const Json::Value& moveObj)
      are done with priority over the other operations that may require coins
      implicitly.  */
   TryCoinOperation (name, mv, burnt);
+
+  /* At this point, we terminate if the game-play itself has not started.
+     This is more or less when the "game world is created", except that we
+     do allow Cubit operations already from the start of the burnsale.  */
+  if (!ctx.Forks ().IsActive (Fork::GameStart))
+    return;
 
   /* We perform account updates first.  That ensures that it is possible to
      e.g. choose one's faction and create characters in a single move.  */

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -88,8 +88,7 @@ ContextForTesting::SetChain (const xaya::Chain c)
   LOG (INFO) << "Setting context chain to " << xaya::ChainToString (c);
   chain = c;
   map = &dynamic_cast<const BaseMapInstances*> (maps)->Get (c);
-  params = std::make_unique<pxd::Params> (chain);
-  cfg = std::make_unique<pxd::RoConfig> (chain);
+  RefreshInstances ();
 }
 
 void
@@ -97,6 +96,7 @@ ContextForTesting::SetHeight (const unsigned h)
 {
   LOG (INFO) << "Setting context height to " << h;
   height = h;
+  RefreshInstances ();
 }
 
 void
@@ -104,6 +104,7 @@ ContextForTesting::SetTimestamp (const int64_t ts)
 {
   LOG (INFO) << "Setting context timestamp to " << ts;
   timestamp = ts;
+  RefreshInstances ();
 }
 
 Json::Value


### PR DESCRIPTION
This ports over the general forking system from #170.  In addition to the commit from there, we also add command-line flags that can be used to override fork heights, which is e.g. useful for testing.

With the forking system, we also define a first fork, the "game start".  Since the burnsale and basic Cubit operations are already live and will not be reset anymore, the game's start height itself is also frozen.  Thus the game-start fork will be used to activate the actual game world itself.  In other words, before the fork Cubit operations and the burnsale are already active, but nothing else.  After the fork activates, all game-related operations (e.g. choosing an account's faction, creating characters) become active.