### PR TITLE
Implement DEX trading

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -20,6 +20,7 @@ libdatabase_la_SOURCES = \
   coord.cpp \
   damagelists.cpp \
   database.cpp \
+  dex.cpp \
   faction.cpp \
   fighter.cpp \
   inventory.cpp \
@@ -38,6 +39,7 @@ noinst_HEADERS = \
   coord.hpp coord.tpp \
   damagelists.hpp \
   database.hpp database.tpp \
+  dex.hpp \
   faction.hpp faction.tpp \
   fighter.hpp \
   inventory.hpp \
@@ -85,6 +87,7 @@ tests_SOURCES = \
   coord_tests.cpp \
   damagelists_tests.cpp \
   database_tests.cpp \
+  dex_tests.cpp \
   faction_tests.cpp \
   fighter_tests.cpp \
   inventory_tests.cpp \

--- a/database/database.hpp
+++ b/database/database.hpp
@@ -88,6 +88,14 @@ public:
   virtual IdT GetNextId () = 0;
 
   /**
+   * Returns the next auto-generated ID that should be used for things
+   * that are not consensus relevant (and thus can be changed more easily).
+   * For instance, as keys into "events / log" tables that are just written
+   * and never read during the state transition.
+   */
+  virtual IdT GetLogId () = 0;
+
+  /**
    * Prepares an SQL statement and returns the wrapper object.
    */
   Statement Prepare (const std::string& sql);

--- a/database/dbtest.cpp
+++ b/database/dbtest.cpp
@@ -38,6 +38,12 @@ TestDatabase::GetNextId ()
   return nextId++;
 }
 
+Database::IdT
+TestDatabase::GetLogId ()
+{
+  return nextLogId++;
+}
+
 DBTestWithSchema::DBTestWithSchema ()
 {
   LOG (INFO) << "Setting up game-state schema in test database...";

--- a/database/dbtest.hpp
+++ b/database/dbtest.hpp
@@ -50,6 +50,9 @@ private:
   /** The next ID to give out.  */
   IdT nextId = 1;
 
+  /** The next log ID to give out.  */
+  IdT nextLogId = 1;
+
 public:
 
   TestDatabase ();
@@ -58,6 +61,7 @@ public:
   void operator= (const TestDatabase&) = delete;
 
   IdT GetNextId () override;
+  IdT GetLogId () override;
 
   /**
    * Sets the next ID to be given out.  This is useful for tests to force

--- a/database/dex.cpp
+++ b/database/dex.cpp
@@ -1,0 +1,356 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "dex.hpp"
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+/* ************************************************************************** */
+
+DexOrder::DexOrder (Database& d)
+  : db(d), id(db.GetNextId ()),
+    buildingId(Database::EMPTY_ID),
+    type(Type::INVALID),
+    quantity(0), price(0),
+    isNew(true), dirty(false)
+{
+  VLOG (1) << "Created new DEX order with ID " << id;
+}
+
+DexOrder::DexOrder (Database& d, const Database::Result<DexOrderResult>& res)
+  : db(d), isNew(false), dirty(false)
+{
+  id = res.Get<DexOrderResult::id> ();
+  buildingId = res.Get<DexOrderResult::building> ();
+  account = res.Get<DexOrderResult::account> ();
+  type = static_cast<Type> (res.Get<DexOrderResult::type> ());
+  CHECK (type == Type::BID || type == Type::ASK)
+      << "Unexpected order type read from DB for order " << id
+      << ": " << static_cast<int> (type);
+  item = res.Get<DexOrderResult::item> ();
+  quantity = res.Get<DexOrderResult::quantity> ();
+  price = res.Get<DexOrderResult::price> ();
+}
+
+DexOrder::~DexOrder ()
+{
+  if (isNew && quantity == 0)
+    {
+      VLOG (1) << "Not inserting immediately deleted order " << id;
+      return;
+    }
+
+  if (isNew)
+    {
+      VLOG (1) << "Inserting new DEX order " << id << "into the database";
+
+      CHECK_NE (buildingId, Database::EMPTY_ID)
+          << "No building ID set for new order " << id;
+      CHECK_NE (item, "")
+          << "No item type set for new order " << id;
+
+      CHECK (type == Type::BID || type == Type::ASK)
+          << "Unexpected order type for DB insertion for order " << id
+          << ": " << static_cast<int> (type);
+
+      CHECK_GT (quantity, 0)
+          << "No quantity set for order " << id;
+      CHECK_LE (quantity, MAX_QUANTITY)
+          << "Invalid quantity for new order " << id;
+      CHECK_GE (price, 0)
+          << "Invalid (negative) price for order " << id;
+
+      auto stmt = db.Prepare (R"(
+        INSERT INTO `dex_orders`
+          (`id`, `building`, `account`, `type`, `item`, `quantity`, `price`)
+          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+      )");
+
+      stmt.Bind (1, id);
+      stmt.Bind (2, buildingId);
+      stmt.Bind (3, account);
+      stmt.Bind (4, static_cast<int> (type));
+      stmt.Bind (5, item);
+      stmt.Bind (6, quantity);
+      stmt.Bind (7, price);
+
+      stmt.Execute ();
+      return;
+    }
+
+  if (!dirty)
+    {
+      VLOG (1) << "DEX order " << id << " is not dirty";
+      return;
+    }
+
+  if (quantity == 0)
+    {
+      VLOG (1) << "Deleting used up order " << id;
+      auto stmt = db.Prepare (R"(
+        DELETE FROM `dex_orders`
+          WHERE `id` = ?1
+      )");
+      stmt.Bind (1, id);
+      stmt.Execute ();
+      return;
+    }
+
+  VLOG (1) << "Updating dirty DEX order " << id;
+  CHECK_GT (quantity, 0)
+      << "Invalid item quantity for updated order " << id;
+
+  auto stmt = db.Prepare (R"(
+    UPDATE `dex_orders`
+      SET `quantity` = ?2
+      WHERE `id` = ?1
+  )");
+  stmt.Bind (1, id);
+  stmt.Bind (2, quantity);
+  stmt.Execute ();
+}
+
+void
+DexOrder::ReduceQuantity (const Quantity q)
+{
+  CHECK_LE (q, quantity);
+  quantity -= q;
+  dirty = true;
+}
+
+void
+DexOrder::Delete ()
+{
+  quantity = 0;
+  dirty = true;
+}
+
+/* ************************************************************************** */
+
+DexOrderTable::Handle
+DexOrderTable::CreateNew (const Database::IdT building, const std::string& acc,
+                          const DexOrder::Type type, const std::string& item,
+                          const Quantity quantity, const Amount price)
+{
+  Handle o(new DexOrder (db));
+
+  o->buildingId = building;
+  o->account = acc;
+  o->type = type;
+  o->item = item;
+  o->quantity = quantity;
+  o->price = price;
+
+  return o;
+}
+
+DexOrderTable::Handle
+DexOrderTable::GetFromResult (const Database::Result<DexOrderResult>& res)
+{
+  return Handle (new DexOrder (db, res));
+}
+
+DexOrderTable::Handle
+DexOrderTable::GetById (const Database::IdT id)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `dex_orders`
+      WHERE `id` = ?1
+  )");
+  stmt.Bind (1, id);
+  auto res = stmt.Query<DexOrderResult> ();
+  if (!res.Step ())
+    return nullptr;
+
+  auto o = GetFromResult (res);
+  CHECK (!res.Step ());
+  return o;
+}
+
+Database::Result<DexOrderResult>
+DexOrderTable::QueryAll ()
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `dex_orders`
+      ORDER BY `id`
+  )");
+  return stmt.Query<DexOrderResult> ();
+}
+
+Database::Result<DexOrderResult>
+DexOrderTable::QueryForBuilding (const Database::IdT building)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `dex_orders`
+      WHERE `building` = ?1
+      ORDER BY `item`, `type`, `price`, `id`
+  )");
+  stmt.Bind (1, building);
+  return stmt.Query<DexOrderResult> ();
+}
+
+Database::Result<DexOrderResult>
+DexOrderTable::QueryToMatchBid (const Database::IdT building,
+                                const std::string& item, const Amount price)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `dex_orders`
+      WHERE
+        `building` = ?1 AND `item` = ?2 AND `type` = ?3
+        AND `price` <= ?4
+      ORDER BY `price`, `id`
+  )");
+  stmt.Bind (1, building);
+  stmt.Bind (2, item);
+  stmt.Bind (3, static_cast<int> (DexOrder::Type::ASK));
+  stmt.Bind (4, price);
+  return stmt.Query<DexOrderResult> ();
+}
+
+Database::Result<DexOrderResult>
+DexOrderTable::QueryToMatchAsk (const Database::IdT building,
+                                const std::string& item, const Amount price)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `dex_orders`
+      WHERE
+        `building` = ?1 AND `item` = ?2 AND `type` = ?3
+        AND `price` >= ?4
+      ORDER BY `price` DESC, `id`
+  )");
+  stmt.Bind (1, building);
+  stmt.Bind (2, item);
+  stmt.Bind (3, static_cast<int> (DexOrder::Type::BID));
+  stmt.Bind (4, price);
+  return stmt.Query<DexOrderResult> ();
+}
+
+namespace
+{
+
+/**
+ * Database result with reserved Cubit balances per account.
+ */
+struct ReservedCoinsResult : public Database::ResultType
+{
+  RESULT_COLUMN (std::string, account, 1);
+  RESULT_COLUMN (int64_t, cost, 2);
+};
+
+/**
+ * Database result with reserved item quantities per account.
+ */
+struct ReservedQuantitiesResult : public Database::ResultType
+{
+  RESULT_COLUMN (std::string, account, 1);
+  RESULT_COLUMN (std::string, item, 2);
+  RESULT_COLUMN (int64_t, quantity, 3);
+};
+
+} // anonymous namespace
+
+std::map<std::string, Amount>
+DexOrderTable::GetReservedCoins (const Database::IdT building) const
+{
+  std::ostringstream sql;
+  sql << R"(
+    SELECT `account`, SUM(`quantity` * `price`) AS `cost`
+      FROM `dex_orders`
+      WHERE `type` = ?1
+  )";
+  if (building != Database::EMPTY_ID)
+    sql << " AND `building` = ?2";
+  sql << R"(
+      GROUP BY `account`
+  )";
+
+  auto stmt = db.Prepare (sql.str ());
+  stmt.Bind (1, static_cast<int> (DexOrder::Type::BID));
+  if (building != Database::EMPTY_ID)
+    stmt.Bind (2, building);
+
+  std::map<std::string, Amount> balances;
+  auto res = stmt.Query<ReservedCoinsResult> ();
+  while (res.Step ())
+    balances.emplace (res.Get<ReservedCoinsResult::account> (),
+                      res.Get<ReservedCoinsResult::cost> ());
+
+  return balances;
+}
+
+std::map<std::string, Inventory>
+DexOrderTable::GetReservedQuantities (const Database::IdT building) const
+{
+  auto stmt = db.Prepare (R"(
+    SELECT `account`, `item`, SUM(`quantity`) AS `quantity`
+      FROM `dex_orders`
+      WHERE `building` = ?1 AND `type` = ?2
+      GROUP BY `account`, `item`
+      ORDER BY `account`
+  )");
+  stmt.Bind (1, building);
+  stmt.Bind (2, static_cast<int> (DexOrder::Type::ASK));
+
+  std::map<std::string, Inventory> balances;
+  auto res = stmt.Query<ReservedQuantitiesResult> ();
+
+  /* Since we get the results ordered by account, we can keep track of the
+     last account's map iterator, and only need to check if that still
+     matches the next row.  There is no need to keep looking up the name.  */
+  auto lastIt = balances.end ();
+
+  while (res.Step ())
+    {
+      const auto account = res.Get<ReservedQuantitiesResult::account> ();
+      if (lastIt == balances.end () || lastIt->first != account)
+        {
+          auto ins = balances.emplace (account, Inventory ());
+          CHECK (ins.second) << "We already have an entry for " << account;
+          lastIt = ins.first;
+        }
+
+      lastIt->second.AddFungibleCount (
+          res.Get<ReservedQuantitiesResult::item> (),
+          res.Get<ReservedQuantitiesResult::quantity> ());
+    }
+
+  return balances;
+}
+
+void
+DexOrderTable::DeleteForBuilding (const Database::IdT building)
+{
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `dex_orders`
+      WHERE `building` = ?1
+  )");
+  stmt.Bind (1, building);
+  stmt.Execute ();
+}
+
+/* ************************************************************************** */
+
+} // namespace pxd

