### PR TITLE
Remember building age

### DIFF
--- a/gametest/buildings_construction.py
+++ b/gametest/buildings_construction.py
@@ -48,6 +48,7 @@ class BuildingConstructionTest (PXTest):
     })
     self.generate (1)
 
+    foundedHeight = self.rpc.xaya.getblockcount ()
     buildings = self.getBuildings ()
     bId = list (buildings.keys ())[-1]
     self.assertEqual (buildings[bId].isFoundation (), True)
@@ -55,6 +56,7 @@ class BuildingConstructionTest (PXTest):
       "foo": 98,
     })
     self.assertEqual (buildings[bId].getOngoingConstruction (), None)
+    self.assertEqual (buildings[bId].data["age"], {"founded": foundedHeight})
 
     self.mainLogger.info ("Starting the construction...")
     self.getCharacters ()["domob"].sendMove ({
@@ -74,6 +76,7 @@ class BuildingConstructionTest (PXTest):
 
     self.mainLogger.info ("Finishing construction...")
     self.generate (1)
+    finishedHeight = self.rpc.xaya.getblockcount ()
     b = self.getBuildings ()[bId]
     self.assertEqual (b.isFoundation (), False)
     self.assertEqual (b.getFungibleInventory ("domob"), {
@@ -81,6 +84,10 @@ class BuildingConstructionTest (PXTest):
       "zerospace": 90,
     })
     self.assertEqual (b.getOngoingConstruction (), None)
+    self.assertEqual (b.data["age"], {
+      "founded": foundedHeight,
+      "finished": finishedHeight,
+    })
 
 
 if __name__ == "__main__":

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -35,6 +35,9 @@ class GodModeTest (PXTest):
     charIdStr = c.getIdStr ()
 
     self.mainLogger.info ("Testing build...")
+    # Base height for building age.  Each build function call mines
+    # a block on top of it.
+    height = self.rpc.xaya.getblockcount ()
     self.build ("checkmark", None, {"x": 100, "y": 150}, rot=2)
     self.build ("checkmark", "domob", {"x": -100, "y": -150}, rot=0)
     buildings = self.getBuildings ()
@@ -46,6 +49,7 @@ class GodModeTest (PXTest):
       "centre": {"x": 100, "y": 150},
       "rotationsteps": 2,
       "servicefee": 0,
+      "age": {"founded": height + 1, "finished": height + 1},
       "tiles":
         [
           {"x": 100, "y": 150},
@@ -72,6 +76,7 @@ class GodModeTest (PXTest):
       "centre": {"x": -100, "y": -150},
       "rotationsteps": 0,
       "servicefee": 0,
+      "age": {"founded": height + 2, "finished": height + 2},
       "tiles":
         [
           {"x": -100, "y": -150},

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -79,4 +79,22 @@ message Building
    */
   optional uint32 service_fee_percent = 6;
 
+  /**
+   * Data about the building age, i.e. the block heights when it was founded
+   * and finished.
+   */
+  message AgeData
+  {
+
+    /** Block height when it was founded.  */
+    optional uint32 founded_height = 1;
+
+    /** Block height when it was finished.  */
+    optional uint32 finished_height = 2;
+
+  }
+
+  /** Age data for this building.  */
+  optional AgeData age_data = 7;
+
 }

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -105,10 +105,13 @@ InitialiseBuildings (Database& db, const xaya::Chain chain)
   const RoConfig cfg(chain);
   for (const auto& ib : cfg->initial_buildings ())
     {
-      auto h = tbl.CreateNew (ib.type (), "", Faction::ANCIENT);
-      h->SetCentre (CoordFromProto (ib.centre ()));
-      *h->MutableProto ().mutable_shape_trafo () = ib.shape_trafo ();
-      UpdateBuildingStats (*h, chain);
+      auto b = tbl.CreateNew (ib.type (), "", Faction::ANCIENT);
+      b->SetCentre (CoordFromProto (ib.centre ()));
+      auto& pb = b->MutableProto ();
+      *pb.mutable_shape_trafo () = ib.shape_trafo ();
+      pb.mutable_age_data ()->set_founded_height (0);
+      pb.mutable_age_data ()->set_finished_height (0);
+      UpdateBuildingStats (*b, chain);
     }
 }
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -367,6 +367,12 @@ template <>
       res["inventories"] = inv;
     }
 
+  Json::Value age(Json::objectValue);
+  age["founded"] = IntToJson (pb.age_data ().founded_height ());
+  if (!pb.foundation ())
+    age["finished"] = IntToJson (pb.age_data ().finished_height ());
+  res["age"] = age;
+
   return res;
 }
 

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -747,6 +747,48 @@ TEST_F (BuildingJsonTests, ServiceFees)
   })");
 }
 
