### PR TITLE
Faction restrictions for items

### DIFF
--- a/gametest/buildings_foundations.py
+++ b/gametest/buildings_foundations.py
@@ -36,10 +36,11 @@ class BuildingFoundationsTest (PXTest):
     pos = {"x": 0, "y": 0}
     self.dropLoot (pos, {"foo": 100})
     self.moveCharactersTo ({"domob": pos})
-    self.getCharacters ()["domob"].sendMove ({"pu": {"f": {"foo": 4}}})
+    self.getCharacters ()["domob"].sendMove ({"pu": {"f": {"foo": 10}}})
     self.generate (1)
 
     self.mainLogger.info ("Building foundations...")
+    numBefore = len (self.getBuildings ())
     # It is actually possible to build *two* foundations (or more)
     # in a single block in the way done below.
     c = self.getCharacters ()["domob"]
@@ -47,19 +48,27 @@ class BuildingFoundationsTest (PXTest):
       "fb": {"t": "huesli", "rot": 0},
       "xb": {},
     })
+    # This one won't work due to faction mismatch.
     c.sendMove ({
-      "fb": {"t": "huesli", "rot": 0},
+      "fb": {"t": "g test", "rot": 0},
+      "xb": {},
+    })
+    # This will be fine.
+    c.sendMove ({
+      "fb": {"t": "r test", "rot": 0},
       "xb": {},
     })
     self.generate (1)
 
     buildings = self.getBuildings ()
+    self.assertEqual (len (buildings), numBefore + 2)
     bIds = list (buildings.keys ())[-2:]
     for b in bIds:
       self.assertEqual (buildings[b].isFoundation (), True)
       self.assertEqual (buildings[b].getOwner (), "domob")
       self.assertEqual (buildings[b].getFaction (), "r")
