### PR TITLE
Delay the effect of building config updates

### DIFF
--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -8,6 +8,7 @@ REGTESTS = \
   accounts.py \
   buildings_basic.py \
   buildings_combat.py \
+  buildings_config.py \
   buildings_construction.py \
   buildings_enterexit.py \
   buildings_foundations.py \

--- a/gametest/buildings_config.py
+++ b/gametest/buildings_config.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests the owner configuration of buildings.
+"""
+
+from pxtest import PXTest
+
+
+class BuildingsConfigTest (PXTest):
+
+  def expectConfig (self, bId, dexFee, serviceFee):
+    """
+    Checks that the configuration of the given building matches
+    the expected values.  None values mean that the field should not
+    be explicitly set in the building config.
+    """
+
+    expected = {}
+    if dexFee is not None:
+      expected["dexfee"] = dexFee
+    if serviceFee is not None:
+      expected["servicefee"] = serviceFee
+
+    self.assertEqual (self.getBuildings ()[bId].data["config"], expected)
+
+  def expectScheduled (self, bId, expected):
+    """
+    Checks that the scheduled ongoing operations for building updates
+    match exactly the expected list.  All entries that are building updates
+    must be for the given building.  expected is a list of pairs
+    (height offset, new config), where height offset is the end height
+    of the operation relative to current block height.
+    """
+
+    height = self.rpc.xaya.getblockcount ()
+    ongoings = self.getRpc ("getongoings")
+    actual = []
+    for o in ongoings:
+      if o["operation"] != "config":
+        continue
+      self.assertEqual (o["buildingid"], bId)
+      assert "characterid" not in o
+      actual.append ((
+        o["end_height"] - height,
+        o["newconfig"],
+      ))
+
+    self.assertEqual (actual, expected)
+
+  def run (self):
+    self.collectPremine ()
+
+    self.initAccount ("domob", "r")
+    self.initAccount ("andy", "r")
+    self.generate (1)
+    self.build ("huesli", None, {"x": 0, "y": 0}, rot=0)
+    self.build ("huesli", "domob", {"x": 1, "y": 0}, rot=0)
+    buildings = self.getBuildings ()
+    lastId = max (buildings.keys ())
+    unowned = lastId - 1
+    domob = lastId
+    self.assertEqual (buildings[unowned].getOwner (), None)
+    self.assertEqual (buildings[domob].getOwner (), "domob")
+
+    # These operations are invalid.
+    self.sendMove ("andy", {"b": [
+      {"id": unowned, "sf": 1},
+      {"id": domob, "sf": 1},
+    ]})
+    buildings[domob].sendMove ({"sf": -10})
+    self.generate (1)
+
+    self.expectConfig (unowned, None, None)
+    self.expectConfig (domob, None, None)
+    self.expectScheduled (domob, [])
+
+    self.getBuildings ()[domob].sendMove ({"xf": 25, "sf": 1})
+    self.generate (1)
+    self.getBuildings ()[domob].sendMove ({})
+    self.generate (1)
+    self.getBuildings ()[domob].sendMove ({"xf": 50})
+    self.generate (1)
+    self.getBuildings ()[domob].sendMove ({"sf": 2})
+    self.getBuildings ()[domob].sendMove ({"sf": 3})
+    self.generate (1)
+
+    self.expectConfig (unowned, None, None)
+    self.expectConfig (domob, None, None)
+    self.expectScheduled (domob, [
+      (7, {"dexfee": 0.25, "servicefee": 1}),
+      (9, {"dexfee": 0.5}),
+      (10, {"servicefee": 2}),
+      (10, {"servicefee": 3}),
+    ])
+
+    self.generate (6)
+    self.expectConfig (unowned, None, None)
+    self.expectConfig (domob, None, None)
+    self.expectScheduled (domob, [
+      (1, {"dexfee": 0.25, "servicefee": 1}),
+      (3, {"dexfee": 0.5}),
+      (4, {"servicefee": 2}),
+      (4, {"servicefee": 3}),
+    ])
+
+    self.generate (1)
+    self.expectConfig (unowned, None, None)
+    self.expectConfig (domob, dexFee=0.25, serviceFee=1)
+    self.expectScheduled (domob, [
+      (2, {"dexfee": 0.5}),
+      (3, {"servicefee": 2}),
+      (3, {"servicefee": 3}),
+    ])
+
+    self.generate (2)
+    self.expectConfig (unowned, None, None)
+    self.expectConfig (domob, dexFee=0.5, serviceFee=1)
+    self.expectScheduled (domob, [
+      (1, {"servicefee": 2}),
+      (1, {"servicefee": 3}),
+    ])
+
+    self.generate (1)
+    self.expectConfig (unowned, None, None)
+    self.expectConfig (domob, dexFee=0.5, serviceFee=3)
+    self.expectScheduled (domob, [])
+
+
+if __name__ == "__main__":
+  BuildingsConfigTest ().main ()

--- a/gametest/dex.py
+++ b/gametest/dex.py
@@ -87,7 +87,9 @@ class DexTest (PXTest):
     self.giftCoins ({"buyer": 1_000})
     self.dropIntoBuilding (self.buildingId, "seller", {"foo": 10, "bar": 20})
 
-    self.generate (1)
+    # Make sure to wait long enough for the building update
+    # to have taken effect.
+    self.generate (10)
     reorgBlk = self.rpc.xaya.getbestblockhash ()
 
     self.mainLogger.info ("Transferring assets...")
@@ -109,7 +111,9 @@ class DexTest (PXTest):
     self.expectItems (self.buildingId, "gifted", {"foo": 0, "bar": 5})
 
     self.mainLogger.info ("Placing orders...")
-    firstOrderId = self.buildingId + 1
+    # After placing the building, one ID is also used up for the
+    # ongoing operation that updates the DEX fee.
+    firstOrderId = self.buildingId + 2
     self.sendMove ("seller", {"x": [
       {
         "b": self.buildingId,

--- a/gametest/getserviceinfo.py
+++ b/gametest/getserviceinfo.py
@@ -42,7 +42,8 @@ class GetServiceInfoTest (PXTest):
 
     self.getBuildings ()[building].sendMove ({"sf": 50})
     self.generate (1)
-    self.assertEqual (self.getBuildings ()[building].data["servicefee"], 50)
+    b = self.getBuildings ()[building]
+    self.assertEqual (b.data["config"]["servicefee"], 50)
 
     self.dropIntoBuilding (building, "andy", {"test ore": 3})
 

--- a/gametest/getserviceinfo.py
+++ b/gametest/getserviceinfo.py
@@ -41,7 +41,7 @@ class GetServiceInfoTest (PXTest):
     self.assertEqual (self.getBuildings ()[building].getOwner (), "domob")
 
     self.getBuildings ()[building].sendMove ({"sf": 50})
-    self.generate (1)
+    self.generate (11)
     b = self.getBuildings ()[building]
     self.assertEqual (b.data["config"]["servicefee"], 50)
 

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -48,8 +48,7 @@ class GodModeTest (PXTest):
       "faction": "a",
       "centre": {"x": 100, "y": 150},
       "rotationsteps": 2,
-      "servicefee": 0,
-      "dexfee": 0.0,
+      "config": {},
       "age": {"founded": height + 1, "finished": height + 1},
       "tiles":
         [
@@ -78,8 +77,7 @@ class GodModeTest (PXTest):
       "owner": "domob",
       "centre": {"x": -100, "y": -150},
       "rotationsteps": 0,
-      "servicefee": 0,
-      "dexfee": 0.0,
+      "config": {},
       "age": {"founded": height + 2, "finished": height + 2},
       "tiles":
         [

--- a/gametest/services_fees.py
+++ b/gametest/services_fees.py
@@ -46,7 +46,7 @@ class ServicesFeesTest (PXTest):
 
     self.mainLogger.info ("Setting service fee...")
     self.getBuildings ()[domob].sendMove ({"sf": 50})
-    self.generate (1)
+    self.generate (11)
     b = self.getBuildings ()[domob]
     self.assertEqual (b.data["config"]["servicefee"], 50)
 

--- a/gametest/services_fees.py
+++ b/gametest/services_fees.py
@@ -47,7 +47,8 @@ class ServicesFeesTest (PXTest):
     self.mainLogger.info ("Setting service fee...")
     self.getBuildings ()[domob].sendMove ({"sf": 50})
     self.generate (1)
-    self.assertEqual (self.getBuildings ()[domob].data["servicefee"], 50)
+    b = self.getBuildings ()[domob]
+    self.assertEqual (b.data["config"]["servicefee"], 50)
 
     self.mainLogger.info ("Using 'free' services...")
     self.giftCoins ({"domob": 10, "andy": 10})

--- a/proto/building.proto
+++ b/proto/building.proto
@@ -74,18 +74,30 @@ message Building
   optional CombatData combat_data = 5;
 
   /**
-   * The service fee that users need to pay to the building owner for using
-   * services in the building.  This is a percentage of the service's base
-   * fee (the burnt amount).
+   * Configuration data for a building, which can be changed by the
+   * building's owner at will.
    */
-  optional uint32 service_fee_percent = 6;
+  message Config
+  {
 
-  /**
-   * The fee charged by the building owner for trades on the building's DEX.
-   * This is in basis points (1/100 of a percent) and paid by the seller
-   * from the received Cubits.
-   */
-  optional int32 dex_fee_bps = 7;
+    /**
+     * The service fee that users need to pay to the building owner for using
+     * services in the building.  This is a percentage of the service's base
+     * fee (the burnt amount).
+     */
+    optional uint32 service_fee_percent = 1;
+
+    /**
+     * The fee charged by the building owner for trades on the building's DEX.
+     * This is in basis points (1/100 of a percent) and paid by the seller
+     * from the received Cubits.
+     */
+    optional int32 dex_fee_bps = 2;
+
+  }
+
+  /** The current configuration for the building.  */
+  optional Config config = 6;
 
   /**
    * Data about the building age, i.e. the block heights when it was founded
@@ -103,6 +115,6 @@ message Building
   }
 
   /** Age data for this building.  */
-  optional AgeData age_data = 8;
+  optional AgeData age_data = 7;
 
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -572,25 +572,31 @@ message Params
   /** Nubmer of blocks for constructing an item, per complexity.  */
   optional uint32 construction_blocks = 11;
 
+  /**
+   * Delay (in blocks) until an owner-initiated update to the building
+   * configuration takes effect.
+   */
+  optional uint32 building_update_delay = 12;
+
   /** Base fee (which is burnt) paid by sellers on the DEX in basis points.  */
-  optional uint32 dex_fee_bps = 12;
+  optional uint32 dex_fee_bps = 13;
 
   /** Minimum units of ore found in a prospected region.  */
-  optional int64 min_region_ore = 13;
+  optional int64 min_region_ore = 14;
   /** Maximum units of ore found in a prospected region.  */
-  optional int64 max_region_ore = 14;
+  optional int64 max_region_ore = 15;
 
   /** The address to which developer payments should be sent.  */
-  optional string dev_addr = 15;
+  optional string dev_addr = 16;
 
   /** Whether or not god mode is enabled.  */
-  optional bool god_mode = 16;
+  optional bool god_mode = 17;
 
   /** Spawn areas for the factions (with the "r", "g", "b" string as key).  */
-  map<string, SpawnArea> spawn_areas = 17;
+  map<string, SpawnArea> spawn_areas = 18;
 
   /** Data about the burnsale schedule.  */
-  repeated BurnsaleStage burnsale_stages = 18;
+  repeated BurnsaleStage burnsale_stages = 19;
 
   /**
    * Prospecting prizes.  They are just a list and not a map, because the
@@ -600,7 +606,7 @@ message Params
    * It is replaced rather than concatenated (which would be the default
    * behaviour for proto merge).
    */
-  repeated ProspectingPrize prizes = 19;
+  repeated ProspectingPrize prizes = 20;
 
 }
 

--- a/proto/ongoing.proto
+++ b/proto/ongoing.proto
@@ -19,6 +19,8 @@
 syntax = "proto2";
 option cc_enable_arenas = true;
 
+import "proto/building.proto";
+
 package pxd.proto;
 
 /**
@@ -122,6 +124,19 @@ message BuildingConstruction
 }
 
 /**
+ * An operation for changing the owner-configurable building data.  This is
+ * delayed to prevent frontrunning.  At the end of the ongoing operation,
+ * the data will be updated in the building itself.
+ */
+message BuildingConfigUpdate
+{
+
+  /** The new configuration data.  */
+  optional Building.Config new_config = 1;
+
+}
+
+/**
  * Data about an ongoing operation.
  */
 message OngoingOperation
@@ -141,6 +156,7 @@ message OngoingOperation
     BlueprintCopy blueprint_copy = 103;
     ItemConstruction item_construction = 104;
     BuildingConstruction building_construction = 105;
+    BuildingConfigUpdate building_update = 106;
   }
 
   /* The database stores extra data directly in columns:

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -15,6 +15,7 @@ params:
     construction_cost: 1
     construction_blocks: 1
 
+    building_update_delay: 120
     dex_fee_bps: 300  # 3% base fee for sellers
 
     min_region_ore: 2000000

--- a/proto/roconfig/test_params.pb.text
+++ b/proto/roconfig/test_params.pb.text
@@ -9,6 +9,7 @@ params:
     bp_copy_blocks: 10
     construction_cost: 100
     construction_blocks: 10
+    building_update_delay: 10
     dex_fee_bps: 1000  # 10% base fee for simpler numbers
 
     # We have tests that use up all materials (and then reprospect a region),

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -557,6 +557,11 @@ template <>
       res["operation"] = "build";
       break;
 
+    case proto::OngoingOperation::kBuildingUpdate:
+      res["operation"] = "config";
+      res["newconfig"] = Convert (pb.building_update ().new_config ());
+      break;
+
     default:
       LOG (FATAL) << "Unexpected ongoing operation case: " << pb.op_case ();
     }

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -326,6 +326,19 @@ template <>
   return res;
 }
 
+template <>
+  Json::Value
+  GameStateJson::Convert<proto::Building::Config> (
+      const proto::Building::Config& cfg) const
+{
+  Json::Value res(Json::objectValue);
+  if (cfg.has_service_fee_percent ())
+    res["servicefee"] = IntToJson (cfg.service_fee_percent ());
+  if (cfg.has_dex_fee_bps ())
+    res["dexfee"] = cfg.dex_fee_bps () / 100.0;
+  return res;
+}
+
 namespace
 {
 
@@ -411,8 +424,7 @@ template <>
   res["centre"] = CoordToJson (b.GetCentre ());
 
   res["rotationsteps"] = IntToJson (pb.shape_trafo ().rotation_steps ());
-  res["servicefee"] = IntToJson (pb.service_fee_percent ());
-  res["dexfee"] = pb.dex_fee_bps () / 100.0;
+  res["config"] = Convert (pb.config ());
 
   Json::Value tiles(Json::arrayValue);
   for (const auto& c : GetBuildingShape (b, ctx))

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -1249,6 +1249,51 @@ TEST_F (OngoingsJsonTests, BuildingConstruction)
   })");
 }
 
+TEST_F (OngoingsJsonTests, BuildingConfigUpdate)
+{
+  auto op = tbl.CreateNew (1);
+  ASSERT_EQ (op->GetId (), 1);
+  op->SetBuildingId (42);
+  op->MutableProto ().mutable_building_update ();
+  op.reset ();
+
+  ExpectStateJson (R"({
+    "ongoings":
+      [
+        {
+          "id": 1,
+          "operation": "config",
+          "newconfig":
+            {
+              "servicefee": null,
+              "dexfee": null
+            }
+        }
+      ]
+  })");
+
+  op = tbl.GetById (1);
+  auto* upd = op->MutableProto ().mutable_building_update ();
+  upd->mutable_new_config ()->set_service_fee_percent (2);
+  upd->mutable_new_config ()->set_dex_fee_bps (150);
+  op.reset ();
+
+  ExpectStateJson (R"({
+    "ongoings":
+      [
+        {
+          "id": 1,
+          "operation": "config",
+          "newconfig":
+            {
+              "servicefee": 2,
+              "dexfee": 1.5
+            }
+        }
+      ]
+  })");
+}
+
 /* ************************************************************************** */
 
 class RegionJsonTests : public GameStateJsonTests

--- a/src/gamestatejson_tests.cpp
+++ b/src/gamestatejson_tests.cpp
@@ -877,15 +877,18 @@ TEST_F (BuildingJsonTests, ConfiguredFees)
       [
         {
           "id": 1,
-          "servicefee": 0,
-          "dexfee": 0.0
+          "config":
+            {
+              "servicefee": null,
+              "dexfee": null
+            }
         }
       ]
   })");
 
   b = tbl.GetById (1);
-  b->MutableProto ().set_service_fee_percent (42);
-  b->MutableProto ().set_dex_fee_bps (1'725);
+  b->MutableProto ().mutable_config ()->set_service_fee_percent (42);
+  b->MutableProto ().mutable_config ()->set_dex_fee_bps (1'725);
   b.reset ();
 
   ExpectStateJson (R"({
@@ -893,8 +896,11 @@ TEST_F (BuildingJsonTests, ConfiguredFees)
       [
         {
           "id": 1,
-          "servicefee": 42,
-          "dexfee": 17.25
+          "config":
+            {
+              "servicefee": 42,
+              "dexfee": 17.25
+            }
         }
       ]
   })");

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -1800,7 +1800,7 @@ MaybeUpdateServiceFee (Building& b, const Json::Value& upd)
   LOG (INFO)
       << "Setting service fee for building " << b.GetId ()
       << " to " << val << "%";
-  b.MutableProto ().set_service_fee_percent (val);
+  b.MutableProto ().mutable_config ()->set_service_fee_percent (val);
 }
 
 /**
@@ -1824,7 +1824,7 @@ MaybeUpdateDexFee (Building& b, const Json::Value& upd)
   LOG (INFO)
       << "Setting DEX fee for building " << b.GetId ()
       << " to " << val << " basis points";
-  b.MutableProto ().set_dex_fee_bps (val);
+  b.MutableProto ().mutable_config ()->set_dex_fee_bps (val);
 }
 
 } // anonymous namespace

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -3238,8 +3238,7 @@ TEST_F (BuildingUpdateTests, InvalidFormat)
     }
   ])");
 
-  EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)
-                  ->GetProto ().has_service_fee_percent ());
+  EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)->GetProto ().has_config ());
 }
 
 TEST_F (BuildingUpdateTests, NonExistantBuilding)
@@ -3250,8 +3249,7 @@ TEST_F (BuildingUpdateTests, NonExistantBuilding)
       "move": {"b": {"id": 12345, "sf": 10}}
     }
   ])");
-  EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)
-                  ->GetProto ().has_service_fee_percent ());
+  EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)->GetProto ().has_config ());
 }
 
 TEST_F (BuildingUpdateTests, AncientCannotBeUpdated)
@@ -3262,8 +3260,7 @@ TEST_F (BuildingUpdateTests, AncientCannotBeUpdated)
       "move": {"b": {"id": 100, "sf": 10}}
     }
   ])");
-  EXPECT_FALSE (buildings.GetById (ANCIENT)
-                  ->GetProto ().has_service_fee_percent ());
+  EXPECT_FALSE (buildings.GetById (ANCIENT)->GetProto ().has_config ());
 }
 
 TEST_F (BuildingUpdateTests, NotOwner)
@@ -3274,8 +3271,7 @@ TEST_F (BuildingUpdateTests, NotOwner)
       "move": {"b": {"id": 101, "sf": 10}}
     }
   ])");
-  EXPECT_FALSE (buildings.GetById (ANDY_OWNED)
-                  ->GetProto ().has_service_fee_percent ());
+  EXPECT_FALSE (buildings.GetById (ANDY_OWNED)->GetProto ().has_config ());
 }
 
 TEST_F (BuildingUpdateTests, ArrayUpdate)
@@ -3291,10 +3287,9 @@ TEST_F (BuildingUpdateTests, ArrayUpdate)
       ]}
     }
   ])");
-  EXPECT_FALSE (buildings.GetById (ANDY_OWNED)
-                  ->GetProto ().has_service_fee_percent ());
+  EXPECT_FALSE (buildings.GetById (ANDY_OWNED)->GetProto ().has_config ());
   EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
-                ->GetProto ().service_fee_percent (), 70);
+                ->GetProto ().config ().service_fee_percent (), 70);
 }
 
 TEST_F (BuildingUpdateTests, SetServiceFee)
@@ -3310,9 +3305,9 @@ TEST_F (BuildingUpdateTests, SetServiceFee)
     }
   ])");
   EXPECT_EQ (buildings.GetById (ANDY_OWNED)
-                ->GetProto ().service_fee_percent (), 1'000);
+                ->GetProto ().config ().service_fee_percent (), 1'000);
   EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
-                ->GetProto ().service_fee_percent (), 1);
+                ->GetProto ().config ().service_fee_percent (), 1);
 
   Process (R"([
     {
@@ -3337,9 +3332,9 @@ TEST_F (BuildingUpdateTests, SetServiceFee)
     }
   ])");
   EXPECT_EQ (buildings.GetById (ANDY_OWNED)
-                ->GetProto ().service_fee_percent (), 1'000);
+                ->GetProto ().config ().service_fee_percent (), 1'000);
   EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
-                ->GetProto ().service_fee_percent (), 0);
+                ->GetProto ().config ().service_fee_percent (), 0);
 }
 
 TEST_F (BuildingUpdateTests, SetDexFee)
@@ -3354,8 +3349,12 @@ TEST_F (BuildingUpdateTests, SetDexFee)
       "move": {"b": {"id": 102, "xf": 100}}
     }
   ])");
-  EXPECT_EQ (buildings.GetById (ANDY_OWNED)->GetProto ().dex_fee_bps (), 3'000);
-  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)->GetProto ().dex_fee_bps (), 100);
+  EXPECT_EQ (buildings.GetById (ANDY_OWNED)
+                ->GetProto ().config ().dex_fee_bps (),
+             3'000);
+  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
+                ->GetProto ().config ().dex_fee_bps (),
+             100);
 
   Process (R"([
     {
@@ -3379,8 +3378,12 @@ TEST_F (BuildingUpdateTests, SetDexFee)
       "move": {"b": {"id": 102, "xf": 0}}
     }
   ])");
-  EXPECT_EQ (buildings.GetById (ANDY_OWNED)->GetProto ().dex_fee_bps (), 3'000);
-  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)->GetProto ().dex_fee_bps (), 0);
+  EXPECT_EQ (buildings.GetById (ANDY_OWNED)
+                ->GetProto ().config ().dex_fee_bps (),
+             3'000);
+  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
+                ->GetProto ().config ().dex_fee_bps (),
+             0);
 }
 
 /* ************************************************************************** */

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -3198,14 +3198,16 @@ protected:
   static constexpr Database::IdT DOMOB_OWNED = 102;
 
   BuildingsTable buildings;
+  OngoingsTable ongoings;
 
   BuildingUpdateTests ()
-    : buildings(db)
+    : buildings(db), ongoings(db)
   {
     accounts.CreateNew ("domob")->SetFaction (Faction::RED);
     accounts.CreateNew ("andy")->SetFaction (Faction::RED);
 
     db.SetNextId (100);
+    ctx.SetHeight (10);
 
     auto b = buildings.CreateNew ("ancient1", "", Faction::ANCIENT);
     CHECK_EQ (b->GetId (), ANCIENT);
@@ -3220,7 +3222,17 @@ protected:
     b->SetCentre (HexCoord (10, 10));
   }
 
+  void
+  ExpectNoOngoings ()
+  {
+    ASSERT_FALSE (ongoings.QueryAll ().Step ());
+  }
+
 };
+
+constexpr Database::IdT BuildingUpdateTests::ANCIENT;
+constexpr Database::IdT BuildingUpdateTests::ANDY_OWNED;
+constexpr Database::IdT BuildingUpdateTests::DOMOB_OWNED;
 
 TEST_F (BuildingUpdateTests, InvalidFormat)
 {
@@ -3239,6 +3251,7 @@ TEST_F (BuildingUpdateTests, InvalidFormat)
   ])");
 
   EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)->GetProto ().has_config ());
+  ExpectNoOngoings ();
 }
 
 TEST_F (BuildingUpdateTests, NonExistantBuilding)
@@ -3250,6 +3263,7 @@ TEST_F (BuildingUpdateTests, NonExistantBuilding)
     }
   ])");
   EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)->GetProto ().has_config ());
+  ExpectNoOngoings ();
 }
 
 TEST_F (BuildingUpdateTests, AncientCannotBeUpdated)
@@ -3261,6 +3275,7 @@ TEST_F (BuildingUpdateTests, AncientCannotBeUpdated)
     }
   ])");
   EXPECT_FALSE (buildings.GetById (ANCIENT)->GetProto ().has_config ());
+  ExpectNoOngoings ();
 }
 
 TEST_F (BuildingUpdateTests, NotOwner)
@@ -3272,6 +3287,7 @@ TEST_F (BuildingUpdateTests, NotOwner)
     }
   ])");
   EXPECT_FALSE (buildings.GetById (ANDY_OWNED)->GetProto ().has_config ());
+  ExpectNoOngoings ();
 }
 
 TEST_F (BuildingUpdateTests, ArrayUpdate)
@@ -3287,28 +3303,35 @@ TEST_F (BuildingUpdateTests, ArrayUpdate)
       ]}
     }
   ])");
+
   EXPECT_FALSE (buildings.GetById (ANDY_OWNED)->GetProto ().has_config ());
-  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
-                ->GetProto ().config ().service_fee_percent (), 70);
+  EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)->GetProto ().has_config ());
+
+  auto res = ongoings.QueryAll ();
+
+  ASSERT_TRUE (res.Step ());
+  auto op = ongoings.GetFromResult (res);
+  EXPECT_EQ (op->GetCharacterId (), Database::EMPTY_ID);
+  EXPECT_EQ (op->GetBuildingId (), DOMOB_OWNED);
+  EXPECT_EQ (op->GetHeight (), 20);
+  const auto* upd = &op->GetProto ().building_update ();
+  EXPECT_EQ (upd->new_config ().service_fee_percent (), 10);
+  EXPECT_FALSE (upd->new_config ().has_dex_fee_bps ());
+
+  ASSERT_TRUE (res.Step ());
+  op = ongoings.GetFromResult (res);
+  EXPECT_EQ (op->GetCharacterId (), Database::EMPTY_ID);
+  EXPECT_EQ (op->GetBuildingId (), DOMOB_OWNED);
+  EXPECT_EQ (op->GetHeight (), 20);
+  upd = &op->GetProto ().building_update ();
+  EXPECT_EQ (upd->new_config ().service_fee_percent (), 70);
+  EXPECT_FALSE (upd->new_config ().has_dex_fee_bps ());
+
+  EXPECT_FALSE (res.Step ());
 }
 
 TEST_F (BuildingUpdateTests, SetServiceFee)
 {
-  Process (R"([
-    {
-      "name": "andy",
-      "move": {"b": {"id": 101, "x": 42, "sf": 1000}}
-    },
-    {
-      "name": "domob",
-      "move": {"b": [{"id": 101, "sf": 0}, {"id": 102, "sf": 1}]}
-    }
-  ])");
-  EXPECT_EQ (buildings.GetById (ANDY_OWNED)
-                ->GetProto ().config ().service_fee_percent (), 1'000);
-  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
-                ->GetProto ().config ().service_fee_percent (), 1);
-
   Process (R"([
     {
       "name": "andy",
@@ -3325,37 +3348,47 @@ TEST_F (BuildingUpdateTests, SetServiceFee)
     {
       "name": "andy",
       "move": {"b": {"id": 101, "sf": "42"}}
+    }
+  ])");
+  EXPECT_FALSE (buildings.GetById (ANDY_OWNED)->GetProto ().has_config ());
+  ExpectNoOngoings ();
+
+  Process (R"([
+    {
+      "name": "andy",
+      "move": {"b": {"id": 101, "x": 42, "sf": 1000}}
     },
     {
       "name": "domob",
       "move": {"b": {"id": 102, "sf": 0}}
     }
   ])");
-  EXPECT_EQ (buildings.GetById (ANDY_OWNED)
-                ->GetProto ().config ().service_fee_percent (), 1'000);
-  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
-                ->GetProto ().config ().service_fee_percent (), 0);
+
+  EXPECT_FALSE (buildings.GetById (ANDY_OWNED)->GetProto ().has_config ());
+  EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)->GetProto ().has_config ());
+
+  auto res = ongoings.QueryAll ();
+
+  ASSERT_TRUE (res.Step ());
+  auto op = ongoings.GetFromResult (res);
+  EXPECT_EQ (op->GetBuildingId (), ANDY_OWNED);
+  const auto* upd = &op->GetProto ().building_update ();
+  EXPECT_EQ (upd->new_config ().service_fee_percent (), 1'000);
+  EXPECT_FALSE (upd->new_config ().has_dex_fee_bps ());
+
+  ASSERT_TRUE (res.Step ());
+  op = ongoings.GetFromResult (res);
+  EXPECT_EQ (op->GetBuildingId (), DOMOB_OWNED);
+  upd = &op->GetProto ().building_update ();
+  EXPECT_TRUE (upd->new_config ().has_service_fee_percent ());
+  EXPECT_EQ (upd->new_config ().service_fee_percent (), 0);
+  EXPECT_FALSE (upd->new_config ().has_dex_fee_bps ());
+
+  EXPECT_FALSE (res.Step ());
 }
 
 TEST_F (BuildingUpdateTests, SetDexFee)
 {
-  Process (R"([
-    {
-      "name": "andy",
-      "move": {"b": {"id": 101, "xf": 3000}}
-    },
-    {
-      "name": "domob",
-      "move": {"b": {"id": 102, "xf": 100}}
-    }
-  ])");
-  EXPECT_EQ (buildings.GetById (ANDY_OWNED)
-                ->GetProto ().config ().dex_fee_bps (),
-             3'000);
-  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
-                ->GetProto ().config ().dex_fee_bps (),
-             100);
-
   Process (R"([
     {
       "name": "andy",
@@ -3372,18 +3405,43 @@ TEST_F (BuildingUpdateTests, SetDexFee)
     {
       "name": "andy",
       "move": {"b": {"id": 101, "xf": "42"}}
+    }
+  ])");
+  EXPECT_FALSE (buildings.GetById (ANDY_OWNED)->GetProto ().has_config ());
+  ExpectNoOngoings ();
+
+  Process (R"([
+    {
+      "name": "andy",
+      "move": {"b": {"id": 101, "xf": 3000}}
     },
     {
       "name": "domob",
       "move": {"b": {"id": 102, "xf": 0}}
     }
   ])");
-  EXPECT_EQ (buildings.GetById (ANDY_OWNED)
-                ->GetProto ().config ().dex_fee_bps (),
-             3'000);
-  EXPECT_EQ (buildings.GetById (DOMOB_OWNED)
-                ->GetProto ().config ().dex_fee_bps (),
-             0);
+
+  EXPECT_FALSE (buildings.GetById (ANDY_OWNED)->GetProto ().has_config ());
+  EXPECT_FALSE (buildings.GetById (DOMOB_OWNED)->GetProto ().has_config ());
+
+  auto res = ongoings.QueryAll ();
+
+  ASSERT_TRUE (res.Step ());
+  auto op = ongoings.GetFromResult (res);
+  EXPECT_EQ (op->GetBuildingId (), ANDY_OWNED);
+  const auto* upd = &op->GetProto ().building_update ();
+  EXPECT_EQ (upd->new_config ().dex_fee_bps (), 3'000);
+  EXPECT_FALSE (upd->new_config ().has_service_fee_percent ());
+
+  ASSERT_TRUE (res.Step ());
+  op = ongoings.GetFromResult (res);
+  EXPECT_EQ (op->GetBuildingId (), DOMOB_OWNED);
+  upd = &op->GetProto ().building_update ();
+  EXPECT_TRUE (upd->new_config ().has_dex_fee_bps ());
+  EXPECT_EQ (upd->new_config ().dex_fee_bps (), 0);
+  EXPECT_FALSE (upd->new_config ().has_service_fee_percent ());
+
+  EXPECT_FALSE (res.Step ());
 }
 
 /* ************************************************************************** */

--- a/src/ongoings.cpp
+++ b/src/ongoings.cpp
@@ -203,6 +203,20 @@ ProcessAllOngoings (Database& db, xaya::Random& rnd, const Context& ctx)
           FinishBuildingConstruction (*b, ctx, buildingInv);
           break;
 
+        case proto::OngoingOperation::kBuildingUpdate:
+          {
+            CHECK (b != nullptr);
+            const auto& newConfig
+                = op->GetProto ().building_update ().new_config ();
+            LOG (INFO)
+                << "Executing delayed config update for building "
+                << b->GetId () << ":\n" << newConfig.DebugString ();
+            /* We want to merge here rather than assign, so that fields
+               unset in the newConfig are left untouched.  */
+            b->MutableProto ().mutable_config ()->MergeFrom (newConfig);
+            break;
+          }
+
         default:
           LOG (FATAL)
               << "Unexpected operation case: " << op->GetProto ().op_case ();

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -1038,7 +1038,8 @@ ServiceOperation::GetCosts (Amount& base, Amount& fee) const
   /* Otherwise the service fee is determined as a percentage of the base cost,
      with the percentage given by the building configuration.  The result
      is rounded up.  */
-  fee = (base * building->GetProto ().service_fee_percent () + 99) / 100;
+  const auto& cfg = building->GetProto ().config ();
+  fee = (base * cfg.service_fee_percent () + 99) / 100;
 }
 
 std::string

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -247,7 +247,7 @@ TEST_F (ServicesTests, PendingJson)
 
   auto b = buildings.CreateNew ("ancient1", "andy", Faction::RED);
   ASSERT_EQ (b->GetId (), 101);
-  b->MutableProto ().set_service_fee_percent (50);
+  b->MutableProto ().mutable_config ()->set_service_fee_percent (50);
   b.reset ();
 
   inv.Get (101, "domob")->GetInventory ().AddFungibleCount ("test ore", 10);
@@ -310,7 +310,8 @@ TEST_F (ServicesFeeTests, NoFeeInAncientBuilding)
 
 TEST_F (ServicesFeeTests, NoFeeInOwnBuilding)
 {
-  buildings.GetById (101)->MutableProto ().set_service_fee_percent (50);
+  buildings.GetById (101)
+      ->MutableProto ().mutable_config ()->set_service_fee_percent (50);
   ASSERT_TRUE (Process ("andy", R"({
     "t": "ref",
     "b": 101,
@@ -324,7 +325,7 @@ TEST_F (ServicesFeeTests, InsufficientBalanceWithFee)
 {
   auto b = buildings.CreateNew ("ancient1", "domob", Faction::RED);
   ASSERT_EQ (b->GetId (), 102);
-  b->MutableProto ().set_service_fee_percent (50);
+  b->MutableProto ().mutable_config ()->set_service_fee_percent (50);
   b.reset ();
 
   inv.Get (102, "andy")
@@ -341,7 +342,8 @@ TEST_F (ServicesFeeTests, InsufficientBalanceWithFee)
 
 TEST_F (ServicesFeeTests, NormalFeePayment)
 {
-  buildings.GetById (101)->MutableProto ().set_service_fee_percent (50);
+  buildings.GetById (101)
+      ->MutableProto ().mutable_config ()->set_service_fee_percent (50);
   ASSERT_TRUE (Process ("domob", R"({
     "t": "ref",
     "b": 101,
@@ -354,7 +356,8 @@ TEST_F (ServicesFeeTests, NormalFeePayment)
 
 TEST_F (ServicesFeeTests, ZeroFeePossible)
 {
-  buildings.GetById (101)->MutableProto ().set_service_fee_percent (0);
+  buildings.GetById (101)
+      ->MutableProto ().mutable_config ()->set_service_fee_percent (0);
   ASSERT_TRUE (Process ("domob", R"({
     "t": "ref",
     "b": 101,
@@ -367,7 +370,8 @@ TEST_F (ServicesFeeTests, ZeroFeePossible)
 
 TEST_F (ServicesFeeTests, FeeRoundedUp)
 {
-  buildings.GetById (101)->MutableProto ().set_service_fee_percent (1);
+  buildings.GetById (101)
+      ->MutableProto ().mutable_config ()->set_service_fee_percent (1);
   ASSERT_TRUE (Process ("domob", R"({
     "t": "ref",
     "b": 101,

--- a/src/trading.cpp
+++ b/src/trading.cpp
@@ -293,7 +293,7 @@ NewOrderOperation::PayToSellerAndFee (const std::string& recipient,
   CHECK (b != nullptr);
 
   const int baseBps = ctx.RoConfig ()->params ().dex_fee_bps ();
-  const int ownerBps = b->GetProto ().dex_fee_bps ();
+  const int ownerBps = b->GetProto ().config ().dex_fee_bps ();
   const int totalBps = baseBps + ownerBps;
 
   if (b->GetFaction () == Faction::ANCIENT)

--- a/src/trading_tests.cpp
+++ b/src/trading_tests.cpp
@@ -517,7 +517,8 @@ protected:
        owner fee to -10%, which offsets the base fee on regtest completely.
        This obviously only works by changing the value directly, and won't
        be possible to do in the real game through moves.  */
-    buildings.GetById (1)->MutableProto ().set_dex_fee_bps (-1'000);
+    buildings.GetById (1)
+        ->MutableProto ().mutable_config ()->set_dex_fee_bps (-1'000);
     accounts.GetByName ("building")->AddBalance (1'000'000);
 
     /* Future orders (placed by the test) will have IDs from 201.  */
@@ -715,7 +716,8 @@ protected:
         ->GetInventory ().AddFungibleCount ("foo", 1'000);
 
     /* Owner fee in the tests is 20%, for a total fee of 30%.  */
-    buildings.GetById (1)->MutableProto ().set_dex_fee_bps (2'000);
+    buildings.GetById (1)
+        ->MutableProto ().mutable_config ()->set_dex_fee_bps (2'000);
 
     db.SetNextId (101);
   }


### PR DESCRIPTION
This implements #95:  When a building owner updates the configuration (service and DEX fee), this no longer takes place immediately.  Instead, it starts a new type of ongoing operation for a "delayed update", and only changes the building configuration after a certain number of blocks (120 on mainnet, 10 on regtest).  This prevents frontrunning attacks against users of the building.

As a side effect, this also changes the game-state JSON format for the building configuration.  Instead of returning `dexfee` and `servicefee` directly inside the building JSON, they are now wrapped into a new `config` sub-object (whose format is reused for the delayed-update ongoing operations).  Fields are only present in there if they are actually set vs. being the default value of 0.