### PR TITLE
Some modularisation of target finding

### DIFF
--- a/database/target.cpp
+++ b/database/target.cpp
@@ -39,7 +39,7 @@ TargetFinder::ProcessL1Targets (const HexCoord& centre,
                                 const HexCoord::IntT l1range,
                                 const Faction faction,
                                 const bool enemies, const bool friendlies,
-                                const ProcessingFcn& cb)
+                                const ProcessingFcn& cb) const
 {
   CHECK (enemies || friendlies)
       << "Neither enemy nor friendly targets requested?";

--- a/database/target.hpp
+++ b/database/target.hpp
@@ -64,7 +64,7 @@ public:
    */
   void ProcessL1Targets (const HexCoord& centre, HexCoord::IntT l1range,
                          Faction faction, bool enemies, bool friendlies,
-                         const ProcessingFcn& cb);
+                         const ProcessingFcn& cb) const;
 
 };
 

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -36,8 +36,10 @@ message TargetId
   enum Type
   {
     INVALID_TYPE = 0;
-    TYPE_CHARACTER = 1;
-    TYPE_BUILDING = 2;
+    /* The numeric values below are used to sort TargetKey instances, which
+       are expected to match the sorting order used in some DB queries.  */
+    TYPE_BUILDING = 1;
+    TYPE_CHARACTER = 2;
   }
 
   /** The type of this target.  */

--- a/src/combat.hpp
+++ b/src/combat.hpp
@@ -38,7 +38,9 @@ namespace pxd
 
 /**
  * Representation of a Target that can be used as key in a map or as
- * entry in a set.
+ * entry in a set.  The natural sorting order matches the order in
+ * which TargetFinder::ProcessL1Targets and FighterTable::ProcessWithAttacks
+ * returns their results.
  */
 class TargetKey : public std::pair<proto::TargetId::Type, Database::IdT>
 {


### PR DESCRIPTION
This refactors the target-finding code in a way that makes it more modular, with some state wrapped into a processor class.  It also splits the "computation" and "update" phases apart from each other.

This could be used to parallelise the computation phase in the future, although directly doing that seems to be less efficient on the 0.3 competition chain; but it could be possible to do in the future.  Also, with this it would be easier to instead optimise by loading all combat entities into memory first, then doing in-memory parallel target finding (without having to synchronise database accesses), and then doing the updates from one thread again.