### PR TITLE
Use libxayagame's SQLite statement

### DIFF
--- a/database/character_bench.cpp
+++ b/database/character_bench.cpp
@@ -69,7 +69,7 @@ void
 CharacterLookupSimple (benchmark::State& state)
 {
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   const unsigned numInDb = state.range (0);
   const unsigned numLookedUp = state.range (1);
@@ -107,7 +107,7 @@ void
 CharacterLookupProto (benchmark::State& state)
 {
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   const unsigned numChar = state.range (0);
   const unsigned numWP = state.range (1);
@@ -142,7 +142,7 @@ BENCHMARK (CharacterLookupProto)
 void CharacterQuery (benchmark::State& state)
 {
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   const unsigned numChar = state.range (0);
   const unsigned numWP = state.range (1);
@@ -179,7 +179,7 @@ void
 CharacterFieldsUpdate (benchmark::State& state)
 {
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   const unsigned n = state.range (0);
   const unsigned numWP = state.range (1);
@@ -216,7 +216,7 @@ void
 CharacterProtoUpdate (benchmark::State& state)
 {
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   const unsigned n = state.range (0);
   const unsigned numWP = state.range (1);

--- a/database/database.cpp
+++ b/database/database.cpp
@@ -25,127 +25,51 @@
 namespace pxd
 {
 
-/* ************************************************************************** */
-
 constexpr Database::IdT Database::EMPTY_ID;
+
+void
+Database::SetDatabase (xaya::SQLiteDatabase& d)
+{
+  CHECK (db == nullptr) << "Database has already been set";
+  db = &d;
+}
 
 Database::Statement
 Database::Prepare (const std::string& sql)
 {
-  return Statement (*this, PrepareStatement (sql));
+  CHECK (db != nullptr) << "Database has not been set";
+  return Statement (*this, db->Prepare (sql));
 }
-
-/* ************************************************************************** */
 
 void
 Database::Statement::Reset ()
 {
-  sqlite3_reset (stmt);
-  CHECK_EQ (sqlite3_clear_bindings (stmt), SQLITE_OK);
-  run = false;
+  CHECK (!queried) << "SELECT statements can't be reset";
+  sqlite3_clear_bindings (*stmt);
+  stmt.Reset ();
+  executed = false;
 }
 
 void
 Database::Statement::Execute ()
 {
-  CHECK (!run) << "Database statement has already been run";
-  run = true;
-  CHECK_EQ (sqlite3_step (stmt), SQLITE_DONE);
-}
-
-template <>
-  void
-  Database::Statement::Bind<int32_t> (const unsigned ind, const int32_t& val)
-{
-  CHECK (!run);
-  CHECK_EQ (sqlite3_bind_int (stmt, ind, val), SQLITE_OK);
-}
-
-template <>
-  void
-  Database::Statement::Bind<int64_t> (const unsigned ind, const int64_t& val)
-{
-  CHECK (!run);
-  CHECK_EQ (sqlite3_bind_int64 (stmt, ind, val), SQLITE_OK);
+  CHECK (!executed && !queried) << "Database statement has already been run";
+  executed = true;
+  stmt.Execute ();
 }
 
 template <>
   void
   Database::Statement::Bind<int16_t> (const unsigned ind, const int16_t& val)
 {
-  Bind<int32_t> (ind, val);
-}
-
-template <>
-  void
-  Database::Statement::Bind<uint64_t> (const unsigned ind, const uint64_t& val)
-{
-  CHECK_LE (val, std::numeric_limits<int64_t>::max ());
   Bind<int64_t> (ind, val);
 }
 
 template <>
   void
-  Database::Statement::Bind<uint32_t> (const unsigned ind, const uint32_t& val)
+  Database::Statement::Bind<int32_t> (const unsigned ind, const int32_t& val)
 {
-  Bind<uint64_t> (ind, val);
+  Bind<int64_t> (ind, val);
 }
-
-template <>
-  void
-  Database::Statement::Bind<bool> (const unsigned ind, const bool& val)
-{
-  CHECK (!run);
-  CHECK_EQ (sqlite3_bind_int (stmt, ind, val), SQLITE_OK);
-}
-
-template <>
-  void
-  Database::Statement::Bind<std::string> (const unsigned ind,
-                                          const std::string& val)
-{
-  CHECK (!run);
-  CHECK_EQ (sqlite3_bind_text (stmt, ind, &val[0], val.size (),
-                               SQLITE_TRANSIENT),
-            SQLITE_OK);
-}
-
-void
-Database::Statement::BindNull (const unsigned ind)
-{
-  CHECK (!run);
-  CHECK_EQ (sqlite3_bind_null (stmt, ind), SQLITE_OK);
-}
-
-/* ************************************************************************** */
-
-namespace internal
-{
-
-template <>
-  int64_t
-  GetColumnValue<int64_t> (sqlite3_stmt* stmt, const int index)
-{
-  return sqlite3_column_int64 (stmt, index);
-}
-
-template <>
-  bool
-  GetColumnValue<bool> (sqlite3_stmt* stmt, const int index)
-{
-  return sqlite3_column_int (stmt, index);
-}
-
-template <>
-  std::string
-  GetColumnValue<std::string> (sqlite3_stmt* stmt, const int index)
-{
-  const unsigned char* str = sqlite3_column_text (stmt, index);
-  return reinterpret_cast<const char*> (str);
-}
-
-} // namespace internal
-
-/* ************************************************************************** */
 
 } // namespace pxd

--- a/database/database.hpp
+++ b/database/database.hpp
@@ -92,6 +92,15 @@ public:
    */
   Statement Prepare (const std::string& sql);
 
+  /**
+   * Gives access to the underlying libxayagame Database instance.
+   */
+  xaya::SQLiteDatabase&
+  operator* ()
+  {
+    return *db;
+  }
+
 };
 
 /**

--- a/database/dbtest.cpp
+++ b/database/dbtest.cpp
@@ -28,12 +28,8 @@ namespace pxd
 
 TestDatabase::TestDatabase ()
   : db("test", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MEMORY)
-{}
-
-sqlite3_stmt*
-TestDatabase::PrepareStatement (const std::string& sql)
 {
-  return db.Prepare (sql);
+  SetDatabase (db);
 }
 
 Database::IdT

--- a/database/dbtest.cpp
+++ b/database/dbtest.cpp
@@ -41,7 +41,7 @@ TestDatabase::GetNextId ()
 DBTestWithSchema::DBTestWithSchema ()
 {
   LOG (INFO) << "Setting up game-state schema in test database...";
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   MoneySupply ms(db);
   ms.InitialiseDatabase ();

--- a/database/dbtest.hpp
+++ b/database/dbtest.hpp
@@ -69,15 +69,6 @@ public:
     nextId = id;
   }
 
-  /**
-   * Returns the underlying database handle for SQLite.
-   */
-  sqlite3*
-  GetHandle ()
-  {
-    return *db;
-  }
-
 };
 
 /**

--- a/database/dbtest.hpp
+++ b/database/dbtest.hpp
@@ -50,10 +50,6 @@ private:
   /** The next ID to give out.  */
   IdT nextId = 1;
 
-protected:
-
-  sqlite3_stmt* PrepareStatement (const std::string& sql) override;
-
 public:
 
   TestDatabase ();

--- a/database/schema.hpp
+++ b/database/schema.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
 #ifndef DATABASE_SCHEMA_HPP
 #define DATABASE_SCHEMA_HPP
 
-#include <sqlite3.h>
+#include <xayagame/sqlitestorage.hpp>
 
 namespace pxd
 {
@@ -28,7 +28,7 @@ namespace pxd
  * Create the database schema (if it does not exist yet) in the given database
  * connection.
  */
-void SetupDatabaseSchema (sqlite3* db);
+void SetupDatabaseSchema (xaya::SQLiteDatabase& db);
 
 } // namespace pxd
 

--- a/database/schema_head.cpp
+++ b/database/schema_head.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,8 +17,6 @@
 */
 
 #include "schema.hpp"
-
-#include <glog/logging.h>
 
 namespace pxd
 {

--- a/database/schema_tail.cpp
+++ b/database/schema_tail.cpp
@@ -1,21 +1,11 @@
 )";
 
-/**
- * Callback for sqlite3_exec that expects not to be called.
- */
-int
-ExpectNoResult (void* data, int columns, char** strs, char** names)
-{
-  LOG (FATAL) << "Expected no result from DB query";
-}
-
 } // anonymous namespace
 
 void
-SetupDatabaseSchema (sqlite3* db)
+SetupDatabaseSchema (xaya::SQLiteDatabase& db)
 {
-  CHECK_EQ (sqlite3_exec (db, SCHEMA_SQL, &ExpectNoResult, nullptr, nullptr),
-            SQLITE_OK);
+  db.Execute (SCHEMA_SQL);
 }
 
 } // namespace pxd

--- a/database/schema_tests.cpp
+++ b/database/schema_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -31,13 +31,13 @@ using SchemaTests = DBTestFixture;
 
 TEST_F (SchemaTests, Works)
 {
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 }
 
 TEST_F (SchemaTests, TwiceIsOk)
 {
-  SetupDatabaseSchema (db.GetHandle ());
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
+  SetupDatabaseSchema (*db);
 }
 
 } // anonymous namespace