--- a/database/dex.hpp
+++ b/database/dex.hpp
@@ -1,0 +1,278 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_DEX_HPP
+#define DATABASE_DEX_HPP
+
+#include "amount.hpp"
+#include "database.hpp"
+#include "inventory.hpp"
+
+#include <memory>
+#include <string>
+
+namespace pxd
+{
+
+/**
+ * Database result type for rows from the dex-orders table.
+ */
+struct DexOrderResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, id, 1);
+  RESULT_COLUMN (int64_t, building, 2);
+  RESULT_COLUMN (std::string, account, 3);
+  RESULT_COLUMN (int64_t, type, 4);
+  RESULT_COLUMN (std::string, item, 5);
+  RESULT_COLUMN (int64_t, quantity, 6);
+  RESULT_COLUMN (int64_t, price, 7);
+};
+
+/**
+ * Wrapper class around a DEX order in the database.  Instances should be
+ * obtained through DexOrderTable.  Once created, instances are "mostly"
+ * immutable; only the order amount can be changed, which is what we need
+ * during partial order fill.
+ */
+class DexOrder
+{
+
+public:
+
+  /**
+   * Type of an order.  The numeric values match the values stored
+   * in the database integer field.
+   */
+  enum class Type
+  {
+    INVALID = 0,
+    BID = 1,
+    ASK = 2,
+  };
+
+private:
+
+  /** Database reference this belongs to.  */
+  Database& db;
+
+  /** The underlying ID in the database.  */
+  Database::IdT id;
+
+  /** The building this is in.  */
+  Database::IdT buildingId;
+
+  /** The account this belongs to.  */
+  std::string account;
+
+  /** Type of this order.  */
+  Type type;
+
+  /** The type of item.  */
+  std::string item;
+
+  /** The quantity of the item.  */
+  Quantity quantity;
+
+  /** The price in Cubits of one unit.  */
+  Amount price;
+
+  /** Whether or not this is a new instance.  */
+  bool isNew;
+
+  /** Whether or not this is an existing but dirty instance.  */
+  bool dirty;
+
+  /**
+   * Constructs a new instance with auto-generated ID meant to be inserted
+   * into the database.
+   */
+  explicit DexOrder (Database& d);
+
+  /**
+   * Constructs an instance based on the given DB result set.  The result
+   * set should be constructed by a DexOrderTable.
+   */
+  explicit DexOrder (Database& d,
+                     const Database::Result<DexOrderResult>& res);
+
+  friend class DexOrderTable;
+
+public:
+
+  /**
+   * In the destructor, the underlying database is updated if there are any
+   * modifications to send.
+   */
+  ~DexOrder ();
+
+  DexOrder () = delete;
+  DexOrder (const DexOrder&) = delete;
+  void operator= (const DexOrder&) = delete;
+
+  Database::IdT
+  GetId () const
+  {
+    return id;
+  }
+
+  Database::IdT
+  GetBuilding () const
+  {
+    return buildingId;
+  }
+
+  const std::string&
+  GetAccount () const
+  {
+    return account;
+  }
+
+  Type
+  GetType () const
+  {
+    return type;
+  }
+
+  const std::string&
+  GetItem () const
+  {
+    return item;
+  }
+
+  Quantity
+  GetQuantity () const
+  {
+    return quantity;
+  }
+
+  Amount
+  GetPrice () const
+  {
+    return price;
+  }
+
+  /**
+   * Updates the quantity by subtracting the given amount from it.  If this
+   * brings the quantity to zero, the order will be deleted from the DB.
+   */
+  void ReduceQuantity (Quantity q);
+
+  /**
+   * Marks this row to be deleted (which effectively means reducing the
+   * quantity to zero).
+   */
+  void Delete ();
+
+};
+
+/**
+ * Utility class that handles querying the table of DEX orders with the things
+ * needed, and also handles the creation of DexOrder instances.
+ */
+class DexOrderTable
+{
+
+private:
+
+  /** The Database reference for creating queries.  */
+  Database& db;
+
+public:
+
+  /** Movable handle to an instance.  */
+  using Handle = std::unique_ptr<DexOrder>;
+
+  explicit DexOrderTable (Database& d)
+    : db(d)
+  {}
+
+  DexOrderTable () = delete;
+  DexOrderTable (const DexOrderTable&) = delete;
+  void operator= (const DexOrderTable&) = delete;
+
+  /**
+   * Inserts a new entry into the database and returns a handle to it.
+   */
+  Handle CreateNew (Database::IdT building, const std::string& account,
+                    DexOrder::Type type, const std::string& item,
+                    Quantity quantity, Amount price);
+
+  /**
+   * Returns a handle for the instance based on a Database::Result.
+   */
+  Handle GetFromResult (const Database::Result<DexOrderResult>& res);
+
+  /**
+   * Returns a handle for the given ID (or null if it doesn't exist).
+   */
+  Handle GetById (Database::IdT id);
+
+  /**
+   * Queries the database for all orders in the entire game world.
+   */
+  Database::Result<DexOrderResult> QueryAll ();
+
+  /**
+   * Queries the database for all orders inside the given building.  The
+   * results are returned in a way that allows direct building up of
+   * order books.  For any (item, type) pair, the matching results
+   * will be sorted increasing by price.
+   */
+  Database::Result<DexOrderResult> QueryForBuilding (Database::IdT building);
+
+  /**
+   * Queries the database for all sell orders of a given building and item,
+   * where prices are not higher than the limit.  They will be returned sorted
+   * by increasing price (and ID as tie breaker).  This is the query one
+   * needs for matching a new bid.
+   */
+  Database::Result<DexOrderResult> QueryToMatchBid (
+      Database::IdT building, const std::string& item, Amount limitPrice);
+
+  /**
+   * Queries for all buy orders, similar to QueryToMatchBid.  The
+   * results are returned ordered by decreasing price until the limit.
+   * This is what one needs to match a new ask.
+   */
+  Database::Result<DexOrderResult> QueryToMatchAsk (
+      Database::IdT building, const std::string& item, Amount limitPrice);
+
+  /**
+   * Returns the reserved Cubits per account inside the given building
+   * or the entire game world if building is EMPTY_ID.
+   */
+  std::map<std::string, Amount> GetReservedCoins (
+      Database::IdT building = Database::EMPTY_ID) const;
+
+  /**
+   * Returns the reserved item quantities (from open bids) of all accounts
+   * inside a given building.
+   */
+  std::map<std::string, Inventory> GetReservedQuantities (
+      Database::IdT building) const;
+
+  /**
+   * Deletes all orders of a given building.
+   */
+  void DeleteForBuilding (Database::IdT building);
+
+};
+
+} // namespace pxd
+
+#endif // DATABASE_DEX_HPP

--- a/database/dex_tests.cpp
+++ b/database/dex_tests.cpp
@@ -1,0 +1,267 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "dex.hpp"
+
+#include "dbtest.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+using testing::ElementsAre;
+using testing::Pair;
+
+/* ************************************************************************** */
+
+class DexOrderTests : public DBTestWithSchema
+{
+
+protected:
+
+  DexOrderTable orders;
+
+  DexOrderTests ()
+    : orders(db)
+  {}
+
+};
+
+TEST_F (DexOrderTests, Creation)
+{
+  auto o = orders.CreateNew (123, "domob", DexOrder::Type::BID, "sword",
+                             10, 100);
+  const auto id1 = o->GetId ();
+  o.reset ();
+
+  o = orders.CreateNew (456, "andy", DexOrder::Type::ASK, "bow", 1, 255);
+  const auto id2 = o->GetId ();
+  o.reset ();
+
+  o = orders.GetById (id1);
+  EXPECT_EQ (o->GetBuilding (), 123);
+  EXPECT_EQ (o->GetAccount (), "domob");
+  EXPECT_EQ (o->GetType (), DexOrder::Type::BID);
+  EXPECT_EQ (o->GetItem (), "sword");
+  EXPECT_EQ (o->GetQuantity (), 10);
+  EXPECT_EQ (o->GetPrice (), 100);
+
+  o = orders.GetById (id2);
+  EXPECT_EQ (o->GetBuilding (), 456);
+  EXPECT_EQ (o->GetAccount (), "andy");
+  EXPECT_EQ (o->GetType (), DexOrder::Type::ASK);
+  EXPECT_EQ (o->GetItem (), "bow");
+  EXPECT_EQ (o->GetQuantity (), 1);
+  EXPECT_EQ (o->GetPrice (), 255);
+}
+
+TEST_F (DexOrderTests, QuantityReduction)
+{
+  auto o = orders.CreateNew (123, "domob", DexOrder::Type::BID, "sword",
+                             10, 100);
+  const auto id = o->GetId ();
+  o->ReduceQuantity (2);
+  o.reset ();
+
+  o = orders.GetById (id);
+  EXPECT_EQ (o->GetQuantity (), 8);
+  o->ReduceQuantity (5);
+  o.reset ();
+
+  o = orders.GetById (id);
+  EXPECT_EQ (o->GetQuantity (), 3);
+  o->ReduceQuantity (3);
+  o.reset ();
+
+  EXPECT_EQ (orders.GetById (id), nullptr);
+}
+
+TEST_F (DexOrderTests, ExplicitDelete)
+{
+  db.SetNextId (101);
+
+  auto o = orders.CreateNew (123, "domob", DexOrder::Type::BID, "sword",
+                             10, 100);
+  EXPECT_EQ (o->GetId (), 101);
+  o.reset ();
+
+  o = orders.CreateNew (42, "deleted", DexOrder::Type::ASK, "sword", 1, 2);
+  EXPECT_EQ (o->GetId (), 102);
+  o->Delete ();
+  o.reset ();
+
+  o = orders.CreateNew (456, "andy", DexOrder::Type::ASK, "bow", 1, 255);
+  EXPECT_EQ (o->GetId (), 103);
+  o.reset ();
+
+  o = orders.GetById (103);
+  o->Delete ();
+  o.reset ();
+
+  EXPECT_EQ (orders.GetById (102), nullptr);
+  EXPECT_EQ (orders.GetById (103), nullptr);
+
+  o = orders.GetById (101);
+  ASSERT_NE (o, nullptr);
+  EXPECT_EQ (o->GetAccount (), "domob");
+  o.reset ();
+}
+
+/* ************************************************************************** */
+
+class DexOrderTableTests : public DexOrderTests
+{
+
+protected:
+
+  DexOrderTableTests ()
+  {
+    db.SetNextId (101);
+  }
+
+  /**
+   * Expects that the result contains exactly the orders with the given
+   * expected IDs (in order).
+   */
+  void
+  ExpectOrderIds (Database::Result<DexOrderResult>&& res,
+                  const std::vector<Database::IdT>& expectedIds)
+  {
+    for (const auto id : expectedIds)
+      {
+        ASSERT_TRUE (res.Step ()) << "Expected ID " << id << ", got end";
+        ASSERT_EQ (orders.GetFromResult (res)->GetId (), id);
+      }
+    ASSERT_FALSE (res.Step ()) << "Expected end, but there are more results";
+  }
+
+};
+
+TEST_F (DexOrderTableTests, QueryAll)
+{
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 5, 10);
+  orders.CreateNew (20, "andy", DexOrder::Type::ASK, "sword", 1, 20);
+  orders.CreateNew (10, "andy", DexOrder::Type::BID, "sword", 1, 5);
+
+  ExpectOrderIds (orders.QueryAll (), {101, 102, 103});
+}
+
+TEST_F (DexOrderTableTests, QueryForBuilding)
+{
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 5, 10);
+  orders.CreateNew (20, "andy", DexOrder::Type::ASK, "sword", 1, 20);
+  orders.CreateNew (10, "andy", DexOrder::Type::BID, "sword", 1, 5);
+
+  ExpectOrderIds (orders.QueryForBuilding (10), {103, 101});
+  ExpectOrderIds (orders.QueryForBuilding (20), {102});
+  ExpectOrderIds (orders.QueryForBuilding (42), {});
+}
+
+TEST_F (DexOrderTableTests, DeleteForBuilding)
+{
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 5, 10);
+  orders.CreateNew (20, "andy", DexOrder::Type::ASK, "sword", 1, 20);
+  orders.CreateNew (10, "andy", DexOrder::Type::BID, "sword", 1, 5);
+
+  orders.DeleteForBuilding (42);
+  orders.DeleteForBuilding (10);
+
+  EXPECT_EQ (orders.GetById (101), nullptr);
+  EXPECT_NE (orders.GetById (102), nullptr);
+  EXPECT_EQ (orders.GetById (103), nullptr);
+
+  orders.DeleteForBuilding (20);
+  EXPECT_EQ (orders.GetById (102), nullptr);
+}
+
+TEST_F (DexOrderTableTests, QueryToMatch)
+{
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 1, 1);
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 1, 2);
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 1, 2);
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 1, 3);
+
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "sword", 1, 30);
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "sword", 1, 20);
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "sword", 1, 20);
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "sword", 1, 10);
+
+  orders.CreateNew (20, "domob", DexOrder::Type::BID, "sword", 1, 5);
+  orders.CreateNew (20, "domob", DexOrder::Type::ASK, "sword", 1, 6);
+
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "bow", 1, 5);
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "bow", 1, 6);
+
+  ExpectOrderIds (orders.QueryToMatchBid (10, "sword", 20), {108, 106, 107});
+  ExpectOrderIds (orders.QueryToMatchAsk (10, "sword", 2), {104, 102, 103});
+}
+
+TEST_F (DexOrderTableTests, ReservedCoins)
+{
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 2, 3);
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "bow", 4, 1);
+  orders.CreateNew (20, "domob", DexOrder::Type::BID, "sword", 1, 1);
+  orders.CreateNew (10, "andy", DexOrder::Type::BID, "sword", 6, 7);
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "sword", 10, 10);
+
+  EXPECT_THAT (orders.GetReservedCoins (), ElementsAre (
+    Pair ("andy", 42),
+    Pair ("domob", 11)
+  ));
+  EXPECT_THAT (orders.GetReservedCoins (10), ElementsAre (
+    Pair ("andy", 42),
+    Pair ("domob", 10)
+  ));
+  EXPECT_THAT (orders.GetReservedCoins (20), ElementsAre (Pair ("domob", 1)));
+  EXPECT_THAT (orders.GetReservedCoins (42), ElementsAre ());
+}
+
+TEST_F (DexOrderTableTests, ReservedQuantities)
+{
+  orders.CreateNew (10, "domob", DexOrder::Type::BID, "sword", 2, 3);
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "sword", 2, 3);
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "sword", 1, 5);
+  orders.CreateNew (10, "andy", DexOrder::Type::ASK, "zerospace", 1, 1);
+  orders.CreateNew (10, "domob", DexOrder::Type::ASK, "bow", 10, 1);
+  orders.CreateNew (20, "domob", DexOrder::Type::ASK, "zerospace", 1, 1);
+
+  Inventory invA, invB;
+  invA.AddFungibleCount ("sword", 3);
+  invA.AddFungibleCount ("bow", 10);
+  invB.AddFungibleCount ("zerospace", 1);
+
+  auto reserved = orders.GetReservedQuantities (10);
+  ASSERT_EQ (reserved.size (), 2);
+  EXPECT_EQ (reserved["domob"], invA);
+  EXPECT_EQ (reserved["andy"], invB);
+
+  reserved = orders.GetReservedQuantities (20);
+  ASSERT_EQ (reserved.size (), 1);
+  EXPECT_EQ (reserved["domob"], invB);
+
+  EXPECT_TRUE (orders.GetReservedQuantities (42).empty ());
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace pxd

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -386,6 +386,45 @@ CREATE INDEX IF NOT EXISTS `dex_orders_by_building`
 CREATE INDEX IF NOT EXISTS `dex_orders_by_price`
   ON `dex_orders` (`building`, `item`, `type`, `price`, `id`);
 
