### PR TITLE
Enforce unique handles to DB entries

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -29,7 +29,8 @@ libdatabase_la_SOURCES = \
   ongoing.cpp \
   region.cpp \
   schema.cpp \
-  target.cpp
+  target.cpp \
+  uniquehandles.cpp
 noinst_HEADERS = \
   amount.hpp \
   account.hpp \
@@ -49,7 +50,8 @@ noinst_HEADERS = \
   lazyproto.hpp lazyproto.tpp \
   region.hpp \
   schema.hpp \
-  target.hpp
+  target.hpp \
+  uniquehandles.hpp uniquehandles.tpp
 
 check_LTLIBRARIES = libdbtest.la
 check_PROGRAMS = tests benchmarks
@@ -97,7 +99,8 @@ tests_SOURCES = \
   ongoing_tests.cpp \
   region_tests.cpp \
   schema_tests.cpp \
-  target_tests.cpp
+  target_tests.cpp \
+  uniquehandles_tests.cpp
 
 benchmarks_CXXFLAGS = \
   -I$(top_srcdir) \

--- a/database/account.cpp
+++ b/database/account.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,7 +22,8 @@ namespace pxd
 {
 
 Account::Account (Database& d, const std::string& n)
-  : db(d), name(n), faction(Faction::INVALID), dirtyFields(true)
+  : db(d), name(n), tracker(db.TrackHandle ("account", n)),
+    faction(Faction::INVALID), dirtyFields(true)
 {
   VLOG (1) << "Created instance for newly initialised account " << name;
   data.SetToDefault ();
@@ -33,6 +34,8 @@ Account::Account (Database& d, const Database::Result<AccountResult>& res)
   : db(d), dirtyFields(false)
 {
   name = res.Get<AccountResult::name> ();
+  tracker = d.TrackHandle ("account", name);
+
   faction = GetNullableFactionFromColumn (res);
   data = res.GetProto<AccountResult::proto> ();
 

--- a/database/account.hpp
+++ b/database/account.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -55,6 +55,9 @@ private:
 
   /** The Xaya name of this account.  */
   std::string name;
+
+  /** UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
 
   /** The faction of this account.  May be INVALID if not yet initialised.  */
   Faction faction;

--- a/database/building.cpp
+++ b/database/building.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -25,7 +25,9 @@ namespace pxd
 
 Building::Building (Database& d, const std::string& t,
                     const std::string& o, const Faction f)
-  : CombatEntity(d), id(db.GetNextId ()), type(t), owner(o), faction(f),
+  : CombatEntity(d), id(db.GetNextId ()),
+    tracker(db.TrackHandle ("building", id)),
+    type(t), owner(o), faction(f),
     pos(0, 0), dirtyFields(true)
 {
   VLOG (1)
@@ -42,6 +44,8 @@ Building::Building (Database& d, const Database::Result<BuildingResult>& res)
   : CombatEntity(d, res), dirtyFields(false)
 {
   id = res.Get<BuildingResult::id> ();
+  tracker = db.TrackHandle ("building", id);
+
   type = res.Get<BuildingResult::type> ();
   faction = GetFactionFromColumn (res);
   if (faction != Faction::ANCIENT)

--- a/database/building.hpp
+++ b/database/building.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -56,6 +56,9 @@ private:
 
   /** The ID of the building.  */
   Database::IdT id;
+
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
 
   /** The building's type.  This is immutable.  */
   std::string type;

--- a/database/character.cpp
+++ b/database/character.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -24,7 +24,9 @@ namespace pxd
 {
 
 Character::Character (Database& d, const std::string& o, const Faction f)
-  : CombatEntity(d), id(db.GetNextId ()), owner(o), faction(f),
+  : CombatEntity(d), id(db.GetNextId ()),
+    tracker(db.TrackHandle ("character", id)),
+    owner(o), faction(f),
     pos(0, 0), inBuilding(Database::EMPTY_ID),
     enterBuilding(Database::EMPTY_ID),
     dirtyFields(true)
@@ -42,6 +44,8 @@ Character::Character (Database& d, const Database::Result<CharacterResult>& res)
   : CombatEntity(d, res), dirtyFields(false)
 {
   id = res.Get<CharacterResult::id> ();
+  tracker = db.TrackHandle ("character", id);
+
   owner = res.Get<CharacterResult::owner> ();
   faction = GetFactionFromColumn (res);
 

--- a/database/character.hpp
+++ b/database/character.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -73,6 +73,9 @@ private:
 
   /** The underlying integer ID in the database.  */
   Database::IdT id;
+
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
 
   /** The owner string.  */
   std::string owner;

--- a/database/database.cpp
+++ b/database/database.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,8 +19,6 @@
 #include "database.hpp"
 
 #include <glog/logging.h>
-
-#include <memory>
 
 namespace pxd
 {

--- a/database/database.hpp
+++ b/database/database.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
 #define DATABASE_DATABASE_HPP
 
 #include "lazyproto.hpp"
+#include "uniquehandles.hpp"
 
 #include <xayagame/sqlitegame.hpp>
 #include <xayagame/sqlitestorage.hpp>
@@ -30,6 +31,7 @@
 #include <sqlite3.h>
 
 #include <array>
+#include <memory>
 #include <string>
 #include <type_traits>
 
@@ -56,6 +58,9 @@ private:
   /** Protocol buffer arena used for protos extracted from the database.  */
   google::protobuf::Arena arena;
 
+  /** Tracker for active handles in this database.  */
+  UniqueHandles handleTracker;
+
 protected:
 
   Database () = default;
@@ -72,6 +77,9 @@ public:
 
   using IdT = xaya::SQLiteGame::IdT;
   static constexpr IdT EMPTY_ID = xaya::SQLiteGame::EMPTY_ID;
+
+  /** A UniqueHandles tracker for this database.  */
+  using HandleTracker = std::unique_ptr<UniqueHandles::Tracker>;
 
   template <typename T>
     class Result;
@@ -112,6 +120,12 @@ public:
   {
     return *db;
   }
+
+  /**
+   * Constructs a new tracker for a handle in this instance's UniqueHandles.
+   */
+  template <typename T>
+    HandleTracker TrackHandle (const std::string& type, const T& id);
 
 };
 

--- a/database/database.tpp
+++ b/database/database.tpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -24,6 +24,13 @@
 
 namespace pxd
 {
+
+template <typename T>
+  Database::HandleTracker
+  Database::TrackHandle (const std::string& type, const T& id)
+{
+  return std::make_unique<UniqueHandles::Tracker> (handleTracker, type, id);
+}
 
 template <typename T>
   Database::Result<T>

--- a/database/dex.cpp
+++ b/database/dex.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -27,6 +27,7 @@ namespace pxd
 
 DexOrder::DexOrder (Database& d)
   : db(d), id(db.GetNextId ()),
+    tracker(db.TrackHandle ("dex order", id)),
     buildingId(Database::EMPTY_ID),
     type(Type::INVALID),
     quantity(0), price(0),
@@ -39,6 +40,8 @@ DexOrder::DexOrder (Database& d, const Database::Result<DexOrderResult>& res)
   : db(d), isNew(false), dirty(false)
 {
   id = res.Get<DexOrderResult::id> ();
+  tracker = db.TrackHandle ("dex order", id);
+
   buildingId = res.Get<DexOrderResult::building> ();
   account = res.Get<DexOrderResult::account> ();
   type = static_cast<Type> (res.Get<DexOrderResult::type> ());
@@ -355,6 +358,7 @@ DexOrderTable::DeleteForBuilding (const Database::IdT building)
 
 DexTrade::DexTrade (Database& d)
   : db(d), id(db.GetLogId ()),
+    tracker(db.TrackHandle ("dex trade", id)),
     height(0), time(0),
     buildingId(Database::EMPTY_ID),
     quantity(0), price(0),
@@ -366,6 +370,9 @@ DexTrade::DexTrade (Database& d)
 DexTrade::DexTrade (Database& d, const Database::Result<DexTradeResult>& res)
   : db(d), isNew(false)
 {
+  id = res.Get<DexTradeResult::id> ();
+  tracker = db.TrackHandle ("dex trade", id);
+
   height = res.Get<DexTradeResult::height> ();
   time = res.Get<DexTradeResult::time> ();
   buildingId = res.Get<DexTradeResult::building> ();

--- a/database/dex.hpp
+++ b/database/dex.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -74,6 +74,9 @@ private:
 
   /** The underlying ID in the database.  */
   Database::IdT id;
+
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
 
   /** The building this is in.  */
   Database::IdT buildingId;
@@ -282,14 +285,15 @@ public:
  */
 struct DexTradeResult : public Database::ResultType
 {
-  RESULT_COLUMN (int64_t, height, 1);
-  RESULT_COLUMN (int64_t, time, 2);
-  RESULT_COLUMN (int64_t, building, 3);
-  RESULT_COLUMN (std::string, item, 4);
-  RESULT_COLUMN (int64_t, quantity, 5);
-  RESULT_COLUMN (int64_t, price, 6);
-  RESULT_COLUMN (std::string, seller, 7);
-  RESULT_COLUMN (std::string, buyer, 8);
+  RESULT_COLUMN (int64_t, id, 1);
+  RESULT_COLUMN (int64_t, height, 2);
+  RESULT_COLUMN (int64_t, time, 3);
+  RESULT_COLUMN (int64_t, building, 4);
+  RESULT_COLUMN (std::string, item, 5);
+  RESULT_COLUMN (int64_t, quantity, 6);
+  RESULT_COLUMN (int64_t, price, 7);
+  RESULT_COLUMN (std::string, seller, 8);
+  RESULT_COLUMN (std::string, buyer, 9);
 };
 
 /**
@@ -305,8 +309,11 @@ private:
   /** Database reference this belongs to.  */
   Database& db;
 
-  /** The ID for this, if inserting a new entry.  */
+  /** The ID for this trade entry.  */
   Database::IdT id;
+
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
 
   /** The block height of the trade.  */
   unsigned height;

--- a/database/fighter_tests.cpp
+++ b/database/fighter_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -259,6 +259,7 @@ TEST_F (FighterTableTests, Effects)
   targetId.set_id (cId);
   f = tbl.GetForTarget(targetId);
   EXPECT_EQ (f->GetEffects ().speed ().percent (), 20);
+  f.reset ();
 
   tbl.ClearAllEffects ();
 

--- a/database/inventory.hpp
+++ b/database/inventory.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -273,6 +273,9 @@ private:
   /** The coordinate of this loot tile.  */
   HexCoord coord;
 
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
+
   /** The associated loot.  */
   Inventory inventory;
 
@@ -394,6 +397,9 @@ private:
 
   /** The account this is for.  */
   std::string account;
+
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
 
   /** The associated loot.  */
   Inventory inventory;

--- a/database/ongoing.cpp
+++ b/database/ongoing.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,7 +22,8 @@ namespace pxd
 {
 
 OngoingOperation::OngoingOperation (Database& d, const unsigned startHeight)
-  : db(d), id(db.GetNextId ()), height(0),
+  : db(d), id(db.GetNextId ()), tracker(db.TrackHandle ("ongoing", id)),
+    height(0),
     characterId(Database::EMPTY_ID), buildingId(Database::EMPTY_ID),
     dirtyFields(true)
 {
@@ -36,6 +37,8 @@ OngoingOperation::OngoingOperation (Database& d,
   : db(d), dirtyFields(false)
 {
   id = res.Get<OngoingResult::id> ();
+  tracker = db.TrackHandle ("ongoing", id);
+
   height = res.Get<OngoingResult::height> ();
   characterId = res.Get<OngoingResult::character> ();
   buildingId = res.Get<OngoingResult::building> ();

--- a/database/ongoing.hpp
+++ b/database/ongoing.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -56,6 +56,9 @@ private:
 
   /** The underlying ID in the database.  */
   Database::IdT id;
+
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
 
   /** The block height at which it needs to be processed.  */
   unsigned height;

--- a/database/region.cpp
+++ b/database/region.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,7 +22,9 @@ namespace pxd
 {
 
 Region::Region (Database& d, const unsigned h, const RegionMap::IdT i)
-  : db(d), currentHeight(h), id(i), resourceLeft(0), dirtyFields(false)
+  : db(d), currentHeight(h), id(i),
+    tracker(db.TrackHandle ("region", id)),
+    resourceLeft(0), dirtyFields(false)
 {
   VLOG (1) << "Created instance for empty region with ID " << id;
   data.SetToDefault ();
@@ -33,6 +35,8 @@ Region::Region (Database& d, const unsigned h,
   : db(d), currentHeight(h), dirtyFields(false)
 {
   id = res.Get<RegionResult::id> ();
+  tracker = db.TrackHandle ("region", id);
+
   resourceLeft = res.Get<RegionResult::resourceleft> ();
   data = res.GetProto<RegionResult::proto> ();
 

--- a/database/region.hpp
+++ b/database/region.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -62,6 +62,9 @@ private:
 
   /** The ID of the region.  */
   RegionMap::IdT id;
+
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
 
   /** The amount of mine-able resources left.  */
   Quantity resourceLeft;

--- a/database/uniquehandles.cpp
+++ b/database/uniquehandles.cpp
@@ -1,0 +1,56 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "uniquehandles.hpp"
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+UniqueHandles::~UniqueHandles ()
+{
+  std::lock_guard<std::mutex> lock(mut);
+  CHECK (active.empty ()) << active.size () << " handles are still active";
+}
+
+void
+UniqueHandles::Add (const std::string& type, const std::string& id)
+{
+  std::lock_guard<std::mutex> lock(mut);
+  const auto ins = active.emplace (type, id);
+  CHECK (ins.second)
+      << "Handle (" << type << ", " << id << ") is already active";
+}
+
+void
+UniqueHandles::Remove (const std::string& type, const std::string& id)
+{
+  std::lock_guard<std::mutex> lock(mut);
+  const auto mit = active.find (std::make_pair (type, id));
+  CHECK (mit != active.end ())
+      << "Handle (" << type << ", " << id << ") is not active";
+  active.erase (mit);
+}
+
+UniqueHandles::Tracker::~Tracker ()
+{
+  handles.Remove (type, id);
+}
+
+} // namespace pxd

--- a/database/uniquehandles.hpp
+++ b/database/uniquehandles.hpp
@@ -1,0 +1,121 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_UNIQUEHANDLES_HPP
+#define DATABASE_UNIQUEHANDLES_HPP
+
+#include <mutex>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace pxd
+{
+
+/**
+ * A helper class to ensure that database handles for a particular instance
+ * (like the character with a given ID, or the account with a given name)
+ * exist at most once at any given moment, so as to make sure there are no
+ * bugs with conflicting changes or reads.
+ *
+ * It keeps track of pairs of "types" and "IDs", and allows users to either
+ * add a pair (when a handle is created) or remove it when it is destroyed.
+ * The IDs are tracked as strings, but the add/remove functions are templates
+ * so they can be called with integers as well (which will be converted
+ * to strings using an ostringstream).
+ */
+class UniqueHandles
+{
+
+private:
+
+  /** Mutex for protecting the active set.  */
+  std::mutex mut;
+
+  /** All currently active handles, as pairs of type and ID.  */
+  std::set<std::pair<std::string, std::string>> active;
+
+public:
+
+  class Tracker;
+
+  UniqueHandles () = default;
+
+  UniqueHandles (const UniqueHandles&) = delete;
+  void operator= (const UniqueHandles&) = delete;
+
+  /**
+   * The destructor verifies that no handles remain active.
+   */
+  ~UniqueHandles ();
+
+  /**
+   * Registers a new handle that has been activated with the given type
+   * and ID.  CHECK-fails if this is already active.
+   */
+  void Add (const std::string& type, const std::string& id);
+
+  /**
+   * Unregisters a handle that has been deactivated.  CHECK-fails if the
+   * handle is not active.
+   */
+  void Remove (const std::string& type, const std::string& id);
+
+};
+
+/**
+ * RAII helper class to add and remove a handle.
+ */
+class UniqueHandles::Tracker
+{
+
+private:
+
+  /** The UniqueHandles instance on which this operates.  */
+  UniqueHandles& handles;
+
+  /** The type of this handle.  */
+  std::string type;
+
+  /** Type ID converted to a string.  */
+  std::string id;
+
+public:
+
+  /**
+   * Constructs the tracker, which adds it to the UniqueHandles instance.
+   */
+  template <typename T>
+    explicit Tracker (UniqueHandles& h, const std::string& t, const T& i);
+
+  /**
+   * Removes the handle from our UniqueHandles instance.
+   */
+  ~Tracker ();
+
+  Tracker () = delete;
+  Tracker (const Tracker&) = delete;
+  void operator= (const Tracker&) = delete;
+
+};
+
+} // namespace pxd
+
+#include "uniquehandles.tpp"
+
+#endif // DATABASE_UNIQUEHANDLES_HPP

--- a/database/uniquehandles.tpp
+++ b/database/uniquehandles.tpp
@@ -1,0 +1,38 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Template implementation for uniquehandles.hpp.  */
+
+#include <sstream>
+
+namespace pxd
+{
+
+template <typename T>
+  UniqueHandles::Tracker::Tracker (UniqueHandles& h,
+                                   const std::string& t, const T& i)
+    : handles(h), type(t)
+{
+  std::ostringstream out;
+  out << i;
+  id = out.str ();
+
+  handles.Add (type, id);
+}
+
+} // namespace pxd

--- a/database/uniquehandles_tests.cpp
+++ b/database/uniquehandles_tests.cpp
@@ -1,0 +1,73 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "uniquehandles.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+using UniqueHandlesTests = testing::Test;
+
+TEST_F (UniqueHandlesTests, AddRemove)
+{
+  UniqueHandles h;
+
+  h.Add ("account", "foo");
+  h.Add ("account", "bar");
+  h.Add ("character", "foo");
+
+  EXPECT_DEATH (h.Add ("character", "foo"), "is already active");
+  EXPECT_DEATH (h.Remove ("character", "bar"), "is not active");
+
+  h.Remove ("account", "bar");
+  h.Add ("account", "bar");
+
+  h.Remove ("account", "foo");
+  h.Remove ("account", "bar");
+  h.Remove ("character", "foo");
+}
+
+TEST_F (UniqueHandlesTests, DestructorCheck)
+{
+  auto h = std::make_unique<UniqueHandles> ();
+  h->Add ("account", "foo");
+  EXPECT_DEATH (h.reset (), "are still active");
+  h->Remove ("account", "foo");
+}
+
+TEST_F (UniqueHandlesTests, Tracker)
+{
+  UniqueHandles h;
+
+  UniqueHandles::Tracker a(h, "account", "foo");
+  UniqueHandles::Tracker b(h, "character", 42);
+
+  auto c = std::make_unique<UniqueHandles::Tracker> (h, "account", "bar");
+  c.reset ();
+  c = std::make_unique<UniqueHandles::Tracker> (h, "account", "bar");
+
+  EXPECT_DEATH (new UniqueHandles::Tracker (h, "character", 42),
+                "is already active");
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -360,6 +360,7 @@ TEST_F (ProcessEnterBuildingsTests, EnteringEffects)
   EXPECT_EQ (c->GetEnterBuilding (), Database::EMPTY_ID);
   EXPECT_FALSE (c->HasTarget ());
   EXPECT_FALSE (dyn->HasVehicle (HexCoord (5, 0)));
+  c.reset ();
 
   /* Movement is stopped.  */
   c = GetCharacter (10);

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -317,6 +317,7 @@ TEST_F (TargetSelectionTests, ClosestTarget)
       const auto& t = c->GetTarget ();
       EXPECT_EQ (t.type (), proto::TargetId::TYPE_CHARACTER);
       EXPECT_EQ (t.id (), idTarget);
+      c.reset ();
     }
 }
 
@@ -619,6 +620,8 @@ TEST_F (TargetSelectionTests, Randomisation)
       const auto mit = targetMap.find (t.id ());
       ASSERT_NE (mit, targetMap.end ());
       ++cnt[mit->second];
+
+      c.reset ();
     }
 
   for (unsigned i = 0; i < nTargets; ++i)
@@ -3109,7 +3112,8 @@ TEST_F (RegenerateHpTests, Works)
   EXPECT_EQ (c->GetHP ().other (), 42); \
   EXPECT_EQ (c->GetHP ().mhp ().other (), 42); \
   EXPECT_EQ (c->GetHP ().type (), t.fullAfter); \
-  EXPECT_EQ (c->GetHP ().mhp ().type (), t.mhpAfter);
+  EXPECT_EQ (c->GetHP ().mhp ().type (), t.mhpAfter); \
+  c.reset ();
 
       DO_TEST(shield, armour)
       DO_TEST(armour, shield)

--- a/src/fame.cpp
+++ b/src/fame.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -77,6 +77,7 @@ FameUpdater::UpdateForKill (const Database::IdT victim,
   const int victimLevel = GetLevel (victimFame);
   VLOG (1)
       << "Victim fame: " << victimFame << " (level: " << victimLevel << ")";
+  victimAccount.reset ();
 
   /* Find the set of distinct accounts that killed the victim.  */
   std::set<std::string> owners;

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -826,6 +826,7 @@ TEST_F (PXLogicTests, ProspectingUserKilled)
 
   auto r = regions.GetById (region);
   EXPECT_EQ (r->GetProto ().prospecting_character (), 2);
+  r.reset ();
 
   /* Process another round, where the prospecting character is killed.  Thus
      the other is able to start prospecting at the same spot.  */
@@ -880,6 +881,7 @@ TEST_F (PXLogicTests, FinishingProspecting)
   auto r = regions.GetById (region);
   EXPECT_EQ (r->GetProto ().prospecting_character (), 1);
   EXPECT_FALSE (r->GetProto ().has_prospection ());
+  r.reset ();
 
   /* Process the next block which finishes prospecting.  We should be able
      to do a movement command right away as well, since the busy state is

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -432,6 +432,7 @@ TEST_F (PXLogicTests, RangeReduction)
           c = characters.GetById (id);
           EXPECT_TRUE (c->GetEffects ().has_range ());
           EXPECT_FALSE (c->HasTarget ());
+          c.reset ();
         }
 
       UpdateState ("[]");
@@ -440,6 +441,7 @@ TEST_F (PXLogicTests, RangeReduction)
           c = characters.GetById (id);
           EXPECT_FALSE (c->GetEffects ().has_range ());
           EXPECT_TRUE (c->HasTarget ());
+          c.reset ();
         }
     }
 }

--- a/src/ongoings_tests.cpp
+++ b/src/ongoings_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -402,30 +402,35 @@ TEST_F (OngoingsTests, BuildingConfigUpdate)
   b = buildings.GetById (bId);
   EXPECT_EQ (b->GetProto ().config ().dex_fee_bps (), 42);
   EXPECT_EQ (b->GetProto ().config ().service_fee_percent (), 1);
+  b.reset ();
 
   ctx.SetHeight (10);
   ProcessAllOngoings (db, rnd, ctx);
   b = buildings.GetById (bId);
   EXPECT_EQ (b->GetProto ().config ().dex_fee_bps (), 50);
   EXPECT_EQ (b->GetProto ().config ().service_fee_percent (), 1);
+  b.reset ();
 
   ctx.SetHeight (11);
   ProcessAllOngoings (db, rnd, ctx);
   b = buildings.GetById (bId);
   EXPECT_EQ (b->GetProto ().config ().dex_fee_bps (), 50);
   EXPECT_EQ (b->GetProto ().config ().service_fee_percent (), 2);
+  b.reset ();
 
   ctx.SetHeight (12);
   ProcessAllOngoings (db, rnd, ctx);
   b = buildings.GetById (bId);
   EXPECT_EQ (b->GetProto ().config ().dex_fee_bps (), 50);
   EXPECT_EQ (b->GetProto ().config ().service_fee_percent (), 2);
+  b.reset ();
 
   ctx.SetHeight (13);
   ProcessAllOngoings (db, rnd, ctx);
   b = buildings.GetById (bId);
   EXPECT_EQ (b->GetProto ().config ().dex_fee_bps (), 50);
   EXPECT_EQ (b->GetProto ().config ().service_fee_percent (), 4);
+  b.reset ();
 }
 
 } // anonymous namespace

--- a/src/ongoings_tests.cpp
+++ b/src/ongoings_tests.cpp
@@ -125,6 +125,7 @@ TEST_F (OngoingsTests, ProcessedByHeight)
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow bpc"), 0);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("sword bpc"), 0);
   EXPECT_EQ (GetNumOngoing (), 2);
+  inv.reset ();
 
   ctx.SetHeight (10);
   ProcessAllOngoings (db, rnd, ctx);
@@ -133,6 +134,7 @@ TEST_F (OngoingsTests, ProcessedByHeight)
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow bpc"), 1);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("sword bpc"), 0);
   EXPECT_EQ (GetNumOngoing (), 1);
+  inv.reset ();
 
   ctx.SetHeight (14);
   ProcessAllOngoings (db, rnd, ctx);
@@ -141,6 +143,7 @@ TEST_F (OngoingsTests, ProcessedByHeight)
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow bpc"), 1);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("sword bpc"), 0);
   EXPECT_EQ (GetNumOngoing (), 1);
+  inv.reset ();
 
   ctx.SetHeight (15);
   ProcessAllOngoings (db, rnd, ctx);
@@ -149,6 +152,7 @@ TEST_F (OngoingsTests, ProcessedByHeight)
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow bpc"), 1);
   EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("sword bpc"), 1);
   EXPECT_EQ (GetNumOngoing (), 0);
+  inv.reset ();
 }
 
 TEST_F (OngoingsTests, ArmourRepair)
@@ -236,6 +240,7 @@ TEST_F (OngoingsTests, BlueprintCopy)
       inv = buildingInv.Get (bId, "domob");
       EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow bpo"), 0);
       EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow bpc"), 10 + i);
+      inv.reset ();
 
       ASSERT_EQ (GetNumOngoing (), 1);
       ASSERT_EQ (ongoings.GetById (opId)->GetHeight (), (i + 1) * baseDuration);
@@ -282,6 +287,7 @@ TEST_F (OngoingsTests, ItemConstructionFromOriginal)
       EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow bpo"), 10);
       EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow bpc"), 0);
       EXPECT_EQ (inv->GetInventory ().GetFungibleCount ("bow"), i);
+      inv.reset ();
 
       ASSERT_EQ (GetNumOngoing (), 1);
       ASSERT_EQ (ongoings.GetById (opId)->GetHeight (), (i + 1) * baseDuration);

--- a/src/pending.cpp
+++ b/src/pending.cpp
@@ -567,10 +567,6 @@ void
 PendingStateUpdater::PerformCharacterUpdate (Character& c,
                                              const Json::Value& upd)
 {
-  BuildingsTable::Handle b;
-  if (c.IsInBuilding ())
-    b = buildings.GetById (c.GetBuildingId ());
-
   Database::IdT regionId;
   if (ParseCharacterProspecting (c, upd, regionId))
     state.AddCharacterProspecting (c, regionId);
@@ -582,6 +578,10 @@ PendingStateUpdater::PerformCharacterUpdate (Character& c,
   items = ParseDropPickupFungible (upd["pu"]);
   if (!items.empty ())
     {
+      BuildingsTable::Handle b;
+      if (c.IsInBuilding ())
+        b = buildings.GetById (c.GetBuildingId ());
+
       if (b != nullptr && b->GetProto ().foundation ())
         LOG (WARNING)
             << "Ignoring pending move for character " << c.GetId ()

--- a/src/services_tests.cpp
+++ b/src/services_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -843,6 +843,8 @@ TEST_F (RepairTests, AlreadyRepairing)
   ASSERT_TRUE (c->IsBusy ());
   auto op = ongoings.GetById (c->GetProto ().ongoing ());
   EXPECT_EQ (op->GetHeight (), 101);
+  op.reset ();
+  c.reset ();
 
   EXPECT_FALSE (Process ("domob", R"({
     "t": "fix",

--- a/src/trading.cpp
+++ b/src/trading.cpp
@@ -323,7 +323,7 @@ NewOrderOperation::PayToSellerAndFee (const std::string& recipient,
      buildings per code above) even though it will be checked
      again in PayCoins.  */
   if (owner > 0)
-    PayCoins (buildings.GetById (building)->GetOwner (), owner);
+    PayCoins (b->GetOwner (), owner);
   PayCoins (recipient, payout);
 }
 

--- a/src/trading.cpp
+++ b/src/trading.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -210,6 +210,11 @@ TransferOperation::Execute ()
       << "Transferring " << quantity << " of " << item
       << " inside " << building
       << " from " << account.GetName () << " to " << recipient;
+
+  /* If sender and recipient are the same, skip the operation and
+     in particular avoid creating another instance of the Account handle.  */
+  if (recipient == account.GetName ())
+    return;
 
   if (accounts.GetByName (recipient) == nullptr)
     accounts.CreateNew (recipient);


### PR DESCRIPTION
The database abstraction makes use of "handles", which represent a row in the database (e.g. a user account or character).  The data is read from the database into the instance, can then be worked with in the rest of the codebase, and if there were any changes, they are written back to the database in the handle's destructor.

This model relies on the assumption that at any given moment in time, there cannot be two handles of the same entry active; if they were, there would be conflicts and those could lead to bugs.

The code has been written already with this in mind, but in this set of changes, we introduce a runtime check that enforces that constraint.  If it is violated, the code will `CHECK`-fail.  We also had to fix some parts of the code that actually violated the assumption, although mostly with read-only handles and in tests.