+TEST_F (BuildingJsonTests, AgeData)
+{
+  auto b = tbl.CreateNew ("checkmark", "daniel", Faction::RED);
+  ASSERT_EQ (b->GetId (), 1);
+  b->MutableProto ().set_foundation (true);
+  b->MutableProto ().mutable_age_data ()->set_founded_height (10);
+  b.reset ();
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "age":
+            {
+              "founded": 10,
+              "finished": null
+            }
+        }
+      ]
+  })");
+
+  b = tbl.GetById (1);
+  b->MutableProto ().set_foundation (false);
+  b->MutableProto ().mutable_age_data ()->set_finished_height (12);
+  b.reset ();
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "age":
+            {
+              "founded": 10,
+              "finished": 12
+            }
+        }
+      ]
+  })");
+}
+
 TEST_F (BuildingJsonTests, CombatData)
 {
   ASSERT_EQ (tbl.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId (), 1);

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1447,6 +1447,7 @@ MoveProcessor::MaybeFoundBuilding (Character& c, const Json::Value& upd)
   auto& pb = b->MutableProto ();
   pb.set_foundation (true);
   *pb.mutable_shape_trafo () = trafo;
+  pb.mutable_age_data ()->set_founded_height (ctx.Height ());
 
   auto& inv = c.GetInventory ();
   const auto& roBuilding = ctx.RoConfig ().Building (b->GetType ());
@@ -1910,14 +1911,17 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl, const Context& ctx,
          placed as needed in tests, without having to worry about regions
          and the ability to build in them.  */
 
-      auto h = tbl.CreateNew (type, owner, f);
-      h->SetCentre (centre);
-      *h->MutableProto ().mutable_shape_trafo () = trafo;
-      UpdateBuildingStats (*h, ctx.Chain ());
+      auto b = tbl.CreateNew (type, owner, f);
+      b->SetCentre (centre);
+      auto& pb = b->MutableProto ();
+      *pb.mutable_shape_trafo () = trafo;
+      pb.mutable_age_data ()->set_founded_height (ctx.Height ());
+      pb.mutable_age_data ()->set_finished_height (ctx.Height ());
+      UpdateBuildingStats (*b, ctx.Chain ());
       LOG (INFO)
           << "God building " << type
           << " for " << owner << " of faction " << FactionToString (f) << ":\n"
-          << "  id: " << h->GetId () << "\n"
+          << "  id: " << b->GetId () << "\n"
           << "  centre: " << centre << "\n"
           << "  rotation: " << trafo.rotation_steps ();
     }

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1702,8 +1702,10 @@ TEST_F (FoundBuildingMoveTests, CannotPlaceBuilding)
 
 TEST_F (FoundBuildingMoveTests, Success)
 {
+  ctx.SetHeight (10);
   const HexCoord pos = GetTest ()->GetPosition ();
   GetTest ()->GetInventory ().AddFungibleCount ("foo", 10);
+
   Process (R"([
     {
       "name": "domob",
@@ -1722,6 +1724,7 @@ TEST_F (FoundBuildingMoveTests, Success)
   const auto& pb = b->GetProto ();
   EXPECT_TRUE (pb.foundation ());
   EXPECT_EQ (pb.shape_trafo ().rotation_steps (), 3);
+  EXPECT_EQ (pb.age_data ().founded_height (), 10);
 
   auto c = GetTest ();
   EXPECT_EQ (c->GetInventory ().GetFungibleCount ("foo"), 8);
@@ -3388,6 +3391,7 @@ TEST_F (GodModeTests, SetHp)
 
 TEST_F (GodModeTests, Build)
 {
+  ctx.SetHeight (10);
   accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   /* This is entirely invalid (not even an array).  */
@@ -3431,6 +3435,8 @@ TEST_F (GodModeTests, Build)
   EXPECT_EQ (h->GetOwner (), "domob");
   EXPECT_EQ (h->GetCentre (), HexCoord (-100, -200));
   EXPECT_EQ (h->GetProto ().shape_trafo ().rotation_steps (), 0);
+  EXPECT_EQ (h->GetProto ().age_data ().founded_height (), 10);
+  EXPECT_EQ (h->GetProto ().age_data ().finished_height (), 10);
 
   ASSERT_TRUE (res.Step ());
   h = buildings.GetFromResult (res);

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -66,6 +66,7 @@ FinishBuildingConstruction (Building& b, const Context& ctx,
   pb.clear_construction_inventory ();
   pb.set_foundation (false);
   pb.clear_ongoing_construction ();
+  pb.mutable_age_data ()->set_finished_height (ctx.Height ());
 
   UpdateBuildingStats (b, ctx.Chain ());
 }

--- a/src/ongoings_tests.cpp
+++ b/src/ongoings_tests.cpp
@@ -309,6 +309,7 @@ TEST_F (OngoingsTests, BuildingConstruction)
   EXPECT_FALSE (b->GetProto ().foundation ());
   EXPECT_FALSE (b->GetProto ().has_ongoing_construction ());
   EXPECT_FALSE (b->GetProto ().has_construction_inventory ());
+  EXPECT_EQ (b->GetProto ().age_data ().finished_height (), 10);
   EXPECT_EQ (b->GetHP ().armour (), 100);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("foo"), 2);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bar"), 42);


### PR DESCRIPTION
With this change, the GSP remembers the age of buildings, i.e. the block heights when they were founded and when construction was finished.  This data is also returned in a new `age` field of the building game-state JSON.

We need this to properly credit prizes of the third competition, but it is useful in general and could e.g. be utilised for building experience in the full game, or just shown for information purposes in the frontend.