+-- Log table of all executed trades.  This is only written and never
+-- read during the state transition, so it is purely here to be queried
+-- by RPC and won't affect consensus.
+CREATE TABLE IF NOT EXISTS `dex_trade_history` (
+
+  -- The log ID of the trade, which is just there to order them by
+  -- creation time.
+  `id` INTEGER PRIMARY KEY,
+
+  -- The block height of the trade.
+  `height` INTEGER NOT NULL,
+
+  -- The block timestamp of the trade.
+  `time` INTEGER NOT NULL,
+
+  -- The building in which the trade took place.
+  `building` INTEGER NOT NULL,
+
+  -- The item traded.
+  `item` TEXT NOT NULL,
+
+  -- The traded quantity.
+  `quantity` INTEGER NOT NULL,
+
+  -- The trade price per unit.
+  `price` INTEGER NOT NULL,
+
+  -- The seller account.
+  `seller` TEXT NOT NULL,
+
+  -- The buyer account.
+  `buyer` TEXT NOT NULL
+
+);
+
+-- Querying of the price history by item and optionally building.
+CREATE INDEX IF NOT EXISTS `dex_trade_history_by_item_building`
+  ON `dex_trade_history` (`item`, `building`, `id`);
+
 -- =============================================================================
 
 -- Data about counts of items found for a particular type already (for

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -23,6 +23,7 @@ REGTESTS = \
   combat_friendly.py \
   combat_targets.py \
   damage_lists.py \
+  dex.py \
   fame.py \
   findpath.py \
   fork_gamestart.py \

--- a/gametest/dex.py
+++ b/gametest/dex.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests DEX operations (trading of assets inside buildings).
+"""
+
+from pxtest import PXTest
+
+
+class DexTest (PXTest):
+
+  def expectBalances (self, expected):
+    """
+    Verifies that a set of accounts has given balances, as stated
+    in the dictionary passed in.  The expected value may be a tuple,
+    in which case it is (available, reserved).  If it is just a number,
+    then we expect the reserved balance to be zero.
+    """
+
+    acc = self.getAccounts ()
+    for k, v in expected.items ():
+      if type (v) == tuple:
+        expectedAvailable, expectedReserved = v
+      else:
+        expectedAvailable = v
+        expectedReserved = 0
+
+      if k not in acc:
+        self.assertEqual (expectedAvailable, 0)
+        self.assertEqual (expectedReserved, 0)
+      else:
+        self.assertEqual (acc[k].getBalance ("available"), expectedAvailable)
+        self.assertEqual (acc[k].getBalance ("reserved"), expectedReserved)
+        total = expectedAvailable + expectedReserved
+        self.assertEqual (acc[k].getBalance ("total"), total)
+
+  def expectItems (self, building, account, expected):
+    """
+    Checks that the item balances reported for a given account inside
+    some building match the expectations.  The expected values can
+    be tuples (available, reserved) or single numbers; if they are just
+    numbers, the reserved value is assumed zero.
+    """
+
+    b = self.getBuildings ()[building]
+    invAvailable = b.getFungibleInventory (account, "available")
+    invReserved = b.getFungibleInventory (account, "reserved")
+
+    for k, v in expected.items ():
+      if type (v) == tuple:
+        self.assertEqual ((invAvailable[k], invReserved[k]), v)
+      else:
+        self.assertEqual (invAvailable[k], v)
+        self.assertEqual (invReserved[k], 0)
+
+  def run (self):
+    self.collectPremine ()
+    self.splitPremine ()
+
+    self.mainLogger.info ("Setting up test situation...")
+    # No need to initialise accounts.  DEX operations also work
+    # without a chosen faction.  Only the building owner has to
+    # have a faction.
+    self.initAccount ("building", "r")
+    self.generate (1)
+    self.build ("checkmark", "building", {"x": 0, "y": 0}, rot=0)
+    buildings = self.getBuildings ()
+    self.buildingId = max (buildings.keys ())
+    self.assertEqual (buildings[self.buildingId].getOwner (), "building")
+    buildings[self.buildingId].sendMove ({"xf": 1_000})
+    self.giftCoins ({"buyer": 1_000})
+    self.dropIntoBuilding (self.buildingId, "seller", {"foo": 10, "bar": 20})
+
+    self.generate (1)
+    reorgBlk = self.rpc.xaya.getbestblockhash ()
+
+    self.mainLogger.info ("Transferring assets...")
+    self.sendMove ("seller", {"x": [{
+      "b": self.buildingId,
+      "i": "bar",
+      "n": 5,
+      "t": "gifted",
+    }]})
+    self.generate (1)
+    self.expectBalances ({
+      "buyer": 1_000,
+      "seller": 0,
+      "building": 0,
+      "gifted": 0,
+    })
+    self.expectItems (self.buildingId, "buyer", {"foo": 0, "bar": 0})
+    self.expectItems (self.buildingId, "seller", {"foo": 10, "bar": 15})
+    self.expectItems (self.buildingId, "gifted", {"foo": 0, "bar": 5})
+
+    self.mainLogger.info ("Placing orders...")
+    firstOrderId = self.buildingId + 1
+    self.sendMove ("seller", {"x": [
+      {
+        "b": self.buildingId,
+        "i": "foo",
+        "n": 2,
+        "ap": 100,
+      },
+      {
+        "b": self.buildingId,
+        "i": "foo",
+        "n": 2,
+        "ap": 50,
+      },
+    ]})
+    # Make sure the two name updates are confirmed in the intended order
+    # relative to each other (otherwise the IDs get messed up).
+    self.generate (1)
+    self.sendMove ("buyer", {"x": [
+      {
+        "b": self.buildingId,
+        "i": "foo",
+        "n": 1,
+        "bp": 10,
+      },
+      {
+        "b": self.buildingId,
+        "i": "foo",
+        "n": 1,
+        "bp": 20,
+      },
+    ]})
+    self.generate (1)
+    self.expectBalances ({
+      "buyer": (970, 30),
+      "seller": 0,
+      "building": 0,
+    })
+    self.expectItems (self.buildingId, "buyer", {"foo": 0})
+    self.expectItems (self.buildingId, "seller", {"foo": (6, 4)})
+    self.assertEqual (self.getBuildings ()[self.buildingId].getOrderbook (), {
+      "foo":
+        {
+          "item": "foo",
+          "bids":
+            [
+              {
+                "id": firstOrderId + 3,
+                "account": "buyer",
+                "price": 20,
+                "quantity": 1,
+              },
+              {
+                "id": firstOrderId + 2,
+                "account": "buyer",
+                "price": 10,
+                "quantity": 1,
+              },
+            ],
+          "asks":
+            [
+              {
+                "id": firstOrderId + 1,
+                "account": "seller",
+                "price": 50,
+                "quantity": 2,
+              },
+              {
+                "id": firstOrderId + 0,
+                "account": "seller",
+                "price": 100,
+                "quantity": 2,
+              },
+            ],
+        },
+    })
+
+    self.mainLogger.info ("Cancelling orders...")
+    self.sendMove ("buyer", {"x": [{"c": firstOrderId + 3}]})
+    self.sendMove ("seller", {"x": [{"c": firstOrderId + 1}]})
+    self.generate (1)
+    self.expectBalances ({
+      "buyer": (990, 10),
+      "seller": 0,
+      "building": 0,
+    })
+    self.expectItems (self.buildingId, "buyer", {"foo": 0})
+    self.expectItems (self.buildingId, "seller", {"foo": (8, 2)})
+    self.assertEqual (self.getBuildings ()[self.buildingId].getOrderbook (), {
+      "foo":
+        {
+          "item": "foo",
+          "bids":
+            [
+              {
+                "id": firstOrderId + 2,
+                "account": "buyer",
+                "price": 10,
+                "quantity": 1,
+              },
+            ],
+          "asks":
+            [
+              {
+                "id": firstOrderId + 0,
+                "account": "seller",
+                "price": 100,
+                "quantity": 2,
+              },
+            ],
+        },
+    })
+
+    self.mainLogger.info ("Partially filling orders...")
+    self.sendMove ("seller", {"x": [
+      {
+        "b": self.buildingId,
+        "i": "foo",
+        "n": 2,
+        "ap": 0,
+      },
+    ]})
+    self.generate (1)
+    blk1 = self.rpc.xaya.getblockheader (self.rpc.xaya.getbestblockhash ())
+    self.sendMove ("buyer", {"x": [
+      {
+        "b": self.buildingId,
+        "i": "foo",
+        "n": 4,
+        "bp": 200,
+      },
+    ]})
+    self.generate (1)
+    blk2 = self.rpc.xaya.getblockheader (self.rpc.xaya.getbestblockhash ())
+    self.expectBalances ({
+      "buyer": (590, 200),
+      "seller": 210 - 2 * 21,
+      "building": 21,
+    })
+    self.expectItems (self.buildingId, "buyer", {"foo": 4})
+    self.expectItems (self.buildingId, "seller", {"foo": 6})
+    self.assertEqual (self.getBuildings ()[self.buildingId].getOrderbook (), {
+      "foo":
+        {
+          "item": "foo",
+          "bids":
+            [
+              {
+                "id": firstOrderId + 5,
+                "account": "buyer",
+                "price": 200,
+                "quantity": 1,
+              },
+            ],
+          # The remaining ask at zero was filled with the subsequent
+          # buy order.
+          "asks": [],
+        },
+    })
+
+    self.mainLogger.info ("Checking trade history...")
+    self.assertEqual (self.getRpc ("gettradehistory",
+                                   item="foo", building=self.buildingId), [
+      {
+        "height": blk1["height"],
+        "timestamp": blk1["time"],
+        "buildingid": self.buildingId,
+        "item": "foo",
+        "price": 10,
+        "quantity": 1,
+        "cost": 10,
+        "seller": "seller",
+        "buyer": "buyer",
+      },
+      {
+        "height": blk2["height"],
+        "timestamp": blk2["time"],
+        "buildingid": self.buildingId,
+        "item": "foo",
+        "price": 0,
+        "quantity": 1,
+        "cost": 0,
+        "seller": "seller",
+        "buyer": "buyer",
+      },
+      {
+        "height": blk2["height"],
+        "timestamp": blk2["time"],
+        "buildingid": self.buildingId,
+        "item": "foo",
+        "price": 100,
+        "quantity": 2,
+        "cost": 200,
+        "seller": "seller",
+        "buyer": "buyer",
+      },
+    ])
+
+    self.testReorg (reorgBlk)
+
+  def testReorg (self, blk):
+    self.mainLogger.info ("Testing reorg...")
+
+    originalState = self.getGameState ()
+    originalHistory = self.getRpc ("gettradehistory",
+                                   item="foo", building=self.buildingId)
+    self.rpc.xaya.invalidateblock (blk)
+
+    self.expectBalances ({
+      "buyer": 1_000,
+      "seller": 0,
+      "building": 0,
+      "gifted": 0,
+    })
+    self.expectItems (self.buildingId, "buyer", {"foo": 0, "bar": 0})
+    self.expectItems (self.buildingId, "seller", {"foo": 10, "bar": 20})
+    self.expectItems (self.buildingId, "gifted", {"foo": 0, "bar": 0})
+    self.assertEqual (self.getBuildings ()[self.buildingId].getOrderbook (), {})
+    self.assertEqual (self.getRpc ("gettradehistory",
+                                   item="foo", building=self.buildingId),
+                      [])
+
+    self.rpc.xaya.reconsiderblock (blk)
+    self.expectGameState (originalState)
+    self.assertEqual (self.getRpc ("gettradehistory",
+                                   item="foo", building=self.buildingId),
+                      originalHistory)
+
+
+if __name__ == "__main__":
+  DexTest ().main ()

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -67,6 +67,8 @@ class GodModeTest (PXTest):
             },
         },
       "inventories": {},
+      "reserved": {},
+      "orderbook": {},
     })
     self.assertEqual (buildings[1003].data, {
       "id": 1003,
@@ -94,6 +96,8 @@ class GodModeTest (PXTest):
             },
         },
       "inventories": {},
+      "reserved": {},
+      "orderbook": {},
     })
 
     self.mainLogger.info ("Testing teleport...")

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -49,6 +49,7 @@ class GodModeTest (PXTest):
       "centre": {"x": 100, "y": 150},
       "rotationsteps": 2,
       "servicefee": 0,
+      "dexfee": 0.0,
       "age": {"founded": height + 1, "finished": height + 1},
       "tiles":
         [
@@ -78,6 +79,7 @@ class GodModeTest (PXTest):
       "centre": {"x": -100, "y": -150},
       "rotationsteps": 0,
       "servicefee": 0,
+      "dexfee": 0.0,
       "age": {"founded": height + 2, "finished": height + 2},
       "tiles":
         [

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -158,6 +158,12 @@ class PendingTest (PXTest):
     }, burn=0.01)
     self.sendMove ("andy", {
       "s": [{"b": building, "t": "ref", "i": "test ore", "n": 9}],
+      "x":
+        [
+          # The first one is invalid (insufficient balance).
+          {"b": building, "i": "foo", "n": 1_000, "bp": 10},
+          {"b": building, "i": "foo", "n": 1, "bp": 0},
+        ],
     })
 
     sleepSome ()
@@ -208,6 +214,16 @@ class PendingTest (PXTest):
                   "input": {"test ore": 9},
                   "output": {"bar": 6, "zerospace": 3},
                 }
+              ],
+            "dexops":
+              [
+                {
+                  "op": "bid",
+                  "building": building,
+                  "item": "foo",
+                  "num": 1,
+                  "price": 0,
+                },
               ],
           },
           {

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -247,8 +247,8 @@ class Account (object):
       return self.data["faction"]
     return None
 
-  def getBalance (self):
-    return self.data["balance"]
+  def getBalance (self, type="available"):
+    return self.data["balance"][type]
 
 
 class Region (object):

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -214,11 +214,21 @@ class Building (object):
     constr = self.data["construction"]
     return collections.Counter (constr["inventory"]["fungible"])
 
-  def getFungibleInventory (self, account):
-    inv = self.data["inventories"]
+  def getFungibleInventory (self, account, type="available"):
+    if type == "available":
+      key = "inventories"
+    elif type == "reserved":
+      key = "reserved"
+    else:
+      raise AssertionError (f"Unexpected type argument: {type}")
+
+    inv = self.data[key]
     if account not in inv:
       return collections.Counter ()
     return collections.Counter (inv[account]["fungible"])
+
+  def getOrderbook (self):
+    return self.data["orderbook"]
 
   def sendMove (self, mv):
     """

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -80,6 +80,13 @@ message Building
   optional uint32 service_fee_percent = 6;
 
   /**
+   * The fee charged by the building owner for trades on the building's DEX.
+   * This is in basis points (1/100 of a percent) and paid by the seller
+   * from the received Cubits.
+   */
+  optional int32 dex_fee_bps = 7;
+
+  /**
    * Data about the building age, i.e. the block heights when it was founded
    * and finished.
    */
@@ -95,6 +102,6 @@ message Building
   }
 
   /** Age data for this building.  */