-      self.assertEqual (buildings[b].getType (), "huesli")
+    self.assertEqual (buildings[bIds[0]].getType (), "huesli")
+    self.assertEqual (buildings[bIds[1]].getType (), "r test")
 
     self.mainLogger.info ("Dropping into foundation...")
     self.dropLoot (self.getCharacters ()["domob"].getPosition (),
@@ -72,7 +81,7 @@ class BuildingFoundationsTest (PXTest):
     self.getCharacters ()["domob"].sendMove ({"drop": {"f": {"zerospace": 5}}})
     self.generate (1)
     c = self.getCharacters ()["domob"]
-    self.assertEqual (c.getFungibleInventory (), {})
+    self.assertEqual (c.getFungibleInventory (), {"foo": 7})
     b = self.getBuildings ()[bIds[1]]
     self.assertEqual (b.getConstructionInventory (), {"zerospace": 5})
 
@@ -86,7 +95,7 @@ class BuildingFoundationsTest (PXTest):
 
     c = self.getCharacters ()["domob"]
     self.assertEqual (c.data["fitments"], ["sword"])
-    self.assertEqual (c.getFungibleInventory (), {})
+    self.assertEqual (c.getFungibleInventory (), {"foo": 7})
 
     self.setCharactersHP ({
       "domob": {"a": 10},

--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -285,17 +285,17 @@ class FindPathTest (PXTest):
     # ensure that it can be passed directly back to setpathdata.
     buildings = [[]]
 
-    self.build ("r rt", None,
+    self.build ("huesli", None,
                 offsetCoord (longA, {"x": 1, "y": 0}, False), rot=0)
-    self.build ("r rt", None,
+    self.build ("huesli", None,
                 offsetCoord (longA, {"x": 1, "y": -1}, False), rot=0)
-    self.build ("r rt", None,
+    self.build ("huesli", None,
                 offsetCoord (longA, {"x": 0, "y": 1}, False), rot=0)
     buildings.append (self.getRpc ("getbuildings"))
 
-    self.build ("r rt", None,
+    self.build ("huesli", None,
                 offsetCoord (longA, {"x": 0, "y": -1}, False), rot=0)
-    self.build ("r rt", None,
+    self.build ("huesli", None,
                 offsetCoord (longA, {"x": -1, "y": 1}, False), rot=0)
     buildings.append (self.getRpc ("getbuildings"))
 

--- a/gametest/services_reveng.py
+++ b/gametest/services_reveng.py
@@ -34,7 +34,7 @@ class ServicesRevEngTest (PXTest):
     building = 1001
     self.assertEqual (self.getBuildings ()[building].getType (), "ancient1")
 
-    self.initAccount ("domob", "r")
+    self.initAccount ("domob", "g")
     self.generate (1)
     self.giftCoins ({"domob": 100})
     self.dropIntoBuilding (building, "domob", {"test artefact": 10})

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -326,6 +326,13 @@ message BuildingData
      */
     optional uint32 blocks = 3;
 
+    /**
+     * The faction of this building type.  If this is set, then only players
+     * with a matching faction can build it.  This is inferred from the
+     * building name in roconfig data and only set at runtime.
+     */
+    optional string faction = 4;
+
   }
 
   /** The data for constructing this building.  */

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -236,6 +236,17 @@ message ItemData
    */
   map<string, uint32> construction_resources = 4;
 
+  /**
+   * If this item is a fitment or vehicle and specific to a particular faction,
+   * then this field indicates that faction.  May be null for faction-neutral
+   * items, e.g. most fitments.
+   *
+   * For fitments, this has to be explicitly set in the roconfig data.
+   * For vehicles, it is deduced from the name prefix (e.g. "rv ") via
+   * the RoConfig logic.
+   */
+  optional string faction = 5;
+
   oneof type
   {
 

--- a/proto/roconfig.cpp
+++ b/proto/roconfig.cpp
@@ -320,6 +320,8 @@ ConstructItemData (const RoConfig& cfg, const std::string& item)
       res->set_space (BLUEPRINT_SPACE);
       auto* bp = res->mutable_is_blueprint ();
       bp->set_for_item (baseName);
+      if (base->has_faction ())
+        res->set_faction (base->faction ());
       bp->set_original (true);
       return res;
     }
@@ -331,6 +333,8 @@ ConstructItemData (const RoConfig& cfg, const std::string& item)
       res->set_space (BLUEPRINT_SPACE);
       auto* bp = res->mutable_is_blueprint ();
       bp->set_for_item (baseName);
+      if (base->has_faction ())
+        res->set_faction (base->faction ());
       bp->set_original (false);
       return res;
     }

--- a/proto/roconfig/buildings/test.pb.text
+++ b/proto/roconfig/buildings/test.pb.text
@@ -80,3 +80,50 @@ building_types:
           }
       }
   }
+
+# Faction-specific test buildings.
+building_types:
+  {
+    key: "r test"
+    value:
+      {
+        enter_radius: 5
+        shape_tiles: { x: 0 y: 0 }
+        construction:
+          {
+            foundation: { key: "foo" value: 1 }
+            full_building: { key: "foo" value: 1 }
+            blocks: 1
+          }
+      }
+  }
+building_types:
+  {
+    key: "g test"
+    value:
+      {
+        enter_radius: 5
+        shape_tiles: { x: 0 y: 0 }
+        construction:
+          {
+            foundation: { key: "foo" value: 1 }
+            full_building: { key: "foo" value: 1 }
+            blocks: 1
+          }
+      }
+  }
+building_types:
+  {
+    key: "b test"
+    value:
+      {
+        enter_radius: 5
+        shape_tiles: { x: 0 y: 0 }
+        construction:
+          {
+            foundation: { key: "foo" value: 1 }
+            full_building: { key: "foo" value: 1 }
+            blocks: 1
+          }
+      }
+  }

--- a/proto/roconfig/items/fitments.pb.text
+++ b/proto/roconfig/items/fitments.pb.text
@@ -934,6 +934,7 @@ fungible_items:
         with_blueprint: true
         construction_resources: { key: "mat a" value: 2500 }
         construction_resources: { key: "mat b" value: 2500 }
+        faction: "r"
         fitment:
           {
             slot: "high"
@@ -959,6 +960,7 @@ fungible_items:
         construction_resources: { key: "mat a" value: 4500 }
         construction_resources: { key: "mat b" value: 4500 }
         construction_resources: { key: "mat f" value: 1000 }
+        faction: "r"
         fitment:
           {
             slot: "high"
@@ -985,6 +987,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 24000 }
         construction_resources: { key: "mat f" value: 9000 }
         construction_resources: { key: "mat g" value: 3000 }
+        faction: "r"
         fitment:
           {
             slot: "high"
@@ -1016,6 +1019,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 6000 }
         construction_resources: { key: "mat h" value: 4800 }
         construction_resources: { key: "mat i" value: 1200 }
+        faction: "r"
         fitment:
           {
             slot: "high"
@@ -1040,6 +1044,7 @@ fungible_items:
         with_blueprint: true
         construction_resources: { key: "mat a" value: 2500 }
         construction_resources: { key: "mat b" value: 2500 }
+        faction: "r"
         fitment:
           {
             slot: "high"
@@ -1064,6 +1069,7 @@ fungible_items:
         construction_resources: { key: "mat a" value: 4500 }
         construction_resources: { key: "mat b" value: 4500 }
         construction_resources: { key: "mat f" value: 1000 }
+        faction: "r"
         fitment:
           {
             slot: "high"
@@ -1089,6 +1095,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 24000 }
         construction_resources: { key: "mat f" value: 9000 }
         construction_resources: { key: "mat g" value: 3000 }
+        faction: "r"
         fitment:
           {
             slot: "high"
@@ -1119,6 +1126,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 6000 }
         construction_resources: { key: "mat h" value: 4800 }
         construction_resources: { key: "mat i" value: 1200 }
+        faction: "r"
         fitment:
           {
             slot: "high"
@@ -1804,6 +1812,7 @@ fungible_items:
         with_blueprint: true
         construction_resources: { key: "mat a" value: 2500 }
         construction_resources: { key: "mat b" value: 2500 }
+        faction: "b"
         fitment:
           {
             slot: "mid"
@@ -1828,6 +1837,7 @@ fungible_items:
         construction_resources: { key: "mat a" value: 4500 }
         construction_resources: { key: "mat b" value: 4500 }
         construction_resources: { key: "mat f" value: 1000 }
+        faction: "b"
         fitment:
           {
             slot: "mid"
@@ -1853,6 +1863,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 24000 }
         construction_resources: { key: "mat f" value: 9000 }
         construction_resources: { key: "mat g" value: 3000 }
+        faction: "b"
         fitment:
           {
             slot: "mid"
@@ -1883,6 +1894,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 6000 }
         construction_resources: { key: "mat h" value: 4800 }
         construction_resources: { key: "mat i" value: 1200 }
+        faction: "b"
         fitment:
           {
             slot: "mid"
@@ -1913,6 +1925,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 6000 }
         construction_resources: { key: "mat h" value: 4800 }
         construction_resources: { key: "mat i" value: 1200 }
+        faction: "b"
         fitment:
           {
             slot: "mid"
@@ -2386,6 +2399,7 @@ fungible_items:
         with_blueprint: true
         construction_resources: { key: "mat a" value: 2500 }
         construction_resources: { key: "mat b" value: 2500 }
+        faction: "g"
         fitment:
           {
             slot: "low"
@@ -2412,6 +2426,7 @@ fungible_items:
         construction_resources: { key: "mat a" value: 4500 }
         construction_resources: { key: "mat b" value: 4500 }
         construction_resources: { key: "mat f" value: 1000 }
+        faction: "g"
         fitment:
           {
             slot: "low"
@@ -2439,6 +2454,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 24000 }
         construction_resources: { key: "mat f" value: 9000 }
         construction_resources: { key: "mat g" value: 3000 }
+        faction: "g"
         fitment:
           {
             slot: "low"
@@ -2471,6 +2487,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 6000 }
         construction_resources: { key: "mat h" value: 4800 }
         construction_resources: { key: "mat i" value: 1200 }
+        faction: "g"
         fitment:
           {
             slot: "low"
@@ -2496,6 +2513,7 @@ fungible_items:
         with_blueprint: true
         construction_resources: { key: "mat a" value: 2500 }
         construction_resources: { key: "mat b" value: 2500 }
+        faction: "g"
         fitment:
           {
             slot: "low"
@@ -2517,6 +2535,7 @@ fungible_items:
         construction_resources: { key: "mat a" value: 4500 }
         construction_resources: { key: "mat b" value: 4500 }
         construction_resources: { key: "mat f" value: 1000 }
+        faction: "g"
         fitment:
           {
             slot: "low"
@@ -2539,6 +2558,7 @@ fungible_items:
         construction_resources: { key: "mat b" value: 24000 }
         construction_resources: { key: "mat f" value: 9000 }
         construction_resources: { key: "mat g" value: 3000 }
+        faction: "g"
         fitment:
           {
             slot: "low"
@@ -2566,6 +2586,7 @@ fungible_items:
         construction_resources: { key: "mat g" value: 6000 }
         construction_resources: { key: "mat h" value: 4800 }
         construction_resources: { key: "mat i" value: 1200 }
+        faction: "g"
         fitment:
           {
             slot: "low"

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -100,6 +100,21 @@ fungible_items:
       }
   }
 
+# Faction-restricted fitment.
+fungible_items:
+  {
+    key: "red fitment"
+    value:
+      {
+        space: 1
+        complexity: 1
+        with_blueprint: true
+        construction_resources: { key: "foo" value: 1 }
+        faction: "r"
+        fitment: { slot: "high" }
+      }
+  }
+
 # Strong complexity multiplier for testing its effect.
 fungible_items:
   {

--- a/proto/roconfig/items/test.pb.text
+++ b/proto/roconfig/items/test.pb.text
@@ -177,6 +177,7 @@ fungible_items:
             cost: 10
             possible_outputs: "bow bpo"
             possible_outputs: "sword bpo"
+            possible_outputs: "red fitment bpo"
           }
       }
   }

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -168,6 +168,35 @@ TEST_F (RoItemsTests, PrizeItems)
 
 /* ************************************************************************** */
 
+using RoBuildingsTests = RoItemsTests;
+
+TEST_F (RoBuildingsTests, FactionFromNamePrefix)
+{
+  EXPECT_FALSE (cfg.Building ("obelisk1").has_construction ());
+  EXPECT_FALSE (cfg.Building ("r c1").has_construction ());
+  EXPECT_EQ (cfg.Building ("r r").construction ().faction (), "r");
+  EXPECT_EQ (cfg.Building ("b cc").construction ().faction (), "b");
+  EXPECT_EQ (cfg.Building ("g vb").construction ().faction (), "g");
+}
+
+TEST_F (RoBuildingsTests, MainnetBuildableHasFaction)
+{
+  /* All buildings that can be built by players in the mainnet
+     config should have a faction (via name prefix).  */
+
+  const RoConfig main(xaya::Chain::MAIN);
+  for (const auto& b : main->building_types ())
+    {
+      const auto& data = main.Building (b.first);
+      ASSERT_TRUE (!data.has_construction ()
+                      || data.construction ().has_faction ())
+          << "Building type " << b.first
+          << " is constructible on mainnet but doesn't have a faction";
+    }
+}
+
+/* ************************************************************************** */
+
 class RoConfigSanityTests : public testing::Test
 {
 
@@ -422,6 +451,12 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
             || b.full_building ().combat_data ().has_target_size ())
         {
           LOG (WARNING) << "Building has a target size: " << entry.first;
+          return false;
+        }
+
+      if (b.construction ().has_faction ())
+        {
+          LOG (WARNING) << "Building has explicit faction set: " << entry.first;
           return false;
         }
     }

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -137,15 +137,20 @@ TEST_F (RoItemsTests, Blueprints)
 
   const auto& orig = cfg.Item ("bow bpo");
   ASSERT_TRUE (orig.has_is_blueprint ());
+  EXPECT_FALSE (orig.has_faction ());
   EXPECT_EQ (orig.space (), 1);
   EXPECT_EQ (orig.is_blueprint ().for_item (), "bow");
   EXPECT_TRUE (orig.is_blueprint ().original ());
 
   const auto& copy = cfg.Item ("bow bpc");
   ASSERT_TRUE (copy.has_is_blueprint ());
+  EXPECT_FALSE (orig.has_faction ());
   EXPECT_EQ (copy.space (), 1);
   EXPECT_EQ (copy.is_blueprint ().for_item (), "bow");
   EXPECT_FALSE (copy.is_blueprint ().original ());
+
+  EXPECT_EQ (cfg.Item ("red fitment bpo").faction (), "r");
+  EXPECT_EQ (cfg.Item ("red fitment bpc").faction (), "r");
 }
 
 TEST_F (RoItemsTests, PrizeItems)

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -166,6 +166,30 @@ TEST_F (RoItemsTests, PrizeItems)
     }
 }
 
+TEST_F (RoItemsTests, VehicleFactions)
+{
+  EXPECT_FALSE (cfg.Item ("lf gun").has_faction ());
+  EXPECT_FALSE (cfg.Item ("basetank").has_faction ());
+  EXPECT_EQ (cfg.Item ("rv st").faction (), "r");
+  EXPECT_EQ (cfg.Item ("gv ma").faction (), "g");
+  EXPECT_EQ (cfg.Item ("bv vlt").faction (), "b");
+}
+
+TEST_F (RoItemsTests, MainnetVehiclesHaveFaction)
+{
+  /* All vehicles available on mainnet should have a faction associated
+     to them via the item prefix.  */
+
+  const RoConfig main(xaya::Chain::MAIN);
+  for (const auto& i : main->fungible_items ())
+    {
+      const auto& data = main.Item (i.first);
+      ASSERT_TRUE (!data.has_vehicle () || data.has_faction ())
+          << "Vehicle " << i.first
+          << " available on mainnet has no faction set";
+    }
+}
+
 /* ************************************************************************** */
 
 using RoBuildingsTests = RoItemsTests;
@@ -330,6 +354,13 @@ RoConfigSanityTests::IsConfigValid (const RoConfig& cfg)
         {
           LOG (WARNING)
               << "Item construction data is invalid for " << entry.first;
+          return false;
+        }
+
+      if (i.has_faction () && !i.has_fitment ())
+        {
+          LOG (WARNING)
+              << "Non-fitment item " << entry.first << " has explicit faction";
           return false;
         }
 

--- a/src/fitments.cpp
+++ b/src/fitments.cpp
@@ -68,6 +68,20 @@ CheckVehicleFitments (const std::string& vehicle,
               << vehicleData.vehicle ().size ();
           return false;
         }
+
+      /* Apply faction restrictions only if both the vehicle and fitment
+         have a faction set.  This allows faction-specific fitments to be used
+         on "neutral" test vehicles.  On mainnet, none of the vehicles is
+         actually neutral.  */
+      if (fitmentData.has_faction () && vehicleData.has_faction ()
+            && fitmentData.faction () != vehicleData.faction ())
+        {
+          VLOG (1)
+              << "Fitment " << f << " of faction " << fitmentData.faction ()
+              << " cannot fit vehicle " << vehicle
+              << " of faction " << vehicleData.faction ();
+          return false;
+        }
     }
 
   /* Now check up the required stats against the vehicle.  */

--- a/src/fitments_tests.cpp
+++ b/src/fitments_tests.cpp
@@ -73,6 +73,15 @@ TEST_F (CheckVehicleFitmentsTests, VehicleSize)
   EXPECT_TRUE (CheckVehicleFitments ("chariot", {"only medium"}, ctx));
 }
 
+TEST_F (CheckVehicleFitmentsTests, FactionRestrictions)
+{
+  EXPECT_TRUE (CheckVehicleFitments ("basetank", {"bow"}, ctx));
+  EXPECT_TRUE (CheckVehicleFitments ("rv vla", {"bow"}, ctx));
+  EXPECT_TRUE (CheckVehicleFitments ("basetank", {"red fitment"}, ctx));
+  EXPECT_TRUE (CheckVehicleFitments ("rv vla", {"red fitment"}, ctx));
+  EXPECT_FALSE (CheckVehicleFitments ("gv vla", {"red fitment"}, ctx));
+}
+
 /* ************************************************************************** */
 
 class DeriveCharacterStatsTests : public DBTestWithSchema

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -266,6 +266,18 @@ ValidateBuildings (Database& db, const Context& ctx)
           CHECK_LE (pb.age_data ().finished_height (), ctx.Height ())
               << "Building " << b->GetId () << " is finished in the future";
         }
+
+      const auto& ro = ctx.RoConfig ().Building (b->GetType ());
+      const auto& constr = ro.construction ();
+      if (constr.has_faction ())
+        {
+          const auto roFaction = FactionFromString (constr.faction ());
+          CHECK (b->GetFaction () == roFaction)
+              << "Building " << b->GetId ()
+              << " is of faction " << FactionToString (b->GetFaction ())
+              << " but the base data requires faction "
+              << FactionToString (roFaction);
+        }
     }
 }
 

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -1178,11 +1178,11 @@ TEST_F (ValidateStateTests, CharacterFactions)
   ValidateState ();
 }
 
-TEST_F (ValidateStateTests, BuildingFactions)
+TEST_F (ValidateStateTests, BuildingOwnerFactions)
 {
-  CreateBuilding ("refinery", "", Faction::ANCIENT);
+  CreateBuilding ("ancient1", "", Faction::ANCIENT);
 
-  auto h = CreateBuilding ("turret", "domob", Faction::RED);
+  auto h = CreateBuilding ("checkmark", "domob", Faction::RED);
   const auto id = h->GetId ();
   h.reset ();
   EXPECT_DEATH (ValidateState (), "owned by uninitialised account");
@@ -1231,6 +1231,28 @@ TEST_F (ValidateStateTests, BuildingAgeData)
   EXPECT_DEATH (ValidateState (), "finished in the future");
 
   ctx.SetHeight (11);
+  ValidateState ();
+}
+
+TEST_F (ValidateStateTests, BuildingConstructionFaction)
+{
+  accounts.CreateNew ("red")->SetFaction (Faction::RED);
+  accounts.CreateNew ("green")->SetFaction (Faction::GREEN);
+
+  CreateBuilding ("checkmark", "", Faction::ANCIENT);
+  CreateBuilding ("checkmark", "red", Faction::RED);
+  CreateBuilding ("r test", "red", Faction::RED);
+  CreateBuilding ("g test", "green", Faction::GREEN);
+  ValidateState ();
+
+  auto id = CreateBuilding ("r test", "green", Faction::GREEN)->GetId ();
+  EXPECT_DEATH (ValidateState (), "base data requires faction");
+  buildings.DeleteById (id);
+
+  id = CreateBuilding ("r test", "", Faction::ANCIENT)->GetId ();
+  EXPECT_DEATH (ValidateState (), "base data requires faction");
+  buildings.DeleteById (id);
+
   ValidateState ();
 }
 

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1077,6 +1077,20 @@ BaseMoveProcessor::ParseFoundBuilding (const Character& c,
       return false;
     }
 
+  if (roData.construction ().has_faction ())
+    {
+      const auto roFaction
+          = FactionFromString (roData.construction ().faction ());
+      if (roFaction != c.GetFaction ())
+        {
+          LOG (WARNING)
+              << "Building " << type
+              << " cannot be constructed by " << c.GetOwner ()
+              << " of faction " << FactionToString (c.GetFaction ());
+          return false;
+        }
+    }
+
   const auto& inv = c.GetInventory ();
   for (const auto& entry : roData.construction ().foundation ())
     {

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1831,6 +1831,31 @@ TEST_F (FoundBuildingMoveTests, CannotPlaceBuilding)
   EXPECT_EQ (buildings.GetById (101), nullptr);
 }
 
+TEST_F (FoundBuildingMoveTests, FactionCheck)
+{
+  ASSERT_EQ (GetTest ()->GetFaction (), Faction::RED);
+  GetTest ()->GetInventory ().AddFungibleCount ("foo", 10);
+
+  db.SetNextId (101);
+  Process (R"([
+    {
+      "name": "domob",
+      "move": {"c": {"id": 1, "fb": {"t": "g test", "rot": 0}}}
+    },
+    {
+      "name": "domob",
+      "move": {"c": {"id": 1, "fb": {"t": "r test", "rot": 0}}}
+    }
+  ])");
+
+  auto b = buildings.GetById (101);
+  ASSERT_NE (b, nullptr);
+  EXPECT_EQ (b->GetType (), "r test");
+  b.reset ();
+
+  EXPECT_EQ (buildings.GetById (102), nullptr);
+}
+
 TEST_F (FoundBuildingMoveTests, Success)
 {
   ctx.SetHeight (10);

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -863,6 +863,21 @@ ConstructionOperation::IsValid () const
   if (num <= 0)
     return false;
 
+  if (outputData->has_faction ())
+    {
+      const auto roFaction = FactionFromString (outputData->faction ());
+      const auto userFaction = GetAccount ().GetFaction ();
+      if (roFaction != userFaction)
+        {
+          LOG (WARNING)
+              << "Item " << output
+              << " of faction " << FactionToString (roFaction)
+              << " cannot be constructed by user " << GetAccount ().GetName ()
+              << " of faction " << FactionToString (userFaction);
+          return false;
+        }
+    }
+
   auto& inv = GetBaseInventory ();
   for (const auto& entry : outputData->construction_resources ())
     {

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -1268,6 +1268,35 @@ TEST_F (ConstructionTests, MissingBlueprints)
   })"));
 }
 
