### PR TITLE
Building age and slow-assert fixes

### DIFF
--- a/database/character.cpp
+++ b/database/character.cpp
@@ -166,11 +166,6 @@ Character::Validate () const
   if (IsBusy ())
     CHECK (!pb.has_movement ()) << "Busy character should not be moving";
 
-  if (!regenData.IsDirty () && !hp.IsDirty ())
-    CHECK_EQ (oldCanRegen, ComputeCanRegen ());
-
-  CHECK_LE (UsedCargoSpace (), pb.cargo_space ());
-
   CHECK (!pb.mining ().active () || !pb.has_movement ())
       << "Character " << id << " is moving and mining at the same time";
 

--- a/database/combat.cpp
+++ b/database/combat.cpp
@@ -83,9 +83,13 @@ CombatEntity::Validate () const
 
   if (!isNew && !IsDirtyCombatData ())
     {
-      CHECK_EQ (oldAttackRange, FindAttackRange (pb.combat_data (), false));
-      CHECK_EQ (oldFriendlyRange, FindAttackRange (pb.combat_data (), true));
+      const auto& cd = GetCombatData ();
+      CHECK_EQ (oldAttackRange, FindAttackRange (cd, false));
+      CHECK_EQ (oldFriendlyRange, FindAttackRange (cd, true));
     }
+
+  if (!regenData.IsDirty () && !hp.IsDirty ())
+    CHECK_EQ (oldCanRegen, ComputeCanRegen (hp.Get (), regenData.Get ()));
 
 #endif // ENABLE_SLOW_ASSERTS
 }

--- a/gametest/buildings_construction.py
+++ b/gametest/buildings_construction.py
@@ -48,6 +48,7 @@ class BuildingConstructionTest (PXTest):
     })
     self.generate (1)
 
+    foundedHeight = self.rpc.xaya.getblockcount ()
     buildings = self.getBuildings ()
     bId = list (buildings.keys ())[-1]
     self.assertEqual (buildings[bId].isFoundation (), True)
@@ -55,6 +56,7 @@ class BuildingConstructionTest (PXTest):
       "foo": 98,
     })
     self.assertEqual (buildings[bId].getOngoingConstruction (), None)
+    self.assertEqual (buildings[bId].data["age"], {"founded": foundedHeight})
 
     self.mainLogger.info ("Starting the construction...")
     self.getCharacters ()["domob"].sendMove ({
@@ -74,6 +76,7 @@ class BuildingConstructionTest (PXTest):
 
     self.mainLogger.info ("Finishing construction...")
     self.generate (1)
+    finishedHeight = self.rpc.xaya.getblockcount ()
     b = self.getBuildings ()[bId]
     self.assertEqual (b.isFoundation (), False)
     self.assertEqual (b.getFungibleInventory ("domob"), {
@@ -81,6 +84,10 @@ class BuildingConstructionTest (PXTest):
       "zerospace": 90,
     })
     self.assertEqual (b.getOngoingConstruction (), None)
+    self.assertEqual (b.data["age"], {
+      "founded": foundedHeight,
+      "finished": finishedHeight,
+    })
 
 
 if __name__ == "__main__":

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -35,6 +35,9 @@ class GodModeTest (PXTest):
     charId = c.getId ()
 
     self.mainLogger.info ("Testing build...")
+    # Base height for building age.  Each build function call mines
+    # a block on top of it.
+    height = self.rpc.xaya.getblockcount ()
     self.build ("checkmark", None, {"x": 100, "y": 150}, rot=2)
     self.build ("checkmark", "domob", {"x": -100, "y": -150}, rot=0)
     buildings = self.getBuildings ()
@@ -46,6 +49,7 @@ class GodModeTest (PXTest):
       "centre": {"x": 100, "y": 150},
       "rotationsteps": 2,
       "servicefee": 0,
+      "age": {"founded": height + 1, "finished": height + 1},
       "tiles":
         [
           {"x": 100, "y": 150},
@@ -72,6 +76,7 @@ class GodModeTest (PXTest):
       "centre": {"x": -100, "y": -150},
       "rotationsteps": 0,
       "servicefee": 0,
+      "age": {"founded": height + 2, "finished": height + 2},
       "tiles":
         [
           {"x": -100, "y": -150},

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -79,4 +79,22 @@ message Building
    */
   optional uint32 service_fee_percent = 6;
 
+  /**
+   * Data about the building age, i.e. the block heights when it was founded
+   * and finished.
+   */
+  message AgeData
+  {
+
+    /** Block height when it was founded.  */
+    optional uint32 founded_height = 1;
+
+    /** Block height when it was finished.  */
+    optional uint32 finished_height = 2;
+
+  }
+
+  /** Age data for this building.  */
+  optional AgeData age_data = 7;
+
 }

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -105,10 +105,13 @@ InitialiseBuildings (Database& db, const xaya::Chain chain)
   const RoConfig cfg(chain);
   for (const auto& ib : cfg->initial_buildings ())
     {
-      auto h = tbl.CreateNew (ib.type (), "", Faction::ANCIENT);
-      h->SetCentre (CoordFromProto (ib.centre ()));
-      *h->MutableProto ().mutable_shape_trafo () = ib.shape_trafo ();
-      UpdateBuildingStats (*h, chain);
+      auto b = tbl.CreateNew (ib.type (), "", Faction::ANCIENT);
+      b->SetCentre (CoordFromProto (ib.centre ()));
+      auto& pb = b->MutableProto ();
+      *pb.mutable_shape_trafo () = ib.shape_trafo ();
+      pb.mutable_age_data ()->set_founded_height (0);
+      pb.mutable_age_data ()->set_finished_height (0);
+      UpdateBuildingStats (*b, chain);
     }
 }
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -368,6 +368,12 @@ template <>
       res["inventories"] = inv;
     }
 
+  Json::Value age(Json::objectValue);
+  age["founded"] = IntToJson (pb.age_data ().founded_height ());
+  if (!pb.foundation ())
+    age["finished"] = IntToJson (pb.age_data ().finished_height ());
+  res["age"] = age;
+
   return res;
 }
 

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -748,6 +748,48 @@ TEST_F (BuildingJsonTests, ServiceFees)
   })");
 }
 