-  optional AgeData age_data = 7;
+  optional AgeData age_data = 8;
 
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -553,22 +553,25 @@ message Params
   /** Nubmer of blocks for constructing an item, per complexity.  */
   optional uint32 construction_blocks = 11;
 
+  /** Base fee (which is burnt) paid by sellers on the DEX in basis points.  */
+  optional uint32 dex_fee_bps = 12;
+
   /** Minimum units of ore found in a prospected region.  */
-  optional int64 min_region_ore = 12;
+  optional int64 min_region_ore = 13;
   /** Maximum units of ore found in a prospected region.  */
-  optional int64 max_region_ore = 13;
+  optional int64 max_region_ore = 14;
 
   /** The address to which developer payments should be sent.  */
-  optional string dev_addr = 14;
+  optional string dev_addr = 15;
 
   /** Whether or not god mode is enabled.  */
-  optional bool god_mode = 15;
+  optional bool god_mode = 16;
 
   /** Spawn areas for the factions (with the "r", "g", "b" string as key).  */
-  map<string, SpawnArea> spawn_areas = 16;
+  map<string, SpawnArea> spawn_areas = 17;
 
   /** Data about the burnsale schedule.  */
-  repeated BurnsaleStage burnsale_stages = 17;
+  repeated BurnsaleStage burnsale_stages = 18;
 
   /**
    * Prospecting prizes.  They are just a list and not a map, because the
@@ -578,7 +581,7 @@ message Params
    * It is replaced rather than concatenated (which would be the default
    * behaviour for proto merge).
    */
-  repeated ProspectingPrize prizes = 18;
+  repeated ProspectingPrize prizes = 19;
 
 }
 

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -15,6 +15,8 @@ params:
     construction_cost: 1
     construction_blocks: 1
 
+    dex_fee_bps: 300  # 3% base fee for sellers
+
     min_region_ore: 2000000
     max_region_ore: 100000000
 

--- a/proto/roconfig/test_params.pb.text
+++ b/proto/roconfig/test_params.pb.text
@@ -9,6 +9,7 @@ params:
     bp_copy_blocks: 10
     construction_cost: 100
     construction_blocks: 10
+    dex_fee_bps: 1000  # 10% base fee for simpler numbers
 
     # We have tests that use up all materials (and then reprospect a region),
     # so that we need lower limits than on mainnet.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,8 @@ libtaurion_la_SOURCES = \
   protoutils.cpp \
   resourcedist.cpp \
   services.cpp \
-  spawn.cpp
+  spawn.cpp \
+  trading.cpp
 libtaurionheaders = \
   buildings.hpp \
   burnsale.hpp \
@@ -71,7 +72,8 @@ libtaurionheaders = \
   protoutils.hpp \
   resourcedist.hpp \
   services.hpp \
-  spawn.hpp
+  spawn.hpp \
+  trading.hpp
 
 tauriond_CXXFLAGS = \
   -I$(top_srcdir) \
@@ -154,7 +156,8 @@ tests_SOURCES = \
   resourcedist_tests.cpp \
   services_tests.cpp \
   spawn_tests.cpp \
-  testutils_tests.cpp
+  testutils_tests.cpp \
+  trading_tests.cpp
 check_HEADERS = \
   fame_tests.hpp \
   \

--- a/src/charon.cpp
+++ b/src/charon.cpp
@@ -118,6 +118,7 @@ const std::map<std::string, PXRpcMethod> CHARON_METHODS = {
   {"getregions", &PXRpcServer::getregionsI},
   {"getmoneysupply", &PXRpcServer::getmoneysupplyI},
   {"getprizestats", &PXRpcServer::getprizestatsI},
+  {"gettradehistory", &PXRpcServer::gettradehistoryI},
 
   {"getserviceinfo", &PXRpcServer::getserviceinfoI},
 

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -412,6 +412,7 @@ template <>
 
   res["rotationsteps"] = IntToJson (pb.shape_trafo ().rotation_steps ());
   res["servicefee"] = IntToJson (pb.service_fee_percent ());
+  res["dexfee"] = pb.dex_fee_bps () / 100.0;
 
   Json::Value tiles(Json::arrayValue);
   for (const auto& c : GetBuildingShape (b, ctx))

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -587,6 +587,29 @@ template <>
   return res;
 }
 
+template <>
+  Json::Value
+  GameStateJson::Convert<DexTrade> (const DexTrade& t) const
+{
+  Json::Value res(Json::objectValue);
+
+  res["height"] = IntToJson (t.GetHeight ());
+  res["timestamp"] = IntToJson (t.GetTimestamp ());
+
+  res["buildingid"] = IntToJson (t.GetBuilding ());
+  res["item"] = t.GetItem ();
+
+  res["quantity"] = t.GetQuantity ();
+  res["price"] = t.GetPrice ();
+  const QuantityProduct cost(t.GetQuantity (), t.GetPrice ());
+  res["cost"] = IntToJson (cost.Extract ());
+
+  res["seller"] = t.GetSeller ();
+  res["buyer"] = t.GetBuyer ();
+
+  return res;
+}
+
 template <typename T, typename R>
   Json::Value
   GameStateJson::ResultsAsArray (T& tbl, Database::Result<R> res) const
@@ -737,6 +760,14 @@ GameStateJson::Regions (const unsigned h)
 {
   RegionsTable tbl(db, RegionsTable::HEIGHT_READONLY);
   return ResultsAsArray (tbl, tbl.QueryModifiedSince (h));
+}
+
+Json::Value
+GameStateJson::TradeHistory (const std::string& item,
+                             const Database::IdT building)
+{
+  DexHistoryTable tbl(db);
+  return ResultsAsArray (tbl, tbl.QueryForItem (item, building));
 }
 
 Json::Value

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -35,6 +35,8 @@
 #include "hexagonal/pathfinder.hpp"
 #include "proto/character.pb.h"
 
+#include <algorithm>
+
 namespace pxd
 {
 
@@ -308,8 +310,11 @@ template <>
 
   Json::Value res(Json::objectValue);
   res["name"] = a.GetName ();
-  res["balance"] = IntToJson (a.GetBalance ());
   res["minted"] = IntToJson (pb.burnsale_balance ());
+
+  Json::Value bal(Json::objectValue);
+  bal["available"] = IntToJson (a.GetBalance ());
+  res["balance"] = bal;
 
   if (a.IsInitialised ())
     {
@@ -320,6 +325,73 @@ template <>
 
   return res;
 }
+
+namespace
+{
+
+/**
+ * Builds up the orderbook of the DEX inside a given building and returns
+ * it as JSON.
+ */
+Json::Value
+GetOrderbookInBuilding (DexOrderTable& orders, const Database::IdT building)
+{
+  Json::Value book(Json::objectValue);
+
+  auto res = orders.QueryForBuilding (building);
+  while (res.Step ())
+    {
+      const auto o = orders.GetFromResult (res);
+
+      if (!book.isMember (o->GetItem ()))
+        {
+          Json::Value freshItem(Json::objectValue);
+          freshItem["item"] = o->GetItem ();
+          freshItem["bids"] = Json::Value (Json::arrayValue);
+          freshItem["asks"] = Json::Value (Json::arrayValue);
+          book[o->GetItem ()] = freshItem;
+        }
+      auto& itm = book[o->GetItem ()];
+      CHECK (itm.isObject ());
+
+      Json::Value cur(Json::objectValue);
+      cur["id"] = IntToJson (o->GetId ());
+      cur["account"] = o->GetAccount ();
+      cur["quantity"] = IntToJson (o->GetQuantity ());
+      cur["price"] = IntToJson (o->GetPrice ());
+
+      std::string key;
+      switch (o->GetType ())
+        {
+        case DexOrder::Type::BID:
+          key = "bids";
+          break;
+        case DexOrder::Type::ASK:
+          key = "asks";
+          break;
+        default:
+          LOG (FATAL)
+              << "Invalid order type: " << static_cast<int> (o->GetType ());
+        }
+
+      auto& orders = itm[key];
+      CHECK (orders.isArray ());
+      orders.append (cur);
+    }
+
+  /* QueryForBuilding orders the results increasing by price.  This means that
+     we want to reverse the order of all bids (so the best is listed first).  */
+  for (auto it = book.begin (); it != book.end (); ++it)
+    {
+      auto& bids = (*it)["bids"];
+      CHECK (bids.isArray ());
+      std::reverse (bids.begin (), bids.end ());
+    }
+
+  return book;
+}
+
+} // anonymous namespace
 
 template <>
   Json::Value
@@ -366,6 +438,13 @@ template <>
           inv[h->GetAccount ()] = Convert (h->GetInventory ());
         }
       res["inventories"] = inv;
+
+      Json::Value reserved(Json::objectValue);
+      for (const auto& entry : orders.GetReservedQuantities (b.GetId ()))
+        reserved[entry.first] = Convert (entry.second);
+      res["reserved"] = reserved;
+
+      res["orderbook"] = GetOrderbookInBuilding (orders, b.GetId ());
     }
 
   Json::Value age(Json::objectValue);
@@ -599,7 +678,29 @@ Json::Value
 GameStateJson::Accounts ()
 {
   AccountsTable tbl(db);
-  return ResultsAsArray (tbl, tbl.QueryAll ());
+  Json::Value res = ResultsAsArray (tbl, tbl.QueryAll ());
+
+  /* Add in also the Cubit balances reserved in open bids.  */
+  const auto reserved = orders.GetReservedCoins ();
+  for (auto& entry : res)
+    {
+      const auto& nmVal = entry["name"];
+      CHECK (nmVal.isString ());
+      const auto mit = reserved.find (nmVal.asString ());
+
+      Amount cur;
+      if (mit == reserved.end ())
+        cur = 0;
+      else
+        cur = mit->second;
+
+      auto& bal = entry["balance"];
+      CHECK (bal.isObject ());
+      bal["reserved"] = IntToJson (cur);
+      bal["total"] = IntToJson (cur + bal["available"].asInt64 ());
+    }
+
+  return res;
 }
 
 Json::Value

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -23,6 +23,7 @@
 
 #include "database/damagelists.hpp"
 #include "database/database.hpp"
+#include "database/dex.hpp"
 #include "database/inventory.hpp"
 #include "mapdata/basemap.hpp"
 
@@ -52,6 +53,12 @@ private:
   /** Damage lists accessor (for adding the attackers to a character JSON).  */
   const DamageLists dl;
 
+  /**
+   * Database table for DEX orders.  This is also used from the "convert"
+   * function for buildings.
+   */
+  mutable DexOrderTable orders;
+
   /** Current parameter context.  */
   const Context& ctx;
 
@@ -65,7 +72,7 @@ private:
 public:
 
   explicit GameStateJson (Database& d, const Context& c)