+TEST_F (ConstructionTests, FactionRestrictions)
+{
+  auto a = accounts.CreateNew ("green");
+  a->SetFaction (Faction::GREEN);
+  a->AddBalance (1'000'000);
+  a.reset ();
+
+  auto i = inv.Get (ANCIENT_BUILDING, "green");
+  i->GetInventory ().AddFungibleCount ("foo", 10);
+  i->GetInventory ().AddFungibleCount ("red fitment bpo", 1);
+  i = inv.Get (ANCIENT_BUILDING, "domob");
+  i->GetInventory ().AddFungibleCount ("foo", 10);
+  i->GetInventory ().AddFungibleCount ("red fitment bpo", 1);
+  i.reset ();
+
+  EXPECT_FALSE (Process ("green", R"({
+    "t": "bld",
+    "b": 100,
+    "i": "red fitment bpo",
+    "n": 1
+  })"));
+  EXPECT_TRUE (Process ("domob", R"({
+    "t": "bld",
+    "b": 100,
+    "i": "red fitment bpo",
+    "n": 1
+  })"));
+}
+
 TEST_F (ConstructionTests, RequiredServiceType)
 {
   inv.Get (ANCIENT_BUILDING, "domob")


### PR DESCRIPTION
This implements #118:  Buildings and vehicles get assigned an "implicit faction" from their name (e.g. `r vb` is Jodon, `gv st` is Ephrati).  Some of the fitments (as defined in the game-design sheet) also are faction-specific with an explicit roconfig definition.

These factions are then used to implement some restrictions.  In particular, founding buildings, constructing items and getting blueprints through reverse engineering are now limited to players of a matching faction.  And fitments with a defined faction can only be placed on vehicles of the same faction.