+TEST_F (BuildingJsonTests, AgeData)
+{
+  auto b = tbl.CreateNew ("checkmark", "daniel", Faction::RED);
+  ASSERT_EQ (b->GetId (), 1);
+  b->MutableProto ().set_foundation (true);
+  b->MutableProto ().mutable_age_data ()->set_founded_height (10);
+  b.reset ();
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "age":
+            {
+              "founded": 10,
+              "finished": null
+            }
+        }
+      ]
+  })");
+
+  b = tbl.GetById (1);
+  b->MutableProto ().set_foundation (false);
+  b->MutableProto ().mutable_age_data ()->set_finished_height (12);
+  b.reset ();
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "age":
+            {
+              "founded": 10,
+              "finished": 12
+            }
+        }
+      ]
+  })");
+}
+
 TEST_F (BuildingJsonTests, CombatData)
 {
   ASSERT_EQ (tbl.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId (), 1);

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -401,9 +401,10 @@ ValidateOngoingsLinks (Database& db)
             CHECK (b != nullptr)
                 << "Operation " << op->GetId ()
                 << " refers to non-existing building " << bId;
-            CHECK_EQ (b->GetProto ().ongoing_construction (), op->GetId ())
-                << "Building " << bId
-                << " does not refer back to ongoing " << op->GetId ();
+            if (op->GetProto ().has_building_construction ())
+              CHECK_EQ (b->GetProto ().ongoing_construction (), op->GetId ())
+                  << "Building " << bId
+                  << " does not refer back to ongoing " << op->GetId ();
           }
 
         if (cId != Database::EMPTY_ID)
@@ -454,6 +455,10 @@ ValidateOngoingsLinks (Database& db)
         CHECK_EQ (op->GetBuildingId (), b->GetId ())
             << "Operation " << opId
             << " does not refer back to building " << b->GetId ();
+        CHECK (op->GetProto ().has_building_construction ())
+            << "Building " << b->GetId ()
+            << " refers to ongoing " << opId
+            << " that is not a building construction";
       }
   }
 }

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -1300,6 +1300,12 @@ TEST_F (ValidateStateTests, OngoingsToBuildingLink)
   EXPECT_DEATH (ValidateState (), "refers to non-existing building");
 
   buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  /* If the ongoing operation is not a building construction, it is fine
+     that the building does not refer to it (in practice, this might be
+     blueprint copies or item constructions going on inside the building).  */
+  ValidateState ();
+
+  ongoings.GetById (101)->MutableProto ().mutable_building_construction ();
   EXPECT_DEATH (ValidateState (), "does not refer back to ongoing");
 
   auto b = buildings.GetById (102);