-    : db(d), buildingInventories(db), dl(db), ctx(c)
+    : db(d), buildingInventories(db), dl(db), orders(db), ctx(c)
   {}
 
   GameStateJson () = delete;

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -129,6 +129,11 @@ public:
   Json::Value PrizeStats ();
 
   /**
+   * Returns the trade history for a given item and building.
+   */
+  Json::Value TradeHistory (const std::string& item, Database::IdT building);
+
+  /**
    * Returns the full game state JSON for the given Database handle.  The full
    * game state as JSON should mainly be used for debugging and testing, not
    * in production.  For that, more targeted RPC results should be used.

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -870,11 +870,10 @@ TEST_F (BuildingJsonTests, Orderbook)
   })");
 }
 
-TEST_F (BuildingJsonTests, ServiceFees)
+TEST_F (BuildingJsonTests, ConfiguredFees)
 {
   auto b = tbl.CreateNew ("checkmark", "daniel", Faction::RED);
   ASSERT_EQ (b->GetId (), 1);
-  b->MutableProto ().set_service_fee_percent (42);
   b.reset ();
 
   ExpectStateJson (R"({
@@ -882,7 +881,24 @@ TEST_F (BuildingJsonTests, ServiceFees)
       [
         {
           "id": 1,
-          "servicefee": 42
+          "servicefee": 0,
+          "dexfee": 0.0
+        }
+      ]
+  })");
+
+  b = tbl.GetById (1);
+  b->MutableProto ().set_service_fee_percent (42);
+  b->MutableProto ().set_dex_fee_bps (1'725);
+  b.reset ();
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "servicefee": 42,
+          "dexfee": 17.25
         }
       ]
   })");

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -26,6 +26,7 @@
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
+#include "database/dex.hpp"
 #include "database/inventory.hpp"
 #include "database/itemcounts.hpp"
 #include "database/moneysupply.hpp"
@@ -568,11 +569,34 @@ TEST_F (AccountJsonTests, UninitialisedBalance)
   a->AddBalance (42);
   a.reset ();
 
+  DexOrderTable orders(db);
+  orders.CreateNew (5, "bar", DexOrder::Type::BID, "foo", 2, 3);
+
   ExpectStateJson (R"({
     "accounts":
       [
-        {"name": "bar", "faction": null, "balance": 42, "minted": 10},
-        {"name": "foo", "faction": "r", "balance": 0, "minted": 0}
+        {
+          "name": "bar",
+          "faction": null,
+          "balance":
+            {
+              "available": 42,
+              "reserved": 6,
+              "total": 48
+            },
+          "minted": 10
+        },
+        {
+          "name": "foo",
+          "faction": "r",
+          "balance":
+            {
+              "available": 0,
+              "reserved": 0,
+              "total": 0
+            },
+          "minted": 0
+        }
       ]
   })");
 }
@@ -699,6 +723,15 @@ TEST_F (BuildingJsonTests, Inventories)
   inv.Get (1, "domob")->GetInventory ().SetFungibleCount ("foo", 2);
   inv.Get (42, "domob")->GetInventory ().SetFungibleCount ("foo", 100);
   inv.Get (1, "andy")->GetInventory ().SetFungibleCount ("bar", 1);
+
+  DexOrderTable orders(db);
+  orders.CreateNew (1, "domob", DexOrder::Type::ASK, "foo", 2, 10);
+  orders.CreateNew (1, "domob", DexOrder::Type::ASK, "foo", 2, 15);
+  orders.CreateNew (1, "domob", DexOrder::Type::ASK, "bar", 1, 10);
+  orders.CreateNew (1, "andy", DexOrder::Type::ASK, "foo", 5, 20);
+  orders.CreateNew (42, "domob", DexOrder::Type::ASK, "foo", 1, 1);
+  orders.CreateNew (1, "domob", DexOrder::Type::BID, "foo", 1, 1);
+
   ExpectStateJson (R"({
     "buildings":
       [
@@ -708,6 +741,11 @@ TEST_F (BuildingJsonTests, Inventories)
             {
               "andy": {"fungible": {"bar": 1}},
               "domob": {"fungible": {"foo": 2}}
+            },
+          "reserved":
+            {
+              "andy": {"fungible": {"foo": 5}},
+              "domob": {"fungible": {"foo": 4, "bar": 1}}
             }
         }
       ]
@@ -715,6 +753,8 @@ TEST_F (BuildingJsonTests, Inventories)
 
   inv.Get (1, "domob")->GetInventory ().SetFungibleCount ("foo", 0);
   inv.Get (1, "andy")->GetInventory ().SetFungibleCount ("bar", 0);
+  orders.DeleteForBuilding (1);
+
   ExpectStateJson (R"({
     "buildings":
       [
@@ -724,6 +764,106 @@ TEST_F (BuildingJsonTests, Inventories)
             {
               "andy": null,
               "domob": null
+            },
+          "reserved":
+            {
+              "andy": null,
+              "domob": null
+            }
+        }
+      ]
+  })");
+}
+
+TEST_F (BuildingJsonTests, Orderbook)
+{
+  ASSERT_EQ (tbl.CreateNew ("checkmark", "", Faction::ANCIENT)->GetId (), 1);
+
+  db.SetNextId (101);
+  DexOrderTable orders(db);
+  orders.CreateNew (1, "domob", DexOrder::Type::BID, "foo", 2, 2);
+  orders.CreateNew (1, "andy", DexOrder::Type::BID, "foo", 1, 2);
+  orders.CreateNew (1, "domob", DexOrder::Type::BID, "foo", 1, 3);
+  orders.CreateNew (1, "domob", DexOrder::Type::ASK, "foo", 1, 8);
+  orders.CreateNew (1, "domob", DexOrder::Type::BID, "foo", 3, 1);
+  orders.CreateNew (1, "domob", DexOrder::Type::ASK, "foo", 1, 10);
+  orders.CreateNew (1, "domob", DexOrder::Type::BID, "bar", 1, 1);
+  orders.CreateNew (42, "domob", DexOrder::Type::BID, "foo", 1, 5);
+  orders.CreateNew (1, "domob", DexOrder::Type::ASK, "foo", 1, 9);
+
+  ExpectStateJson (R"({
+    "buildings":
+      [
+        {
+          "id": 1,
+          "orderbook":
+            {
+              "bar":
+                {
+                  "item": "bar",
+                  "bids":
+                    [
+                      {
+                        "id": 107,
+                        "account": "domob",
+                        "quantity": 1,
+                        "price": 1
+                      }
+                    ],
+                  "asks": []
+                },
+              "foo":
+                {
+                  "item": "foo",
+                  "bids":
+                    [
+                      {
+                        "id": 103,
+                        "account": "domob",
+                        "quantity": 1,
+                        "price": 3
+                      },
+                      {
+                        "id": 102,
+                        "account": "andy",
+                        "quantity": 1,
+                        "price": 2
+                      },
+                      {
+                        "id": 101,
+                        "account": "domob",
+                        "quantity": 2,
+                        "price": 2
+                      },
+                      {
+                        "id": 105,
+                        "account": "domob",
+                        "quantity": 3,
+                        "price": 1
+                      }
+                    ],
+                  "asks":
+                    [
+                      {
+                        "id": 104,
+                        "account": "domob",
+                        "quantity": 1,
+                        "price": 8
+                      },
+                      {
+                        "id": 109,
+                        "account": "domob",
+                        "quantity": 1,
+                        "price": 9
+                      },
+                      {
+                        "id": 106,
+                        "account": "domob",
+                        "quantity": 1,
+                        "price": 10
+                      }
+                    ]
+                }
             }
         }
       ]

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -28,6 +28,7 @@
 
 #include "database/account.hpp"
 #include "database/building.hpp"
+#include "database/dex.hpp"
 #include "database/moneysupply.hpp"
 #include "database/schema.hpp"
 
@@ -504,6 +505,34 @@ ValidateOngoingsLinks (Database& db)
   }
 }
 
+/**
+ * Validates that all DEX orders refer to valid accounts and buildings.
+ */
+void
+ValidateOrderLinks (Database& db)
+{
+  AccountsTable accounts(db);
+  BuildingsTable buildings(db);
+  DexOrderTable orders(db);
+
+  auto res = orders.QueryAll ();
+  while (res.Step ())
+    {
+      auto o = orders.GetFromResult (res);
+      CHECK (accounts.GetByName (o->GetAccount ()) != nullptr)
+          << "Order " << o->GetId ()
+          << " refers to non-existing account " << o->GetAccount ();
+
+      auto b = buildings.GetById (o->GetBuilding ());
+      CHECK (b != nullptr)
+          << "Order " << o->GetId ()
+          << " refers to non-existing building " << o->GetBuilding ();
+      CHECK (!b->GetProto ().foundation ())
+          << "Order " << o->GetId ()
+          << " is in foundation " << o->GetBuilding ();
+    }
+}
+
 } // anonymous namespace
 
 void
@@ -516,6 +545,7 @@ PXLogic::ValidateStateSlow (Database& db, const Context& ctx)
   ValidateCharacterLimit (db, ctx);
   ValidateBuildingInventories (db);
   ValidateOngoingsLinks (db);
+  ValidateOrderLinks (db);
 }
 
 } // namespace pxd

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -49,6 +49,12 @@ SQLiteGameDatabase::GetNextId ()
   return game.Ids ("pxd").GetNext ();
 }
 
+Database::IdT
+SQLiteGameDatabase::GetLogId ()
+{
+  return game.Ids ("log").GetNext ();
+}
+
 const BaseMap&
 PXLogic::GetBaseMap ()
 {

--- a/src/logic.hpp
+++ b/src/logic.hpp
@@ -65,6 +65,7 @@ public:
   void operator= (const SQLiteGameDatabase&) = delete;
 
   Database::IdT GetNextId () override;
+  Database::IdT GetLogId () override;
 
 };
 

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -62,7 +62,8 @@ BaseMoveProcessor::BaseMoveProcessor (Database& d, DynObstacles& o,
                                       const Context& c)
   : ctx(c), db(d), dyn(o),
     accounts(db), buildings(db), characters(db),
-    groundLoot(db), buildingInv(db), itemCounts(db), moneySupply(db),
+    groundLoot(db), buildingInv(db),
+    orders(db), itemCounts(db), moneySupply(db),
     ongoings(db), regions(db, ctx.Height ())
 {}
 
@@ -355,7 +356,8 @@ BaseMoveProcessor::TryDexOperations (const std::string& name,
     {
       auto parsed = DexOperation::Parse (*a, op, ctx,
                                          accounts,
-                                         buildings, buildingInv);
+                                         buildings, buildingInv,
+                                         orders);
       if (parsed == nullptr)
         {
           LOG (WARNING) << "Malformed DEX operation:\n" << op;

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -63,7 +63,8 @@ BaseMoveProcessor::BaseMoveProcessor (Database& d, DynObstacles& o,
   : ctx(c), db(d), dyn(o),
     accounts(db), buildings(db), characters(db),
     groundLoot(db), buildingInv(db),
-    orders(db), itemCounts(db), moneySupply(db),
+    orders(db), dexHistory(db),
+    itemCounts(db), moneySupply(db),
     ongoings(db), regions(db, ctx.Height ())
 {}
 
@@ -357,7 +358,7 @@ BaseMoveProcessor::TryDexOperations (const std::string& name,
       auto parsed = DexOperation::Parse (*a, op, ctx,
                                          accounts,
                                          buildings, buildingInv,
-                                         orders);
+                                         orders, dexHistory);
       if (parsed == nullptr)
         {
           LOG (WARNING) << "Malformed DEX operation:\n" << op;

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -129,6 +129,9 @@ protected:
   /** Access handle for DEX orders.  */
   DexOrderTable orders;
 
+  /** Database table for DEX trading history.  */
+  DexHistoryTable dexHistory;
+
   /** Item counts table.  */
   ItemCounts itemCounts;
 

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -29,6 +29,7 @@
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/database.hpp"
+#include "database/dex.hpp"
 #include "database/inventory.hpp"
 #include "database/itemcounts.hpp"
 #include "database/moneysupply.hpp"
@@ -124,6 +125,9 @@ protected:
 
   /** Access handle for building inventories.  */
   BuildingInventoriesTable buildingInv;
+
+  /** Access handle for DEX orders.  */
+  DexOrderTable orders;
 
   /** Item counts table.  */
   ItemCounts itemCounts;

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -22,6 +22,7 @@
 #include "context.hpp"
 #include "dynobstacles.hpp"
 #include "services.hpp"
+#include "trading.hpp"
 
 #include "database/account.hpp"
 #include "database/amount.hpp"
@@ -275,6 +276,13 @@ protected:
   void TryServiceOperations (const std::string& name, const Json::Value& mv);
 
   /**
+   * Parses and handles a potential move with requested DEX operations.
+   * Each valid operation will be passed to PerfromDexOperation for
+   * either execution or recording into the pending state.
+   */
+  void TryDexOperations (const std::string& name, const Json::Value& mv);
+
+  /**
    * This function is called when TryCharacterCreation found a creation that
    * is valid and should be performed.
    */
@@ -304,6 +312,14 @@ protected:
    */
   virtual void
   PerformServiceOperation (ServiceOperation& op)
+  {}
+
+  /**
+   * This function is called when TryDexOperations has found a valid
+   * DEX operation.
+   */
+  virtual void
+  PerformDexOperation (DexOperation& op)
   {}
 
 public:
@@ -432,6 +448,7 @@ protected:
   void PerformCharacterUpdate (Character& c, const Json::Value& mv) override;
   void PerformBuildingUpdate (Building& b, const Json::Value& mv) override;
   void PerformServiceOperation (ServiceOperation& op) override;
+  void PerformDexOperation (DexOperation& op) override;
 
 public:
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -3292,6 +3292,10 @@ TEST_F (BuildingUpdateTests, SetServiceFee)
     },
     {
       "name": "andy",
+      "move": {"b": {"id": 101, "sf": 42.0}}
+    },
+    {
+      "name": "andy",
       "move": {"b": {"id": 101, "sf": "42"}}
     },
     {
@@ -3303,6 +3307,47 @@ TEST_F (BuildingUpdateTests, SetServiceFee)
                 ->GetProto ().service_fee_percent (), 1'000);
   EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
                 ->GetProto ().service_fee_percent (), 0);
+}
+
+TEST_F (BuildingUpdateTests, SetDexFee)
+{
+  Process (R"([
+    {
+      "name": "andy",
+      "move": {"b": {"id": 101, "xf": 3000}}
+    },
+    {
+      "name": "domob",
+      "move": {"b": {"id": 102, "xf": 100}}
+    }
+  ])");
+  EXPECT_EQ (buildings.GetById (ANDY_OWNED)->GetProto ().dex_fee_bps (), 3'000);
+  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)->GetProto ().dex_fee_bps (), 100);
+
+  Process (R"([
+    {
+      "name": "andy",
+      "move": {"b": {"id": 101, "xf": 3001}}
+    },
+    {
+      "name": "andy",
+      "move": {"b": {"id": 101, "xf": -20}}
+    },
+    {
+      "name": "andy",
+      "move": {"b": {"id": 101, "xf": 42.0}}
+    },
+    {
+      "name": "andy",
+      "move": {"b": {"id": 101, "xf": "42"}}
+    },
+    {
+      "name": "domob",
+      "move": {"b": {"id": 102, "xf": 0}}
+    }
+  ])");
+  EXPECT_EQ (buildings.GetById (ANDY_OWNED)->GetProto ().dex_fee_bps (), 3'000);
+  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)->GetProto ().dex_fee_bps (), 0);
 }
 
 /* ************************************************************************** */

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -3487,9 +3487,10 @@ protected:
   BuildingsTable buildings;
   BuildingInventoriesTable inv;
   CharacterTable characters;
