### PR TITLE
Allow building transfers

### DIFF
--- a/gametest/charon.py
+++ b/gametest/charon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2021  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -193,6 +193,7 @@ class CharonTest (PXTest):
       w.assertRunning ()
       self.createCharacters ("domob", 1)
       self.assertEqual (w.wait ()["pending"], {
+        "buildings": [],
         "characters": [],
         "newcharacters":
           [

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2021  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -64,11 +64,11 @@ class PendingTest (PXTest):
     self.moveCharactersTo ({
       "domob": positionProspect,
       "miner": positionMining,
-      "inbuilding": offsetCoord (positionBuilding, {"x": 30, "y": 0}, False),
-      "inbuilding 2": offsetCoord (positionBuilding, {"x": -30, "y": 0}, False),
+      "inbuilding": offsetCoord (positionBuilding, {"x": 10, "y": 0}, False),
+      "inbuilding 2": offsetCoord (positionBuilding, {"x": -10, "y": 0}, False),
     })
 
-    self.build ("ancient1", None, positionBuilding, 0)
+    self.build ("b cc", "inbuilding", positionBuilding, 0)
     building = list (self.getBuildings ().keys ())[-1]
     self.dropIntoBuilding (building, "andy", {"foo": 100, "test ore": 10})
     self.getCharacters ()["inbuilding"].sendMove ({"eb": building})
@@ -78,6 +78,7 @@ class PendingTest (PXTest):
     self.generate (15)
     self.syncGame ()
     self.assertEqual (self.getPendingState (), {
+      "buildings": [],
       "characters": [],
       "newcharacters": [],
       "accounts": [],
@@ -103,6 +104,7 @@ class PendingTest (PXTest):
         [
           {"name": "domob", "creations": [{"faction": "r"}]},
         ],
+      "buildings": [],
       "accounts": [],
     })
 
@@ -144,6 +146,7 @@ class PendingTest (PXTest):
           {"name": "andy", "creations": [{"faction": "b"}]},
           {"name": "domob", "creations": [{"faction": "r"}] * 2},
         ],
+      "buildings": [],
       "accounts": [],
     })
 
@@ -166,9 +169,18 @@ class PendingTest (PXTest):
         ],
     })
 