@@ -1318,13 +1324,14 @@ TEST_F (ValidateStateTests, BuildingToOngoingsLink)
   b.reset ();
   EXPECT_DEATH (ValidateState (), "has non-existing ongoing");
 
-  ongoings.CreateNew (1);
+  ongoings.CreateNew (1)->MutableProto ().mutable_building_construction ();
   EXPECT_DEATH (ValidateState (), "does not refer back to building");
 
-  auto op = ongoings.GetById (102);
-  op->SetBuildingId (101);
-  op.reset ();
+  ongoings.GetById (102)->SetBuildingId (101);
   ValidateState ();
+
+  ongoings.GetById (102)->MutableProto ().mutable_blueprint_copy ();
+  EXPECT_DEATH (ValidateState (), "that is not a building construction");
 }
 
 /* ************************************************************************** */

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -117,6 +117,21 @@ protected:
   }
 
   /**
+   * Creates a new building and sets up also the age data and other things
+   * so it is considered valid.
+   */
+  BuildingsTable::Handle
+  CreateBuilding (const std::string& type, const std::string& owner,
+                  const Faction f)
+  {
+    auto b = buildings.CreateNew (type, owner, f);
+    auto* age = b->MutableProto ().mutable_age_data ();
+    age->set_founded_height (0);
+    age->set_finished_height (0);
+    return b;
+  }
+
+  /**
    * Sets the block height for processing the next block.
    */
   void