+  DexOrderTable orders;
 
   DexMoveTests ()
-    : buildings(db), inv(db), characters(db)
+    : buildings(db), inv(db), characters(db), orders(db)
   {
     db.SetNextId (100);
     buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
@@ -3529,8 +3530,25 @@ TEST_F (DexMoveTests, Works)
 
 TEST_F (DexMoveTests, AfterCoinOperations)
 {
-  /* FIXME: Test that DEX operations are after coin operations once
-     we can do that (with bids/asks).  */
+  accounts.CreateNew ("domob")->AddBalance (100);
+
+  db.SetNextId (101);
+  Process (R"([
+    {
+      "name": "domob",
+      "move":
+        {
+          "x": [{"b": 100, "i": "foo", "n": 6, "bp": 10}],
+          "vc": {"t": {"andy": 60}}
+        }
+    }
+  ])");
+
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 40);
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 60);
+
+  EXPECT_EQ (orders.GetById (101), nullptr);
+  EXPECT_EQ (db.GetNextId (), 101);
 }
 
 TEST_F (DexMoveTests, BeforeCharacterUpdates)

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -23,6 +23,7 @@
 #include "dynobstacles.hpp"
 #include "moveprocessor.hpp"
 #include "services.hpp"
+#include "trading.hpp"
 
 #include "database/character.hpp"
 #include "database/database.hpp"
@@ -145,6 +146,9 @@ private:
 
     /** The combined coin transfer / burn for this account.  */
     std::unique_ptr<CoinTransferBurn> coinOps;
+
+    /** Requested DEX / trading opreations (already as JSON).  */
+    std::vector<Json::Value> dexOps;
 
     /** Requested service operations (already as JSON).  */
     std::vector<Json::Value> serviceOps;
@@ -276,6 +280,11 @@ public:
   void AddServiceOperation (const ServiceOperation& op);
 
   /**
+   * Updates the state for a given account, adding a new DEX operation.
+   */
+  void AddDexOperation (const DexOperation& op);
+
+  /**
    * Returns true if the given character has pending waypoints.
    */
   bool HasPendingWaypoints (const Character& c) const;
@@ -308,6 +317,7 @@ protected:
   void PerformCharacterCreation (Account& acc, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& upd) override;
   void PerformServiceOperation (ServiceOperation& op) override;
+  void PerformDexOperation (DexOperation& op) override;
 
 public:
 

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -53,6 +53,7 @@ protected:
   BuildingInventoriesTable buildingInv;
   CharacterTable characters;
   DexOrderTable orders;
+  DexHistoryTable history;
   ItemCounts itemCounts;
   OngoingsTable ongoings;
   RegionsTable regions;
@@ -61,7 +62,7 @@ protected:
     : accounts(db),
       buildings(db), buildingInv(db),
       characters(db),
-      orders(db),
+      orders(db), history(db),
       itemCounts(db),
       ongoings(db),
       regions(db, 1'042)
@@ -714,7 +715,7 @@ TEST_F (PendingStateTests, DexOperations)
         "i": "foo",
         "n": 1,
         "t": "daniel"
-      })"), ctx, accounts, buildings, buildingInv, orders));
+      })"), ctx, accounts, buildings, buildingInv, orders, history));
   state.AddDexOperation (*DexOperation::Parse (
       *andy,
       ParseJson (R"({
@@ -722,7 +723,7 @@ TEST_F (PendingStateTests, DexOperations)
         "i": "bar",
         "n": 2,
         "t": "daniel"
-      })"), ctx, accounts, buildings, buildingInv, orders));
+      })"), ctx, accounts, buildings, buildingInv, orders, history));
   state.AddDexOperation (*DexOperation::Parse (
       *domob,
       ParseJson (R"({
@@ -730,7 +731,7 @@ TEST_F (PendingStateTests, DexOperations)
         "i": "foo",
         "n": 3,
         "t": "daniel"
-      })"), ctx, accounts, buildings, buildingInv, orders));
+      })"), ctx, accounts, buildings, buildingInv, orders, history));
 
   ExpectStateJson (R"(
     {

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -26,6 +26,7 @@
 #include "database/building.hpp"
 #include "database/character.hpp"
 #include "database/dbtest.hpp"
+#include "database/dex.hpp"
 #include "database/itemcounts.hpp"
 #include "database/region.hpp"
 
@@ -51,6 +52,7 @@ protected:
   BuildingsTable buildings;
   BuildingInventoriesTable buildingInv;
   CharacterTable characters;
+  DexOrderTable orders;
   ItemCounts itemCounts;
   OngoingsTable ongoings;
   RegionsTable regions;
@@ -59,6 +61,7 @@ protected:
     : accounts(db),
       buildings(db), buildingInv(db),
       characters(db),
+      orders(db),
       itemCounts(db),
       ongoings(db),
       regions(db, 1'042)
@@ -711,7 +714,7 @@ TEST_F (PendingStateTests, DexOperations)
         "i": "foo",
         "n": 1,
         "t": "daniel"
-      })"), ctx, accounts, buildings, buildingInv));
+      })"), ctx, accounts, buildings, buildingInv, orders));
   state.AddDexOperation (*DexOperation::Parse (
       *andy,
       ParseJson (R"({
@@ -719,7 +722,7 @@ TEST_F (PendingStateTests, DexOperations)
         "i": "bar",
         "n": 2,
         "t": "daniel"
-      })"), ctx, accounts, buildings, buildingInv));
+      })"), ctx, accounts, buildings, buildingInv, orders));
   state.AddDexOperation (*DexOperation::Parse (
       *domob,
       ParseJson (R"({
@@ -727,7 +730,7 @@ TEST_F (PendingStateTests, DexOperations)
         "i": "foo",
         "n": 3,
         "t": "daniel"
-      })"), ctx, accounts, buildings, buildingInv));
+      })"), ctx, accounts, buildings, buildingInv, orders));
 
   ExpectStateJson (R"(
     {

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -601,6 +601,19 @@ PXRpcServer::getprizestats ()
 }
 
 Json::Value
+PXRpcServer::gettradehistory (const int building, const std::string& item)
+{
+  LOG (INFO)
+      << "RPC method called: gettradehistory "
+      << item << " " << building;
+  return logic.GetCustomStateData (game,
+    [building, &item] (GameStateJson& gsj)
+      {
+        return gsj.TradeHistory (item, building);
+      });
+}
+
+Json::Value
 PXRpcServer::getbootstrapdata ()
 {
   LOG (INFO) << "RPC method called: getbootstrapdata";

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -207,6 +207,7 @@ public:
   Json::Value getregions (int fromHeight) override;
   Json::Value getmoneysupply () override;
   Json::Value getprizestats () override;
+  Json::Value gettradehistory (int building, const std::string& item) override;
 
   Json::Value getbootstrapdata () override;
 

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -71,6 +71,15 @@
     "params": {},
     "returns": {}
   },
+  {
+    "name": "gettradehistory",
+    "params":
+      {
+        "item": "foo",
+        "building": 42
+      },
+    "returns": {}
+  },
 
   {
     "name": "getbootstrapdata",

--- a/src/trading.cpp
+++ b/src/trading.cpp
@@ -1,0 +1,260 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "trading.hpp"
+
+#include "jsonutils.hpp"
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+/* ************************************************************************** */
+
+/**
+ * Collection of basic "context" references that we need for DEX orders.
+ * This is just used to simplify passing them around.
+ */
+class DexOperation::ContextRefs
+{
+
+private:
+
+  const Context& ctx;
+
+  AccountsTable& accounts;
+  BuildingsTable& buildings;
+  BuildingInventoriesTable& buildingInv;
+
+  explicit ContextRefs (const Context& c,
+                        AccountsTable& a,
+                        BuildingsTable& b, BuildingInventoriesTable& i)
+    : ctx(c), accounts(a), buildings(b), buildingInv(i)
+  {}
+
+  friend class DexOperation;
+
+};
+
+namespace
+{
+
+/* ************************************************************************** */
+
+/**
+ * DEX operation that explicitly specifies a building, item type
+ * and quantity.  This shares logic between transfers, bids and asks.
+ */
+class ItemOperation : public DexOperation
+{
+
+protected:
+
+  /** The building ID this is taking place in.  */
+  const Database::IdT building;
+
+  /** The item type this is for.  */
+  const std::string item;
+
+  /** The amount of item being operated on.  */
+  const Quantity quantity;
+
+  explicit ItemOperation (Account& a, const ContextRefs& r,
+                          const Database::IdT b, const std::string& i,
+                          const Quantity n)
+    : DexOperation(a, r), building(b), item(i), quantity(n)
+  {}
+
+  /**
+   * Checks if the general data pieces are valid (building exists,
+   * item exists and quantity is within range).
+   */
+  bool IsItemOperationValid () const;
+
+  /**
+   * Returns a base pending JSON object for the generic pieces of data
+   * in this item operation.
+   */
+  Json::Value PendingItemOperation () const;
+
+};
+
+bool
+ItemOperation::IsItemOperationValid () const
+{
+  const auto b = buildings.GetById (building);
+  if (b == nullptr)
+    {
+      LOG (WARNING)
+          << "Invalid building " << building << " in operation:\n" << rawMove;
+      return false;
+    }
+  if (b->GetProto ().foundation ())
+    {
+      LOG (WARNING)
+          << "Invalid operation in foundation " << building << ":\n" << rawMove;
+      return false;
+    }
+
+  if (ctx.RoConfig ().ItemOrNull (item) == nullptr)
+    {
+      LOG (WARNING)
+          << "Invalid item '" << item << "' in operation:\n" << rawMove;
+      return false;
+    }
+
+  /* The quantity is already checked for being in range (0, MAX_QUANTITY]
+     when parsing the instance.  */
+
+  return true;
+}
+
+Json::Value
+ItemOperation::PendingItemOperation () const
+{
+  Json::Value res(Json::objectValue);
+  res["building"] = IntToJson (building);
+  res["item"] = item;
+  res["num"] = IntToJson (quantity);
+  return res;
+}
+
+/* ************************************************************************** */
+
+/**
+ * A direct item transfer between user accounts inside a building.
+ */
+class TransferOperation : public ItemOperation
+{
+
+private:
+
+  /** The recipient account.  */
+  const std::string recipient;
+
+public:
+
+  explicit TransferOperation (Account& a, const ContextRefs& r,
+                              const Database::IdT b, const std::string& i,
+                              const Quantity n, const std::string& rec)
+    : ItemOperation(a, r, b, i, n), recipient(rec)
+  {}
+
+  bool IsValid () const override;
+  Json::Value ToPendingJson () const override;
+  void Execute () override;
+
+};
+
+bool
+TransferOperation::IsValid () const
+{
+  if (!IsItemOperationValid ())
+    return false;
+
+  const auto inv = buildingInv.Get (building, account.GetName ());
+  const Quantity got = inv->GetInventory ().GetFungibleCount (item);
+  if (got < quantity)
+    {
+      LOG (WARNING)
+          << "User " << account.GetName () << " has only " << got
+          << " of " << item << " in building " << building
+          << ", cannot transfer:\n" << rawMove;
+      return false;
+    }
+
+  return true;
+}
+
+Json::Value
+TransferOperation::ToPendingJson () const
+{
+  Json::Value res = PendingItemOperation ();
+  res["op"] = "transfer";
+  res["to"] = recipient;
+  return res;
+}
+
+void
+TransferOperation::Execute ()
+{
+  LOG (INFO)
+      << "Transferring " << quantity << " of " << item
+      << " inside " << building
+      << " from " << account.GetName () << " to " << recipient;
+
+  if (accounts.GetByName (recipient) == nullptr)
+    accounts.CreateNew (recipient);
+
+  buildingInv.Get (building, account.GetName ())
+      ->GetInventory ().AddFungibleCount (item, -quantity);
+  buildingInv.Get (building, recipient)
+      ->GetInventory ().AddFungibleCount (item, quantity);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+
+DexOperation::DexOperation (Account& a, const ContextRefs& r)
+  : ctx(r.ctx),
+    accounts(r.accounts), buildings(r.buildings), buildingInv(r.buildingInv),
+    account(a)
+{}
+
+std::unique_ptr<DexOperation>
+DexOperation::Parse (Account& acc, const Json::Value& data,
+                     const Context& ctx,
+                     AccountsTable& accounts,
+                     BuildingsTable& buildings, BuildingInventoriesTable& inv)
+{
+  if (!data.isObject ())
+    return nullptr;
+
+  if (data.size () != 4)
+    return nullptr;
+
+  Database::IdT building;
+  if (!IdFromJson (data["b"], building))
+    return nullptr;
+
+  const auto& itmVal = data["i"];
+  if (!itmVal.isString ())
+    return nullptr;
+  const std::string item = itmVal.asString ();
+
+  Quantity quantity;
+  if (!QuantityFromJson (data["n"], quantity))
+    return nullptr;
+
+  const auto& recvVal = data["t"];
+  if (!recvVal.isString ())
+    return nullptr;
+  const std::string recipient = recvVal.asString ();
+
+  const ContextRefs refs(ctx, accounts, buildings, inv);
+  auto op = std::make_unique<TransferOperation> (acc, refs, building, item,
+                                                 quantity, recipient);
+  op->rawMove = data;
+  return op;
+}
+
+/* ************************************************************************** */
+
+} // namespace pxd

--- a/src/trading.hpp
+++ b/src/trading.hpp
@@ -52,6 +52,7 @@ protected:
   BuildingsTable& buildings;
   BuildingInventoriesTable& buildingInv;
   DexOrderTable& orders;
+  DexHistoryTable& history;
 
   /** The account triggering the operation.  */
   Account& account;
@@ -96,7 +97,7 @@ public:
       const Context& ctx,
       AccountsTable& accounts,
       BuildingsTable& buildings, BuildingInventoriesTable& inv,
-      DexOrderTable& orders);
+      DexOrderTable& orders, DexHistoryTable& history);
 
 };
 

