### PR TITLE
Enable and use protocol-buffer arenas

### DIFF
--- a/database/database.hpp
+++ b/database/database.hpp
@@ -24,6 +24,7 @@
 #include <xayagame/sqlitegame.hpp>
 #include <xayagame/sqlitestorage.hpp>
 
+#include <google/protobuf/arena.h>
 #include <google/protobuf/message.h>
 
 #include <sqlite3.h>
@@ -51,6 +52,9 @@ private:
 
   /** Underlying SQLiteDatabase from libxayagame.  */
   xaya::SQLiteDatabase* db = nullptr;
+
+  /** Protocol buffer arena used for protos extracted from the database.  */
+  google::protobuf::Arena arena;
 
 protected:
 

--- a/database/database.tpp
+++ b/database/database.tpp
@@ -111,7 +111,11 @@ template <typename Col>
   Database::Result<T>::GetProto () const
 {
   const int ind = ColumnIndex<Col> ();
-  return LazyProto<typename Col::Type> (stmt.GetBlob (ind));
+
+  LazyProto<typename Col::Type> res(stmt.GetBlob (ind));
+  res.SetArena (db->arena);
+
+  return res;
 }
 
 } // namespace pxd

--- a/database/inventory.hpp
+++ b/database/inventory.hpp
@@ -178,7 +178,9 @@ public:
   Inventory& operator= (LazyProto<proto::Inventory>&& d);
 
   Inventory (const Inventory&) = delete;
+  Inventory (const LazyProto<proto::Inventory>&) = delete;
   void operator= (const Inventory&) = delete;
+  void operator= (const LazyProto<proto::Inventory>&) = delete;
 
   friend bool operator== (const Inventory& a, const Inventory& b);
 

--- a/proto/account.proto
+++ b/proto/account.proto
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 package pxd.proto;
 

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 import "proto/combat.proto";
 import "proto/inventory.proto";

--- a/proto/character.proto
+++ b/proto/character.proto
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 import "proto/combat.proto";
 import "proto/modifier.proto";

--- a/proto/combat.proto
+++ b/proto/combat.proto
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 import "proto/modifier.proto";
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 import "proto/building.proto";
 import "proto/character.proto";

--- a/proto/geometry.proto
+++ b/proto/geometry.proto
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 package pxd.proto;
 

--- a/proto/inventory.proto
+++ b/proto/inventory.proto
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 package pxd.proto;
 

--- a/proto/modifier.proto
+++ b/proto/modifier.proto
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 package pxd.proto;
 

--- a/proto/movement.proto
+++ b/proto/movement.proto
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 import "proto/geometry.proto";
 

--- a/proto/ongoing.proto
+++ b/proto/ongoing.proto
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 package pxd.proto;
 

--- a/proto/region.proto
+++ b/proto/region.proto
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 */
 
 syntax = "proto2";
+option cc_enable_arenas = true;
 
 package pxd.proto;
 


### PR DESCRIPTION
Enable [protocol-buffer arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas) in Taurion.  In particular, the `Database` instance gets an arena associated to it, and uses that arena for all protocol buffers that are read from the database (through `LazyProto`).  This arena is per processed block.

Not surprisingly, this drastically reduces runtime in the database benchmarks for situations with large protocol buffers.  It also slightly reduced the time for syncing the initial blocks of the 3rd Taurion competition with `0.3`, and clearly made memory-management functions like `malloc` and `free` go down in the overall callgrind profile.

There may still be potential to improve performance, e.g. by using the arena also for other allocations, and by making sure other protocol buffers that are then "moved in" to database protos are allocated on the arena as well; but so far, no specific place showed up on a profile that needs to be fixed immediately.