### PR TITLE
Disallow building in no-combat zones

### DIFF
--- a/proto/config.proto
+++ b/proto/config.proto
@@ -644,6 +644,9 @@ message ConfigData
   /**
    * The regtest-specific configuration data.  This is merged into the testnet
    * data by the RoConfig-helper class when running on regtest.
+   *
+   * Safe zones and prizes in there will completely replace the values
+   * in the mainnet config, instead of being added to them.
    */
   optional ConfigData regtest_merge = 101;
 

--- a/proto/roconfig.cpp
+++ b/proto/roconfig.cpp
@@ -129,6 +129,7 @@ RoConfig::RoConfig (const xaya::Chain chain)
         pb.MergeFrom (pb.testnet_merge ());
       if (mergeRegtest)
         {
+          pb.clear_safe_zones ();
           pb.mutable_params ()->clear_prizes ();
           pb.MergeFrom (pb.regtest_merge ());
         }

--- a/proto/roconfig/test_safezones.pb.text
+++ b/proto/roconfig/test_safezones.pb.text
@@ -1,4 +1,4 @@
-# For testing, we use these additional safe zones which will remain
+# For testing, we use these safe zones instead which will remain
 # unchanged even if we decide to move around or tweak the safe zones
 # in the main game.
 

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -75,6 +75,10 @@ TEST (RoConfigTests, ChainDependence)
   EXPECT_FALSE (test->params ().god_mode ());
   EXPECT_TRUE (regtest->params ().god_mode ());
 
+  EXPECT_GT (main->safe_zones_size (), 3);
+  EXPECT_EQ (test->safe_zones_size (), main->safe_zones_size ());
+  EXPECT_EQ (regtest->safe_zones_size (), 2);
+
   EXPECT_GT (main->params ().prizes ().size (), 20);
   EXPECT_EQ (main->params ().prizes (0).name (), "cash");
   EXPECT_EQ (test->params ().prizes ().size (),

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -73,6 +73,11 @@ CanPlaceBuilding (const std::string& type,
           VLOG (1) << "Position " << c << " is not passable in the base map";
           return false;
         }
+      if (ctx.Map ().SafeZones ().IsNoCombat (c))
+        {
+          VLOG (1) << "Position " << c << " is a no-combat zone, can't build";
+          return false;
+        }
       if (!dyn.IsFree (c))
         {
           VLOG (1) << "Position " << c << " has a dynamic obstacle";

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -146,6 +146,19 @@ TEST_F (CanPlaceBuildingTests, Impassable)
   EXPECT_FALSE (CanPlace ("huesli", 0, impassable));
 }
 
+TEST_F (CanPlaceBuildingTests, SafeZone)
+{
+  const HexCoord neutral(2'042, 0);
+  const HexCoord starter(-2'042, 100);
+  ASSERT_TRUE (ctx.Map ().SafeZones ().IsNoCombat (neutral));
+  ASSERT_TRUE (ctx.Map ().SafeZones ().IsNoCombat (starter));
+  ASSERT_EQ (ctx.Map ().SafeZones ().StarterFor (neutral), Faction::INVALID);
+  ASSERT_EQ (ctx.Map ().SafeZones ().StarterFor (starter), Faction::RED);
+
+  EXPECT_FALSE (CanPlace ("huesli", 0, neutral));
+  EXPECT_FALSE (CanPlace ("huesli", 0, starter));
+}
+
 TEST_F (CanPlaceBuildingTests, DynObstacle)
 {
   characters.CreateNew ("domob", Faction::RED)->SetPosition (HexCoord (0, 0));

--- a/src/prospecting_tests.cpp
+++ b/src/prospecting_tests.cpp
@@ -36,9 +36,9 @@ namespace
 {
 
 /** Position where prizes are won with normal chance.  */
-constexpr HexCoord POS_NORMAL_PRIZES(4'000, 0);
+constexpr HexCoord POS_NORMAL_PRIZES(2'042, 0);
 /** Position with low chance for prizes.  */
-constexpr HexCoord POS_LOW_PRIZES(2'000, -2'650);
+constexpr HexCoord POS_LOW_PRIZES(-2'042, 1'000);
 
 /* ************************************************************************** */
 
@@ -251,8 +251,8 @@ TEST_F (FinishProspectingTests, Prizes)
   EXPECT_EQ (foundMap["gold"], 3);
   EXPECT_EQ (foundMap["bronze"], 1);
   /* Expected value is 1000.  */
-  EXPECT_GE (foundMap["silver"], 950);
-  EXPECT_LE (foundMap["silver"], 1050);
+  EXPECT_GE (foundMap["silver"], 900);
+  EXPECT_LE (foundMap["silver"], 1'100);
 }
 
 TEST_F (FinishProspectingTests, FewerPrizesInLowPrizeZone)


### PR DESCRIPTION
This implements #188:  Players are not allowed to place buildings if any of the building's tile is in a no-combat zone (neutral or starter area).