+    self.getBuildings ()[building].sendMove ({"sf": 3})
+
     sleepSome ()
     oldPending = self.getPendingState ()
     self.assertEqual (oldPending, {
+      "buildings":
+        [
+          {
+            "id": building,
+            "newconfig": {"servicefee": 3},
+          },
+        ],
       "characters":
         [
           {
@@ -237,6 +249,7 @@ class PendingTest (PXTest):
     self.generate (1)
     self.syncGame ()
     self.assertEqual (self.getPendingState (), {
+      "buildings": [],
       "characters": [],
       "newcharacters": [],
       "accounts": [],
@@ -292,6 +305,7 @@ class PendingTest (PXTest):
             "drop": False,
           }
         ],
+      "buildings": [],
       "newcharacters": [],
       "accounts": [],
     })

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -326,10 +326,8 @@ template <>
   return res;
 }
 
-template <>
-  Json::Value
-  GameStateJson::Convert<proto::Building::Config> (
-      const proto::Building::Config& cfg) const
+Json::Value
+GameStateJson::Convert (const proto::Building::Config& cfg)
 {
   Json::Value res(Json::objectValue);
   if (cfg.has_service_fee_percent ())

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@
 #include "database/dex.hpp"
 #include "database/inventory.hpp"
 #include "mapdata/basemap.hpp"
+#include "proto/building.pb.h"
 
 #include <json/json.h>
 
@@ -78,6 +79,13 @@ public:
   GameStateJson () = delete;
   GameStateJson (const GameStateJson&) = delete;
   void operator= (const GameStateJson&) = delete;
+
+  /**
+   * Converts a building configuration proto to JSON.  This does not need
+   * any members and can thus be static (and is being used as such from
+   * the pending code).
+   */
+  static Json::Value Convert (const proto::Building::Config& val);
 
   /**
    * Converts a state instance (like a Character or Region) to the corresponding

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -91,6 +91,14 @@ struct CoinTransferBurn
  */
 class BaseMoveProcessor
 {
+
+private:
+
+  /**
+   * Tries to parse updates to a building from a move.  When successful,
+   * the corresponding Perform* functions will be called on the instance.
+   */
+  void TryBuildingUpdate (Building& b, const Json::Value& upd);
 
 protected:
 
@@ -307,10 +315,11 @@ protected:
 
   /**
    * This function is called when TryBuildingUpdates found a valid update
-   * that should be performed.
+   * to the building configuration, that should be scheduled.
    */
   virtual void
-  PerformBuildingUpdate (Building& b, const Json::Value& upd)
+  PerformBuildingConfigUpdate (Building& b,
+                               const proto::Building::Config& newConfig)
   {}
 
   /**
@@ -453,7 +462,8 @@ protected:
 
   void PerformCharacterCreation (Account& acc, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& mv) override;
-  void PerformBuildingUpdate (Building& b, const Json::Value& mv) override;
+  void PerformBuildingConfigUpdate (
+      Building& b, const proto::Building::Config& newConfig) override;
   void PerformServiceOperation (ServiceOperation& op) override;
   void PerformDexOperation (DexOperation& op) override;
 

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -95,6 +95,13 @@ class BaseMoveProcessor
 private:
 
   /**
+   * Tries to parse a "send building" command from the JSON update
+   * of a building and validate it.  If it is valid, the PerformBuildingTransfer
+   * function is called.
+   */
+  void MaybeTransferBuilding (Building& b, const Json::Value& upd);
+
+  /**
    * Tries to parse updates to a building from a move.  When successful,
    * the corresponding Perform* functions will be called on the instance.
    */
@@ -323,6 +330,14 @@ protected:
   {}
 
   /**
+   * This function is called when TryBuildingUpdates found a valid
+   * transfer of a building to a new owner.
+   */
+  virtual void
+  PerformBuildingTransfer (Building& b, const Account& newOwner)
+  {}
+
+  /**
    * This function is called when TryServiceOperations found a valid
    * service operation.
    */
@@ -462,8 +477,11 @@ protected:
 
   void PerformCharacterCreation (Account& acc, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& mv) override;
+
   void PerformBuildingConfigUpdate (
       Building& b, const proto::Building::Config& newConfig) override;
+  void PerformBuildingTransfer (Building& b, const Account& newOwner) override;
+
   void PerformServiceOperation (ServiceOperation& op) override;
   void PerformDexOperation (DexOperation& op) override;
 

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -108,6 +108,16 @@ PendingState::AddBuildingConfig (const Building& b,
 }
 
 void
+PendingState::AddBuildingTransfer (const Building& b,
+                                   const std::string& newOwner)
+{
+  VLOG (1)
+      << "Adding pending building transfer of " << b.GetId ()
+      << " to account " << newOwner;
+  GetBuildingState (b).sentTo = newOwner;
+}
+
+void
 PendingState::AddCharacterWaypoints (const Character& ch,
                                      const std::vector<HexCoord>& wp,
                                      const bool replace)
@@ -378,6 +388,9 @@ PendingState::BuildingState::ToJson () const
   if (!cfg.empty ())
     res["newconfig"] = cfg;
 
+  if (!sentTo.empty ())
+    res["sentto"] = sentTo;
+
   return res;
 }
 
@@ -535,6 +548,13 @@ PendingStateUpdater::PerformBuildingConfigUpdate (
     Building& b, const proto::Building::Config& newConfig)
 {
   state.AddBuildingConfig (b, newConfig);
+}
+
+void
+PendingStateUpdater::PerformBuildingTransfer (Building& b,
+                                              const Account& newOwner)
+{
+  state.AddBuildingTransfer (b, newOwner.GetName ());
 }
 
 void

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -65,6 +65,14 @@ private:
     proto::Building::Config newConfig;
 
     /**
+     * The account name the building is being sent to (if any).  If there
+     * are multiple, the last one (although typically in such a situation
+     * it will be incorrect, since the move validation is done based on
+     * the confirmed owner and not the actual "current" one).
+     */
+    std::string sentTo;
+
+    /**
      * Returns the JSON representation of the pending state.
      */
     Json::Value ToJson () const;
@@ -227,6 +235,11 @@ public:
                           const proto::Building::Config& newConfig);
 
   /**
+   * Updates the state for a building transfer.
+   */
+  void AddBuildingTransfer (const Building& b, const std::string& newOwner);
+
+  /**
    * Updates the state for waypoints found for a character in a pending move.
    * If replace is true, we erase any existing waypoints in the pending state.
    * Otherwise, we add to them.
@@ -345,10 +358,13 @@ private:
 
 protected:
 
-  void PerformBuildingConfigUpdate (
-      Building& b, const proto::Building::Config& newConfig) override;
   void PerformCharacterCreation (Account& acc, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& upd) override;
+
+  void PerformBuildingConfigUpdate (
+      Building& b, const proto::Building::Config& newConfig) override;
+  void PerformBuildingTransfer (Building& b, const Account& newOwner) override;
+
   void PerformServiceOperation (ServiceOperation& op) override;
   void PerformDexOperation (DexOperation& op) override;
 

--- a/src/pending.hpp
+++ b/src/pending.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -54,6 +54,22 @@ class PendingState
 {
 
 private:
+
+  /**
+   * Pending updates to a building.
+   */
+  struct BuildingState
+  {
+
+    /** The new configuration that will be scheduled.  */
+    proto::Building::Config newConfig;
+
+    /**
+     * Returns the JSON representation of the pending state.
+     */
+    Json::Value ToJson () const;
+
+  };
 
   /**
    * Pending state of one character.
@@ -160,6 +176,9 @@ private:
 
   };
 
+  /** Pending modifications to buildings.  */
+  std::map<Database::IdT, BuildingState> buildings;
+
   /** Pending modifications to characters.  */
   std::map<Database::IdT, CharacterState> characters;
 
@@ -168,6 +187,12 @@ private:
 
   /** Pending updates by account name.  */
   std::map<std::string, AccountState> accounts;
+
+  /**
+   * Returns the pending building state for the given instance, creating
+   * a new empty one if needed.
+   */
+  BuildingState& GetBuildingState (const Building& b);
 
   /**
    * Returns the pending character state for the given instance, creating one
@@ -194,6 +219,12 @@ public:
    * situation without any pending moves).
    */
   void Clear ();
+
+  /**
+   * Updates the state for a new building configuration being scheduled.
+   */
+  void AddBuildingConfig (const Building& b,
+                          const proto::Building::Config& newConfig);
 
   /**
    * Updates the state for waypoints found for a character in a pending move.
@@ -314,6 +345,8 @@ private:
 
 protected:
 
+  void PerformBuildingConfigUpdate (
+      Building& b, const proto::Building::Config& newConfig) override;
   void PerformCharacterCreation (Account& acc, Faction f) override;
   void PerformCharacterUpdate (Character& c, const Json::Value& upd) override;
   void PerformServiceOperation (ServiceOperation& op) override;

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -170,6 +170,7 @@ TEST_F (PendingStateTests, BuildingConfig)
         [
           {
             "id": 1,
+            "sentto": null,
             "newconfig":
               {
                 "servicefee": 1,
@@ -182,6 +183,28 @@ TEST_F (PendingStateTests, BuildingConfig)
               {
                 "servicefee": 5
               }
+          }
+        ]
+    }
+  )");
+}
+
+TEST_F (PendingStateTests, BuildingTransfer)
+{
+  auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  ASSERT_EQ (b->GetId (), 1);
+
+  state.AddBuildingTransfer (*b, "andy");
+  state.AddBuildingTransfer (*b, "daniel");
+
+  ExpectStateJson (R"(
+    {
+      "buildings":
+        [
+          {
+            "id": 1,
+            "sentto": "daniel",
+            "newconfig": null
           }
         ]
     }
@@ -907,6 +930,44 @@ TEST_F (PendingStateUpdaterTests, BuildingConfig)
       "buildings":
         [
           {"id": 1, "newconfig": {"servicefee": 2}}
+        ]
+    }
+  )");
+}
+
+TEST_F (PendingStateUpdaterTests, BuildingTransfer)
+{
+  accounts.CreateNew ("domob")->SetFaction (Faction::RED);
+  accounts.CreateNew ("andy")->SetFaction (Faction::RED);
+
+  auto b = buildings.CreateNew ("checkmark", "domob", Faction::RED);
+  ASSERT_EQ (b->GetId (), 1);
+  b.reset ();
+
+  Process ("domob", R"({
+    "b":
+      [
+        {"id": 1, "send": "nonexistant"}
+      ]
+  })");
+  ExpectStateJson (R"(
+    {
+      "buildings": []
+    }
+  )");
+
+  Process ("domob", R"({
+    "b":
+      [
+        {"id": 1, "send": "domob"},
+        {"id": 1, "send": "andy"}
+      ]
+  })");
+  ExpectStateJson (R"(
+    {
+      "buildings":
+        [
+          {"id": 1, "sentto": "andy"}
         ]
     }
   )");


### PR DESCRIPTION
This implements a new move, which a building's owner can use to transfer ownership of the building to some other account of the same faction:

    {"b": {"id": 10, "send": "domob"}}

It also includes some refactorings and extensions to move parsing of building updates in general to support this, and e.g. also adds pending tracking for configuration updates.