--- a/src/trading.hpp
+++ b/src/trading.hpp
@@ -23,6 +23,7 @@
 
 #include "database/account.hpp"
 #include "database/building.hpp"
+#include "database/dex.hpp"
 #include "database/inventory.hpp"
 
 #include <json/json.h>
@@ -50,6 +51,7 @@ protected:
   AccountsTable& accounts;
   BuildingsTable& buildings;
   BuildingInventoriesTable& buildingInv;
+  DexOrderTable& orders;
 
   /** The account triggering the operation.  */
   Account& account;
@@ -93,7 +95,8 @@ public:
       Account& acc, const Json::Value& data,
       const Context& ctx,
       AccountsTable& accounts,
-      BuildingsTable& buildings, BuildingInventoriesTable& inv);
+      BuildingsTable& buildings, BuildingInventoriesTable& inv,
+      DexOrderTable& orders);
 
 };
 

--- a/src/trading.hpp
+++ b/src/trading.hpp
@@ -1,0 +1,102 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_TRADING_HPP
+#define PXD_TRADING_HPP
+
+#include "context.hpp"
+
+#include "database/account.hpp"
+#include "database/building.hpp"
+#include "database/inventory.hpp"
+
+#include <json/json.h>
+
+#include <memory>
+#include <string>
+
+namespace pxd
+{
+
+/**
+ * A DEX trading operation (item transfer, new order or cancelled order).
+ * This class is used to provide a uniform interface to all of these
+ * operations for move and pending processing.
+ */
+class DexOperation
+{
+
+protected:
+
+  class ContextRefs;
+
+  const Context& ctx;
+
+  AccountsTable& accounts;
+  BuildingsTable& buildings;
+  BuildingInventoriesTable& buildingInv;
+
+  /** The account triggering the operation.  */
+  Account& account;
+
+  /** The operation's raw move JSON (used for logs and error reporting).  */
+  Json::Value rawMove;
+
+  explicit DexOperation (Account& a, const ContextRefs& r);
+
+public:
+
+  virtual ~DexOperation () = default;
+
+  const Account&
+  GetAccount () const
+  {
+    return account;
+  }
+
+  /**
+   * Returns true if the operation is actually valid according to game
+   * and move rules.
+   */
+  virtual bool IsValid () const = 0;
+
+  /**
+   * Returns the pending JSON representation of this operation.
+   */
+  virtual Json::Value ToPendingJson () const = 0;
+
+  /**
+   * Fully executes the update corresponding to this operation.
+   */
+  virtual void Execute () = 0;
+
+  /**
+   * Tries to parse a DEX operation from JSON move data.  Returns nullptr
+   * if the format is invalid.
+   */
+  static std::unique_ptr<DexOperation> Parse (
+      Account& acc, const Json::Value& data,
+      const Context& ctx,
+      AccountsTable& accounts,
+      BuildingsTable& buildings, BuildingInventoriesTable& inv);
+
+};
+
+} // namespace pxd
+
+#endif // PXD_TRADING_HPP

--- a/src/trading_tests.cpp
+++ b/src/trading_tests.cpp
@@ -1,0 +1,273 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "trading.hpp"
+
+#include "testutils.hpp"
+
+#include "database/dbtest.hpp"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+/* ************************************************************************** */
+
+class DexOperationTests : public DBTestWithSchema
+{
+
+private:
+
+  /**
+   * Returns an account handle for the given name, creating it if necessary.
+   */
+  AccountsTable::Handle
+  GetAccount (const std::string& name)
+  {
+    auto a = accounts.GetByName (name);
+    if (a == nullptr)
+      return accounts.CreateNew (name);
+    return a;
+  }
+
+  /**
+   * Tries to parse an operation from JSON.  The operation handle is
+   * returned without any further validation.
+   */
+  std::unique_ptr<DexOperation>
+  Parse (Account& a, const std::string& op)
+  {
+    return DexOperation::Parse (a, ParseJson (op),
+                                ctx, accounts, buildings, buildingInv);
+  }
+
+protected:
+
+  AccountsTable accounts;
+  BuildingsTable buildings;
+  BuildingInventoriesTable buildingInv;
+
+  ContextForTesting ctx;
+
+  DexOperationTests ()
+    : accounts(db), buildings(db), buildingInv(db)
+  {
+    auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+    CHECK_EQ (b->GetId (), 1);
+    b.reset ();
+  }
+
+  /**
+   * Tries to parse an operation JSON and returns true/false depending
+   * on whether it is well-formed (not taking specific validation
+   * like balances into account).
+   */
+  bool
+  IsValidFormat (const std::string& data)
+  {
+    auto a = GetAccount ("formatdummy");
+    return Parse (*a, data) != nullptr;
+  }
+
+  /**
+   * Parses an operation from JSON and validates it.  The format itself must
+   * be valid.  The method returns false if the operation is invalid
+   * (e.g. insufficient balance).  If it is valid, it is executed
+   * and true returned.
+   */
+  bool
+  Process (const std::string& name, const std::string& data)
+  {
+    auto a = GetAccount (name);
+    auto op = Parse (*a, data);
+    CHECK (op != nullptr);
+
+    if (!op->IsValid ())
+      return false;
+
+    op->Execute ();
+    return true;
+  }
+
+  /**
+   * Parses an operation from JSON and returns the associated pending JSON.
+   * The operation must be valid format.
+   */
+  Json::Value
+  GetPending (const std::string& data)
+  {
+    auto a = GetAccount ("pendingdummy");
+    auto op = Parse (*a, data);
+    CHECK (op != nullptr);
+    return op->ToPendingJson ();
+  }
+
+  /**
+   * Returns the amount of some item held in some building account.
+   */
+  Quantity
+  ItemBalance (const Database::IdT building, const std::string& name,
+               const std::string& item)
+  {
+    auto inv = buildingInv.Get (building, name);
+    return inv->GetInventory ().GetFungibleCount (item);
+  }
+
+};
+
+/* ************************************************************************** */
+
+class DexTransferTests : public DexOperationTests
+{
+
+protected:
+
+  DexTransferTests ()
+  {
+    buildingInv.Get (1, "domob")->GetInventory ().AddFungibleCount ("foo", 100);
+  }
+
+};
+
+TEST_F (DexTransferTests, InvalidFormat)
+{
+  const std::string tests[] =
+    {
+      "42",
+      "[]",
+      R"({"b": 1, "i": "foo", "n": 5, "t": "andy", "x": 123})",
+      R"({"b": "1", "i": "foo", "n": 5, "t": "andy"})",
+      R"({"b": 1, "i": 42, "n": 5, "t": "andy"})",
+      R"({"b": 1, "i": "foo", "n": "1", "t": "andy"})",
+      R"({"b": 1, "i": "foo", "n": -1, "t": "andy"})",
+      R"({"b": 1, "i": "foo", "n": 1.0, "t": "andy"})",
+      R"({"b": 1, "i": "foo", "n": 0, "t": "andy"})",
+      R"({"b": 1, "i": "foo", "n": 999999999999999999999, "t": "andy"})",
+      R"({"b": 1, "i": "foo", "n": 5, "t": ["andy"]})",
+      R"({"i": "foo", "n": 5, "t": "andy"})",
+      R"({"b": 1, "n": 5, "t": "andy"})",
+      R"({"b": 1, "i": "foo", "t": "andy"})",
+      R"({"b": 1, "i": "foo", "n": 5})",
+    };
+  for (const auto& t : tests)
+    EXPECT_FALSE (IsValidFormat (t)) << "Expected to be invalid:\n" << t;
+}
+
+TEST_F (DexTransferTests, InvalidItemOperation)
+{
+  db.SetNextId (101);
+  buildings.CreateNew ("checkmark", "", Faction::ANCIENT)
+      ->MutableProto ().set_foundation (true);
+
+  /* Invalid building (does not exist).  */
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 42,
+    "i": "foo",
+    "n": 1,
+    "t": "andy"
+  })"));
+
+  /* Invalid building (is a foundation).  */
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 101,
+    "i": "foo",
+    "n": 1,
+    "t": "andy"
+  })"));
+
+  /* Item does not exist.  */
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 1,
+    "i": "invalid",
+    "n": 1,
+    "t": "andy"
+  })"));
+}
+
+TEST_F (DexTransferTests, InsufficientBalance)
+{
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 101,
+    "t": "andy"
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 1,
+    "i": "bar",
+    "n": 1,
+    "t": "andy"
+  })"));
+  EXPECT_FALSE (Process ("andy", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 1,
+    "t": "domob"
+  })"));
+}
+
+TEST_F (DexTransferTests, PendingJson)
+{
+  EXPECT_TRUE (PartialJsonEqual (GetPending (R"({
+    "b": 1,
+    "i": "foo",
+    "n": 42,
+    "t": "andy"
+  })"), ParseJson (R"({
+    "op": "transfer",
+    "building": 1,
+    "item": "foo",
+    "num": 42,
+    "to": "andy"
+  })")));
+}
+
+TEST_F (DexTransferTests, Success)
+{
+  ASSERT_TRUE (Process ("domob", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 100,
+    "t": "domob"
+  })"));
+  ASSERT_TRUE (Process ("domob", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 30,
+    "t": "andy"
+  })"));
+  ASSERT_TRUE (Process ("andy", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 30,
+    "t": "daniel"
+  })"));
+
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 70);
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 0);
+  EXPECT_EQ (ItemBalance (1, "daniel", "foo"), 30);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/trading_tests.cpp
+++ b/src/trading_tests.cpp
@@ -18,6 +18,7 @@
 
 #include "trading.hpp"
 
+#include "jsonutils.hpp"
 #include "testutils.hpp"
 
 #include "database/dbtest.hpp"
@@ -54,10 +55,10 @@ private:
    * returned without any further validation.
    */
   std::unique_ptr<DexOperation>
-  Parse (Account& a, const std::string& op)
+  Parse (Account& a, const Json::Value& op)
   {
-    return DexOperation::Parse (a, ParseJson (op),
-                                ctx, accounts, buildings, buildingInv);
+    return DexOperation::Parse (a, op, ctx,
+                                accounts, buildings, buildingInv, orders);
   }
 
 protected:
@@ -65,13 +66,15 @@ protected:
   AccountsTable accounts;
   BuildingsTable buildings;
   BuildingInventoriesTable buildingInv;
+  DexOrderTable orders;
 
   ContextForTesting ctx;
 
   DexOperationTests ()
-    : accounts(db), buildings(db), buildingInv(db)
+    : accounts(db), buildings(db), buildingInv(db), orders(db)
   {
-    auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+    accounts.CreateNew ("building")->SetFaction (Faction::RED);
+    auto b = buildings.CreateNew ("checkmark", "building", Faction::RED);
     CHECK_EQ (b->GetId (), 1);
     b.reset ();
   }
@@ -85,7 +88,7 @@ protected:
   IsValidFormat (const std::string& data)
   {
     auto a = GetAccount ("formatdummy");
-    return Parse (*a, data) != nullptr;
+    return Parse (*a, ParseJson (data)) != nullptr;
   }
 
   /**
@@ -95,7 +98,7 @@ protected:
    * and true returned.
    */
   bool
-  Process (const std::string& name, const std::string& data)
+  ProcessJson (const std::string& name, const Json::Value& data)
   {
     auto a = GetAccount (name);
     auto op = Parse (*a, data);
@@ -109,6 +112,16 @@ protected:
   }
 
   /**
+   * Processes an operation as with ProcessJson, except that the operation
+   * is taken directly from a JSON string.
+   */
+  bool
+  Process (const std::string& name, const std::string& data)
+  {
+    return ProcessJson (name, ParseJson (data));
+  }
+
+  /**
    * Parses an operation from JSON and returns the associated pending JSON.
    * The operation must be valid format.
    */
@@ -116,7 +129,7 @@ protected:
   GetPending (const std::string& data)
   {
     auto a = GetAccount ("pendingdummy");
-    auto op = Parse (*a, data);
+    auto op = Parse (*a, ParseJson (data));
     CHECK (op != nullptr);
     return op->ToPendingJson ();
   }
@@ -265,6 +278,451 @@ TEST_F (DexTransferTests, Success)
   EXPECT_EQ (ItemBalance (1, "domob", "foo"), 70);
   EXPECT_EQ (ItemBalance (1, "andy", "foo"), 0);
   EXPECT_EQ (ItemBalance (1, "daniel", "foo"), 30);