@@ -1014,7 +1029,7 @@ TEST_F (PXLogicTests, MiningWhenReprospected)
 
 TEST_F (PXLogicTests, EnterBuildingAfterMovesAndMovement)
 {
-  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  auto b = CreateBuilding ("checkmark", "", Faction::ANCIENT);
   ASSERT_EQ (b->GetId (), 1);
   b->SetCentre (HexCoord (0, 0));
   b.reset ();
@@ -1043,7 +1058,7 @@ TEST_F (PXLogicTests, EnterBuildingAfterMovesAndMovement)
 
 TEST_F (PXLogicTests, EnterBuildingDelayed)
 {
-  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  auto b = CreateBuilding ("checkmark", "", Faction::ANCIENT);
   ASSERT_EQ (b->GetId (), 1);
   b->SetCentre (HexCoord (0, 0));
   b.reset ();
@@ -1071,7 +1086,7 @@ TEST_F (PXLogicTests, EnterBuildingDelayed)
 
 TEST_F (PXLogicTests, EnterBuildingAndTargetFinding)
 {
-  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  auto b = CreateBuilding ("checkmark", "", Faction::ANCIENT);
   ASSERT_EQ (b->GetId (), 1);
   b->SetCentre (HexCoord (0, 0));
   b.reset ();
@@ -1111,7 +1126,7 @@ TEST_F (PXLogicTests, EnterBuildingAndTargetFinding)
 
 TEST_F (PXLogicTests, EnterAndExitBuildingWhenOutside)
 {
-  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  auto b = CreateBuilding ("checkmark", "", Faction::ANCIENT);
   ASSERT_EQ (b->GetId (), 1);
   b->SetCentre (HexCoord (0, 0));
   b.reset ();
@@ -1163,9 +1178,9 @@ TEST_F (ValidateStateTests, CharacterFactions)
 
 TEST_F (ValidateStateTests, BuildingFactions)
 {
-  buildings.CreateNew ("refinery", "", Faction::ANCIENT);
+  CreateBuilding ("refinery", "", Faction::ANCIENT);
 
-  auto h = buildings.CreateNew ("turret", "domob", Faction::RED);
+  auto h = CreateBuilding ("turret", "domob", Faction::RED);
   const auto id = h->GetId ();
   h.reset ();
   EXPECT_DEATH (ValidateState (), "owned by uninitialised account");
@@ -1175,6 +1190,45 @@ TEST_F (ValidateStateTests, BuildingFactions)
 
   accounts.CreateNew ("andy")->SetFaction (Faction::RED);
   buildings.GetById (id)->SetOwner ("andy");
+  ValidateState ();
+}
+
+TEST_F (ValidateStateTests, BuildingAgeData)
+{
+  auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  const auto id = b->GetId ();
+  b->MutableProto ().set_foundation (true);
+  b.reset ();
+  EXPECT_DEATH (ValidateState (), "has no founded height");
+
+  ctx.SetHeight (9);
+  buildings.GetById (id)->MutableProto ().mutable_age_data ()
+      ->set_founded_height (10);
+  EXPECT_DEATH (ValidateState (), "founded in the future");
+
+  ctx.SetHeight (10);
+  ValidateState ();
+
+  buildings.GetById (id)->MutableProto ().mutable_age_data ()
+      ->set_finished_height (10);
+  EXPECT_DEATH (ValidateState (), "has already finished height");
+
+  buildings.GetById (id)->MutableProto ().set_foundation (false);
+  ValidateState ();
+
+  buildings.GetById (id)->MutableProto ().mutable_age_data ()
+      ->clear_finished_height ();
+  EXPECT_DEATH (ValidateState (), "has no finished height");
+
+  buildings.GetById (id)->MutableProto ().mutable_age_data ()
+      ->set_finished_height (9);
+  EXPECT_DEATH (ValidateState (), "was finished before being founded");
+
+  buildings.GetById (id)->MutableProto ().mutable_age_data ()
+      ->set_finished_height (11);
+  EXPECT_DEATH (ValidateState (), "finished in the future");
+
+  ctx.SetHeight (11);
   ValidateState ();
 }
 
@@ -1200,11 +1254,11 @@ TEST_F (ValidateStateTests, CharactersInBuildings)
   accounts.CreateNew ("andy")->SetFaction (Faction::BLUE);
 
   const auto idAncient
-      = buildings.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId ();
+      = CreateBuilding ("checkmark", "", Faction::ANCIENT)->GetId ();
   const auto idOk
-      = buildings.CreateNew ("checkmark", "domob", Faction::RED)->GetId ();
+      = CreateBuilding ("checkmark", "domob", Faction::RED)->GetId ();
   const auto idWrong
-      = buildings.CreateNew ("checkmark", "andy", Faction::BLUE)->GetId ();
+      = CreateBuilding ("checkmark", "andy", Faction::BLUE)->GetId ();
 
   db.SetNextId (10);
   ASSERT_EQ (characters.CreateNew ("domob", Faction::RED)->GetId (), 10);
@@ -1240,7 +1294,7 @@ TEST_F (ValidateStateTests, BuildingInventories)
 {
   db.SetNextId (10);
   accounts.CreateNew ("domob")->SetFaction (Faction::RED);
-  buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  CreateBuilding ("checkmark", "", Faction::ANCIENT);
 
   inv.Get (10, "andy")->GetInventory ().SetFungibleCount ("foo", 1);
   EXPECT_DEATH (ValidateState (), "non-existant account");
@@ -1249,20 +1303,31 @@ TEST_F (ValidateStateTests, BuildingInventories)
 
   inv.Get (11, "domob")->GetInventory ().SetFungibleCount ("foo", 1);
   EXPECT_DEATH (ValidateState (), "non-existant building");
-  buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+  CreateBuilding ("checkmark", "", Faction::ANCIENT);
   ValidateState ();
 
-  buildings.GetById (10)->MutableProto ().set_foundation (true);
+  auto b = buildings.GetById (10);
+  b->MutableProto ().set_foundation (true);
+  b->MutableProto ().mutable_age_data ()->clear_finished_height ();
+  b.reset ();
   EXPECT_DEATH (ValidateState (), "in foundation");
-  buildings.GetById (10)->MutableProto ().set_foundation (false);
+
+  b = buildings.GetById (10);
+  b->MutableProto ().set_foundation (false);
+  b->MutableProto ().mutable_age_data ()->set_finished_height (0);
+  b.reset ();
   ValidateState ();
 
-  auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  b = CreateBuilding ("checkmark", "domob", Faction::RED);
   ASSERT_EQ (b->GetId (), 12);
   b->MutableProto ().mutable_construction_inventory ();
   b.reset ();
   EXPECT_DEATH (ValidateState (), "has construction inventory");
-  buildings.GetById (12)->MutableProto ().set_foundation (true);
+
+  b = buildings.GetById (12);
+  b->MutableProto ().set_foundation (true);
+  b->MutableProto ().mutable_age_data ()->clear_finished_height ();
+  b.reset ();
   ValidateState ();
 }
 
@@ -1314,7 +1379,7 @@ TEST_F (ValidateStateTests, OngoingsToBuildingLink)
   op.reset ();
   EXPECT_DEATH (ValidateState (), "refers to non-existing building");
 
-  buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  CreateBuilding ("checkmark", "domob", Faction::RED);
   /* If the ongoing operation is not a building construction, it is fine
      that the building does not refer to it (in practice, this might be
      blueprint copies or item constructions going on inside the building).  */
@@ -1334,7 +1399,7 @@ TEST_F (ValidateStateTests, BuildingToOngoingsLink)
   accounts.CreateNew ("domob")->SetFaction (Faction::RED);
   db.SetNextId (101);
 
-  auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  auto b = CreateBuilding ("checkmark", "domob", Faction::RED);
   b->MutableProto ().set_ongoing_construction (102);
   b.reset ();
   EXPECT_DEATH (ValidateState (), "has non-existing ongoing");

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -294,6 +294,7 @@ TEST_F (PXLogicTests, NewBuildingBlocksMovement)
   auto c = CreateCharacter ("builder", Faction::GREEN);
   ASSERT_EQ (c->GetId (), 1);
   c->SetPosition (HexCoord (0, 0));
+  c->MutableProto ().set_cargo_space (1'000);
   c->GetInventory ().AddFungibleCount ("foo", 10);
   c.reset ();
 
@@ -1219,6 +1220,20 @@ TEST_F (ValidateStateTests, CharactersInBuildings)
 
   characters.GetById (10)->SetBuildingId (12345);
   EXPECT_DEATH (ValidateState (), "is in non-existant building");
+}
+
+TEST_F (ValidateStateTests, CharacterCargoSpace)
+{
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  auto c = characters.CreateNew ("domob", Faction::RED);
+  const auto id = c->GetId ();
+  c->MutableProto ().set_cargo_space (19);
+  c->GetInventory ().AddFungibleCount ("foo", 2);
+  c.reset ();
+
+  EXPECT_DEATH (ValidateState (), "exceeds cargo limit");
+  characters.GetById (id)->MutableProto ().set_cargo_space (20);
+  ValidateState ();
 }
 
 TEST_F (ValidateStateTests, BuildingInventories)

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1498,6 +1498,7 @@ MoveProcessor::MaybeFoundBuilding (Character& c, const Json::Value& upd)
   auto& pb = b->MutableProto ();
   pb.set_foundation (true);
   *pb.mutable_shape_trafo () = trafo;
+  pb.mutable_age_data ()->set_founded_height (ctx.Height ());
 
   auto& inv = c.GetInventory ();
   const auto& roBuilding = ctx.RoConfig ().Building (b->GetType ());
@@ -1971,14 +1972,17 @@ MaybeGodBuild (AccountsTable& accounts, BuildingsTable& tbl, const Context& ctx,
          placed as needed in tests, without having to worry about regions
          and the ability to build in them.  */
 
-      auto h = tbl.CreateNew (type, owner, f);
-      h->SetCentre (centre);
-      *h->MutableProto ().mutable_shape_trafo () = trafo;
-      UpdateBuildingStats (*h, ctx.Chain ());
+      auto b = tbl.CreateNew (type, owner, f);
+      b->SetCentre (centre);
+      auto& pb = b->MutableProto ();
+      *pb.mutable_shape_trafo () = trafo;
+      pb.mutable_age_data ()->set_founded_height (ctx.Height ());
+      pb.mutable_age_data ()->set_finished_height (ctx.Height ());
+      UpdateBuildingStats (*b, ctx.Chain ());
       LOG (INFO)
           << "God building " << type
           << " for " << owner << " of faction " << FactionToString (f) << ":\n"
-          << "  id: " << h->GetId () << "\n"
+          << "  id: " << b->GetId () << "\n"
           << "  centre: " << centre << "\n"
           << "  rotation: " << trafo.rotation_steps ();
     }

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -2764,9 +2764,12 @@ TEST_F (DropPickupMoveTests, StartBuildingConstruction)
       }
     }
   ])");