--- a/database/target_bench.cpp
+++ b/database/target_bench.cpp
@@ -62,7 +62,7 @@ void
 TargetFinding (benchmark::State& state)
 {
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   const HexCoord::IntT range = state.range (0);
   const unsigned inRange = state.range (1);

--- a/src/combat_damage_bench.cpp
+++ b/src/combat_damage_bench.cpp
@@ -123,7 +123,7 @@ CombatHpUpdate (benchmark::State& state)
   ContextForTesting ctx;
 
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   xaya::SHA256 seed;
   seed << "random seed";
@@ -166,7 +166,7 @@ CombatKills (benchmark::State& state)
   ContextForTesting ctx;
 
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   xaya::SHA256 seed;
   seed << "random seed";

--- a/src/combat_target_bench.cpp
+++ b/src/combat_target_bench.cpp
@@ -87,7 +87,7 @@ TargetSelectionFriendly (benchmark::State& state)
   ContextForTesting ctx;
 
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   xaya::SHA256 seed;
   seed << "random seed";
@@ -135,7 +135,7 @@ TargetSelectionEnemies (benchmark::State& state)
   ContextForTesting ctx;
 
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   xaya::SHA256 seed;
   seed << "random seed";

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -118,7 +118,7 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
 void
 PXLogic::SetupSchema (xaya::SQLiteDatabase& db)
 {
-  SetupDatabaseSchema (*db);
+  SetupDatabaseSchema (db);
 }
 
 void

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -36,10 +36,10 @@
 namespace pxd
 {
 
-sqlite3_stmt*
-SQLiteGameDatabase::PrepareStatement (const std::string& sql)
+SQLiteGameDatabase::SQLiteGameDatabase (xaya::SQLiteDatabase& d, PXLogic& g)
+  : game(g)
 {
-  return db.Prepare (sql);
+  SetDatabase (d);
 }
 
 Database::IdT

--- a/src/logic.hpp
+++ b/src/logic.hpp
@@ -53,21 +53,12 @@ class SQLiteGameDatabase : public Database
 
 private:
 
-  /** The underlying SQLiteDatabase instance.  */
-  xaya::SQLiteDatabase& db;
-
   /** The underlying SQLiteGame instance.  */
   PXLogic& game;
 
-protected:
-
-  sqlite3_stmt* PrepareStatement (const std::string& sql) override;
-
 public:
 
-  explicit SQLiteGameDatabase (xaya::SQLiteDatabase& d, PXLogic& g)
-    : db(d), game(g)
-  {}
+  explicit SQLiteGameDatabase (xaya::SQLiteDatabase& d, PXLogic& g);
 
   SQLiteGameDatabase () = delete;
   SQLiteGameDatabase (const SQLiteGameDatabase&) = delete;

--- a/src/movement_bench.cpp
+++ b/src/movement_bench.cpp
@@ -77,7 +77,7 @@ void
 MovementLongHaul (benchmark::State& state)
 {
   TestDatabase db;
-  SetupDatabaseSchema (db.GetHandle ());
+  SetupDatabaseSchema (*db);
 
   ContextForTesting ctx;
 


### PR DESCRIPTION
This refactors the internal database layer to use the new `SQLiteDatabase::Statement` wrapper class from libxayagame introduced in https://github.com/xaya/libxayagame/pull/102.