+}
+
+/* ************************************************************************** */
+
+class NewOrderTests : public DexOperationTests
+{
+
+protected:
+
+  NewOrderTests ()
+  {
+    accounts.CreateNew ("andy")->AddBalance (1'000);
+    accounts.CreateNew ("domob")->AddBalance (1'000);
+
+    buildingInv.Get (1, "andy")->GetInventory ().AddFungibleCount ("foo", 100);
+    buildingInv.Get (1, "domob")->GetInventory ().AddFungibleCount ("foo", 100);
+
+    /* We define some assets and orders in other buildings or for a different
+       item, which none of the tests are supposed to touch.  */
+
+    auto b = buildings.CreateNew ("checkmark", "", Faction::ANCIENT);
+    CHECK_EQ (b->GetId (), 2);
+    b.reset ();
+
+    buildingInv.Get (1, "domob")->GetInventory ().AddFungibleCount ("bar", 100);
+    buildingInv.Get (2, "domob")->GetInventory ().AddFungibleCount ("foo", 100);
+
+    db.SetNextId (11);
+    orders.CreateNew (1, "domob", DexOrder::Type::BID, "bar", 1, 1'000);
+    orders.CreateNew (1, "domob", DexOrder::Type::ASK, "bar", 1, 1);
+    orders.CreateNew (2, "domob", DexOrder::Type::BID, "foo", 1, 1'000);
+    orders.CreateNew (2, "domob", DexOrder::Type::ASK, "foo", 1, 1);
+  }
+
+  ~NewOrderTests ()
+  {
+    for (unsigned i = 11; i <= 14; ++i)
+      EXPECT_NE (orders.GetById (i), nullptr) << "Order does not exist: " << i;
+
+    EXPECT_EQ (ItemBalance (1, "domob", "bar"), 100);
+    EXPECT_EQ (ItemBalance (2, "domob", "foo"), 100);
+  }
+
+  /**
+   * Utility method to perform an order in our test building for the test item.
+   */
+  void
+  PlaceOrder (const std::string& name, const DexOrder::Type t,
+              const Quantity q, const Amount p)
+  {
+    auto op = ParseJson (R"({
+      "b": 1,
+      "i": "foo"
+    })");
+
+    op["n"] = IntToJson (q);
+    switch (t)
+      {
+      case DexOrder::Type::BID:
+        op["bp"] = IntToJson (p);
+        break;
+      case DexOrder::Type::ASK:
+        op["ap"] = IntToJson (p);
+        break;
+      default:
+        LOG (FATAL) << "Invalid order type: " << static_cast<int> (t);
+      }
+
+    EXPECT_TRUE (ProcessJson (name, op));
+  }
+
+};
+
+TEST_F (NewOrderTests, InvalidFormat)
+{
+  const std::string tests[] =
+    {
+      "42",
+      "[]",
+      R"({"b": 1, "i": "foo", "n": 5, "t": "andy", "bp": 1})",
+      R"({"b": 1, "i": "foo", "n": 5, "bp": "42"})",
+      R"({"b": 1, "i": "foo", "n": 5, "bp": -5})",
+      R"({"b": 1, "i": "foo", "n": 5, "bp": 100000000001})",
+      R"({"b": 1, "i": "foo", "n": 5, "bp": 1, "ap": 2})",
+      R"({"b": 1, "i": "foo", "n": 5, "ap": "42"})",
+      R"({"b": 1, "i": "foo", "n": 5, "ap": -5})",
+      R"({"b": 1, "i": "foo", "n": 5, "ap": 100000000001})",
+    };
+  for (const auto& t : tests)
+    EXPECT_FALSE (IsValidFormat (t)) << "Expected to be invalid:\n" << t;
+
+}
+TEST_F (NewOrderTests, InvalidItemOperation)
+{
+  db.SetNextId (101);
+  buildings.CreateNew ("checkmark", "", Faction::ANCIENT)
+      ->MutableProto ().set_foundation (true);
+
+  /* Invalid building (does not exist).  */
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 42,
+    "i": "foo",
+    "n": 1,
+    "bp": 1
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 42,
+    "i": "foo",
+    "n": 1,
+    "ap": 1
+  })"));
+
+  /* Invalid building (is a foundation).  */
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 101,
+    "i": "foo",
+    "n": 1,
+    "bp": 1
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 101,
+    "i": "foo",
+    "n": 1,
+    "ap": 1
+  })"));
+
+  /* Item does not exist.  */
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 1,
+    "i": "invalid",
+    "n": 1,
+    "bp": 1
+  })"));
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 1,
+    "i": "invalid",
+    "n": 1,
+    "ap": 1
+  })"));
+}
+
+TEST_F (NewOrderTests, InsufficientBalance)
+{
+  /* Trying to sell more than 100 foo.  */
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 101,
+    "ap": 1
+  })"));
+
+  /* Offering more than 1k Cubits for foo (in total).  */
+  EXPECT_FALSE (Process ("domob", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 10,
+    "bp": 101
+  })"));
+}
+
+TEST_F (NewOrderTests, PendingJson)
+{
+  EXPECT_TRUE (PartialJsonEqual (GetPending (R"({
+    "b": 1,
+    "i": "foo",
+    "n": 42,
+    "bp": 2
+  })"), ParseJson (R"({
+    "op": "bid",
+    "building": 1,
+    "item": "foo",
+    "num": 42,
+    "price": 2
+  })")));
+
+  EXPECT_TRUE (PartialJsonEqual (GetPending (R"({
+    "b": 1,
+    "i": "foo",
+    "n": 42,
+    "ap": 5
+  })"), ParseJson (R"({
+    "op": "ask",
+    "building": 1,
+    "item": "foo",
+    "num": 42,
+    "price": 5
+  })")));
+}
+
+TEST_F (NewOrderTests, VeryHighAsk)
+{
+  /* Asks are valid as long as the price is not exceeding MAX_MONEY, even
+     if the total cost is exceeding the money supply.  */
+  db.SetNextId (101);
+  ASSERT_TRUE (Process ("domob", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 10,
+    "ap": 100000000000
+  })"));
+
+  auto o = orders.GetById (101);
+  ASSERT_NE (o, nullptr);
+  EXPECT_EQ (o->GetType (), DexOrder::Type::ASK);
+  EXPECT_EQ (o->GetQuantity (), 10);
+  EXPECT_EQ (o->GetPrice (), 100'000'000'000);
+
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 90);
+}
+
+/* ************************************************************************** */
+
+class OrderMatchingTests : public NewOrderTests
+{
+
+protected:
+
+  OrderMatchingTests ()
+  {
+    /* These orders are created directly in the table, so they won't
+       reduce assets / balances of domob.  */
+    db.SetNextId (101);
+    orders.CreateNew (1, "domob", DexOrder::Type::BID, "foo", 10, 1);
+    orders.CreateNew (1, "domob", DexOrder::Type::BID, "foo", 1, 3);
+    orders.CreateNew (1, "domob", DexOrder::Type::ASK, "foo", 1, 10);
+    orders.CreateNew (1, "domob", DexOrder::Type::ASK, "foo", 10, 20);
+
+    /* We want to execute these tests without any DEX fees (there are
+       separate unit tests for the fees).  Thus we set the building
+       owner fee to -10%, which offsets the base fee on regtest completely.
+       This obviously only works by changing the value directly, and won't
+       be possible to do in the real game through moves.  */
+    buildings.GetById (1)->MutableProto ().set_dex_fee_bps (-1'000);
+    accounts.GetByName ("building")->AddBalance (1'000'000);
+
+    /* Future orders (placed by the test) will have IDs from 201.  */
+    db.SetNextId (201);
+  }
+
+};
+
+TEST_F (OrderMatchingTests, NewBid)
+{
+  PlaceOrder ("andy", DexOrder::Type::BID, 2, 5);
+
+  auto o = orders.GetById (201);
+  ASSERT_NE (o, nullptr);
+  EXPECT_EQ (o->GetType (), DexOrder::Type::BID);
+  EXPECT_EQ (o->GetAccount (), "andy");
+  EXPECT_EQ (o->GetBuilding (), 1);
+  EXPECT_EQ (o->GetItem (), "foo");
+  EXPECT_EQ (o->GetQuantity (), 2);
+  EXPECT_EQ (o->GetPrice (), 5);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 990);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000);
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 100);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 100);
+}
+
+TEST_F (OrderMatchingTests, NewAsk)
+{
+  PlaceOrder ("andy", DexOrder::Type::ASK, 2, 5);
+
+  auto o = orders.GetById (201);
+  ASSERT_NE (o, nullptr);
+  EXPECT_EQ (o->GetType (), DexOrder::Type::ASK);
+  EXPECT_EQ (o->GetAccount (), "andy");
+  EXPECT_EQ (o->GetBuilding (), 1);
+  EXPECT_EQ (o->GetItem (), "foo");
+  EXPECT_EQ (o->GetQuantity (), 2);
+  EXPECT_EQ (o->GetPrice (), 5);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000);
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 98);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 100);
+}
+
+TEST_F (OrderMatchingTests, FilledBid)
+{
+  PlaceOrder ("andy", DexOrder::Type::BID, 2, 100);
+
+  EXPECT_EQ (orders.GetById (101)->GetQuantity (), 10);
+  EXPECT_EQ (orders.GetById (102)->GetQuantity (), 1);
+  EXPECT_EQ (orders.GetById (103), nullptr);
+  EXPECT_EQ (orders.GetById (104)->GetQuantity (), 9);
+  EXPECT_EQ (db.GetNextId (), 201);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000 - 10 - 20);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000 + 10 + 20);
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 102);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 100);
+}
+
+TEST_F (OrderMatchingTests, FilledAsk)
+{
+  PlaceOrder ("andy", DexOrder::Type::ASK, 2, 0);
+
+  EXPECT_EQ (orders.GetById (101)->GetQuantity (), 9);
+  EXPECT_EQ (orders.GetById (102), nullptr);
+  EXPECT_EQ (orders.GetById (103)->GetQuantity (), 1);
+  EXPECT_EQ (orders.GetById (104)->GetQuantity (), 10);
+  EXPECT_EQ (db.GetNextId (), 201);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000 + 3 + 1);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000);
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 98);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 102);
+}
+
+TEST_F (OrderMatchingTests, PartialBid)
+{
+  PlaceOrder ("andy", DexOrder::Type::BID, 2, 15);
+
+  EXPECT_EQ (orders.GetById (101)->GetQuantity (), 10);
+  EXPECT_EQ (orders.GetById (102)->GetQuantity (), 1);
+  EXPECT_EQ (orders.GetById (103), nullptr);
+  EXPECT_EQ (orders.GetById (104)->GetQuantity (), 10);
+  EXPECT_EQ (orders.GetById (201)->GetQuantity (), 1);
+  EXPECT_EQ (db.GetNextId (), 202);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000 - 10 - 15);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000 + 10);
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 101);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 100);
+}
+
+TEST_F (OrderMatchingTests, PartialAsk)
+{
+  PlaceOrder ("andy", DexOrder::Type::ASK, 2, 2);
+
+  EXPECT_EQ (orders.GetById (101)->GetQuantity (), 10);
+  EXPECT_EQ (orders.GetById (102), nullptr);
+  EXPECT_EQ (orders.GetById (103)->GetQuantity (), 1);
+  EXPECT_EQ (orders.GetById (104)->GetQuantity (), 10);
+  EXPECT_EQ (orders.GetById (201)->GetQuantity (), 1);
+  EXPECT_EQ (db.GetNextId (), 202);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000 + 3);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000);
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 98);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 101);
+}
+
+TEST_F (OrderMatchingTests, FillingOwnOrder)
+{
+  PlaceOrder ("domob", DexOrder::Type::ASK, 1, 3);
+  PlaceOrder ("domob", DexOrder::Type::BID, 1, 10);
+
+  EXPECT_EQ (orders.GetById (101)->GetQuantity (), 10);
+  EXPECT_EQ (orders.GetById (102), nullptr);
+  EXPECT_EQ (orders.GetById (103), nullptr);
+  EXPECT_EQ (orders.GetById (104)->GetQuantity (), 10);
+  EXPECT_EQ (db.GetNextId (), 201);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000 + 3);
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 100);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 101);
+}
+
+/* ************************************************************************** */
+
+class DexFeeTests : public NewOrderTests
+{
+
+protected:
+
+  DexFeeTests ()
+  {
+    /* We also do tests with the building owner account here, to see
+       how that interacts with the fee they get.  */
+    accounts.GetByName ("building")->AddBalance (1'000);
+    buildingInv.Get (1, "building")
+        ->GetInventory ().AddFungibleCount ("foo", 1'000);
+
+    /* Owner fee in the tests is 20%, for a total fee of 30%.  */
+    buildings.GetById (1)->MutableProto ().set_dex_fee_bps (2'000);
+
+    db.SetNextId (101);
+  }
+
+};
+
+TEST_F (DexFeeTests, BasicFeeDistribution)
+{
+  PlaceOrder ("domob", DexOrder::Type::ASK, 1, 100);
+  PlaceOrder ("andy", DexOrder::Type::BID, 2, 100);
+  PlaceOrder ("domob", DexOrder::Type::ASK, 1, 100);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000 - 200);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000 + 140);
+  EXPECT_EQ (accounts.GetByName ("building")->GetBalance (), 1'000 + 40);
+
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 102);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 98);
+}
+
+TEST_F (DexFeeTests, ZeroPrice)
+{
+  PlaceOrder ("domob", DexOrder::Type::ASK, 1, 0);
+  PlaceOrder ("andy", DexOrder::Type::BID, 2, 0);
+  PlaceOrder ("domob", DexOrder::Type::ASK, 1, 0);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000);
+  EXPECT_EQ (accounts.GetByName ("building")->GetBalance (), 1'000);
+
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 102);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 98);
+}
+
+TEST_F (DexFeeTests, Rounding)
+{
+  for (unsigned i = 0; i < 10; ++i)
+    PlaceOrder ("domob", DexOrder::Type::ASK, 1, 1);
+  PlaceOrder ("andy", DexOrder::Type::BID, 10, 1);
+
+  EXPECT_EQ (accounts.GetByName ("andy")->GetBalance (), 1'000 - 10);
+  EXPECT_EQ (accounts.GetByName ("domob")->GetBalance (), 1'000);
+  EXPECT_EQ (accounts.GetByName ("building")->GetBalance (), 1'000);
+
+  EXPECT_EQ (ItemBalance (1, "andy", "foo"), 110);
+  EXPECT_EQ (ItemBalance (1, "domob", "foo"), 90);
+}
+
+TEST_F (DexFeeTests, BuildingOwnerSells)
+{
+  PlaceOrder ("building", DexOrder::Type::ASK, 1'000, 1);
+
+  /* Even though we get money back (and end up with sufficient balance),
+     it is not possible to buy with more than what we have liquid.  */
+
+  ASSERT_FALSE (Process ("building", R"({
+    "b": 1,
+    "i": "foo",
+    "n": 1001,
+    "bp": 1
+  })"));
+
+  PlaceOrder ("building", DexOrder::Type::BID, 1'000, 1);
+  EXPECT_EQ (ItemBalance (1, "building", "foo"), 1'000);
+  EXPECT_EQ (accounts.GetByName ("building")->GetBalance (), 1'000 - 100);
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
This implements DEX trading inside each building.  With a new set of commands, users can transfer assets inside a building between accounts, place buy/sell limit orders and cancel those orders again.  Building owners can also configure a new option, namely the DEX fee to charge sellers (out of their profit in Cubits) for trades inside their building.  This fee can be chosen between 0% and 30%, and is on top of a base fee of 3% that all trades incur and that is burnt.