+
   auto res = ongoings.QueryAll ();
   ASSERT_TRUE (res.Step ());
-  EXPECT_EQ (ongoings.GetFromResult (res)->GetBuildingId (), bId);
+  auto op = ongoings.GetFromResult (res);
+  EXPECT_EQ (op->GetBuildingId (), bId);
+  EXPECT_TRUE (op->GetProto ().has_building_construction ());
   EXPECT_FALSE (res.Step ());
 }
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1825,8 +1825,10 @@ TEST_F (FoundBuildingMoveTests, CannotPlaceBuilding)
 
 TEST_F (FoundBuildingMoveTests, Success)
 {
+  ctx.SetHeight (10);
   const HexCoord pos = GetTest ()->GetPosition ();
   GetTest ()->GetInventory ().AddFungibleCount ("foo", 10);
+
   Process (R"([
     {
       "name": "domob",
@@ -1845,6 +1847,7 @@ TEST_F (FoundBuildingMoveTests, Success)
   const auto& pb = b->GetProto ();
   EXPECT_TRUE (pb.foundation ());
   EXPECT_EQ (pb.shape_trafo ().rotation_steps (), 3);
+  EXPECT_EQ (pb.age_data ().founded_height (), 10);
 
   auto c = GetTest ();
   EXPECT_EQ (c->GetInventory ().GetFungibleCount ("foo"), 8);
@@ -3564,6 +3567,7 @@ TEST_F (GodModeTests, SetHp)
 
 TEST_F (GodModeTests, Build)
 {
+  ctx.SetHeight (10);
   accounts.CreateNew ("domob")->SetFaction (Faction::RED);
 
   /* This is entirely invalid (not even an array).  */
@@ -3607,6 +3611,8 @@ TEST_F (GodModeTests, Build)
   EXPECT_EQ (h->GetOwner (), "domob");
   EXPECT_EQ (h->GetCentre (), HexCoord (-100, -200));
   EXPECT_EQ (h->GetProto ().shape_trafo ().rotation_steps (), 0);
+  EXPECT_EQ (h->GetProto ().age_data ().founded_height (), 10);
+  EXPECT_EQ (h->GetProto ().age_data ().finished_height (), 10);
 
   ASSERT_TRUE (res.Step ());
   h = buildings.GetFromResult (res);

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -137,6 +137,7 @@ FinishBuildingConstruction (Building& b, const Context& ctx,
   pb.clear_construction_inventory ();
   pb.set_foundation (false);
   pb.clear_ongoing_construction ();
+  pb.mutable_age_data ()->set_finished_height (ctx.Height ());
 
   UpdateBuildingStats (b, ctx.Chain ());
 }

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -136,6 +136,7 @@ FinishBuildingConstruction (Building& b, const Context& ctx,
 
   pb.clear_construction_inventory ();
   pb.set_foundation (false);
+  pb.clear_ongoing_construction ();
 
   UpdateBuildingStats (b, ctx.Chain ());
 }

--- a/src/ongoings_tests.cpp
+++ b/src/ongoings_tests.cpp
@@ -351,6 +351,7 @@ TEST_F (OngoingsTests, BuildingConstruction)
   EXPECT_FALSE (b->GetProto ().foundation ());
   EXPECT_FALSE (b->GetProto ().has_ongoing_construction ());
   EXPECT_FALSE (b->GetProto ().has_construction_inventory ());
+  EXPECT_EQ (b->GetProto ().age_data ().finished_height (), 10);
   EXPECT_EQ (b->GetHP ().armour (), 100);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("foo"), 2);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bar"), 42);

--- a/src/ongoings_tests.cpp
+++ b/src/ongoings_tests.cpp
@@ -349,6 +349,7 @@ TEST_F (OngoingsTests, BuildingConstruction)
   b = buildings.GetById (bId);
   auto inv = buildingInv.Get (bId, "domob");
   EXPECT_FALSE (b->GetProto ().foundation ());
+  EXPECT_FALSE (b->GetProto ().has_ongoing_construction ());
   EXPECT_FALSE (b->GetProto ().has_construction_inventory ());
   EXPECT_EQ (b->GetHP ().armour (), 100);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("foo"), 2);


### PR DESCRIPTION
This backports some fixes to "slow assert" validation as well as building age data (#182) to `master` from `0.3`.