### PR TITLE
Avoid unnecessary turns in path finder

### DIFF
--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2021  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -275,10 +275,8 @@ class FindPathTest (PXTest):
 
     # This is a very long path.  Make sure its encoded form is relatively
     # small, though.
-    assert len (path["wp"]) > 100
-    assert len (path["encoded"]) < 750
     serialised = json.dumps (path["wp"], separators=(",", ":"))
-    assert len (serialised) > 3000
+    assert len (path["encoded"]) < len (serialised)
 
     # Now place buildings in two steps on the map, which make the path from
     # longA to longB further.  We use the outputs of getbuildings itself, to

--- a/hexagonal/coord_tests.cpp
+++ b/hexagonal/coord_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -56,38 +56,48 @@ TEST_F (CoordTests, LessThan)
   EXPECT_FALSE (c < b);
 }
 
-TEST_F (CoordTests, Arithmetic)
+TEST_F (CoordTests, DifferenceArithmetic)
 {
-  HexCoord test(-2, 5);
-  EXPECT_EQ (2 * test, HexCoord (-4, 10));
-  EXPECT_EQ (0 * test, HexCoord (0, 0));
-  EXPECT_EQ (-1 * test, HexCoord (2, -5));
+  HexCoord::Difference diff(-2, 5);
+  EXPECT_EQ (2 * diff, HexCoord::Difference (-4, 10));
+  EXPECT_EQ (0 * diff, HexCoord::Difference (0, 0));
+  EXPECT_EQ (-1 * diff, HexCoord::Difference (2, -5));
 
-  test += HexCoord (5, -5);
-  EXPECT_EQ (test, HexCoord (3, 0));
+  diff = HexCoord (10, 2) - HexCoord (3, -5);
+  EXPECT_EQ (diff, HexCoord::Difference (7, 7));
 
-  EXPECT_EQ (HexCoord (1, 2) + HexCoord (-5, 3), HexCoord (-4, 5));
+  HexCoord pos(-2, 5);
+  pos += HexCoord::Difference (5, -5);
+  EXPECT_EQ (pos, HexCoord (3, 0));
+
+  EXPECT_EQ (pos + diff, HexCoord (10, 7));
 }
 
 TEST_F (CoordTests, Rotation)
 {
-  EXPECT_EQ (HexCoord (1, 2).RotateCW (0), HexCoord (1, 2));
-  EXPECT_EQ (HexCoord (1, 2).RotateCW (1), HexCoord (3, -1));
-  EXPECT_EQ (HexCoord (1, 2).RotateCW (2), HexCoord (2, -3));
-  EXPECT_EQ (HexCoord (1, 2).RotateCW (3), HexCoord (-1, -2));
-  EXPECT_EQ (HexCoord (1, 2).RotateCW (4), HexCoord (-3, 1));
-  EXPECT_EQ (HexCoord (1, 2).RotateCW (5), HexCoord (-2, 3));
+  EXPECT_EQ (HexCoord::Difference (1, 2).RotateCW (0),
+             HexCoord::Difference (1, 2));
+  EXPECT_EQ (HexCoord::Difference (1, 2).RotateCW (1),
+             HexCoord::Difference (3, -1));
+  EXPECT_EQ (HexCoord::Difference (1, 2).RotateCW (2),
+             HexCoord::Difference (2, -3));
+  EXPECT_EQ (HexCoord::Difference (1, 2).RotateCW (3),
+             HexCoord::Difference (-1, -2));
+  EXPECT_EQ (HexCoord::Difference (1, 2).RotateCW (4),
+             HexCoord::Difference (-3, 1));
+  EXPECT_EQ (HexCoord::Difference (1, 2).RotateCW (5),
+             HexCoord::Difference (-2, 3));
 
   /* This is a chained rotation that will come out to zero, but
      verifies various cases other than the basic rotations.  */
-  EXPECT_EQ (HexCoord (1, 2)
+  EXPECT_EQ (HexCoord::Difference (1, 2)
                 .RotateCW (20)
                 .RotateCW (-30)
                 .RotateCW (1)
                 .RotateCW (2)
                 .RotateCW (3)
                 .RotateCW (4),
-             HexCoord (1, 2));
+             HexCoord::Difference (1, 2));
 }
 
 TEST_F (CoordTests, DistanceL1)
@@ -171,42 +181,42 @@ TEST_F (CoordTests, IsPrincipalDirectionTo)
 {
   constexpr HexCoord base(42, -10);
 
-  constexpr HexCoord nonPrincipal[] =
+  constexpr HexCoord::Difference nonPrincipal[] =
     {
-      HexCoord (1, 1),
-      HexCoord (-1, -1),
-      HexCoord (2, 3),
-      HexCoord (-5, -5),
-      HexCoord (3, 10),
-      HexCoord (0, 0),
-      base + HexCoord (1, 0),
+      HexCoord::Difference (1, 1),
+      HexCoord::Difference (-1, -1),
+      HexCoord::Difference (2, 3),
+      HexCoord::Difference (-5, -5),
+      HexCoord::Difference (3, 10),
+      HexCoord::Difference (0, 0),
+      HexCoord::Difference (base.GetX () + 1, base.GetY () + 0),
     };
   for (const auto& dir : nonPrincipal)
     {
-      HexCoord d;
+      HexCoord::Difference d;
       HexCoord::IntT steps;
       ASSERT_FALSE (base.IsPrincipalDirectionTo (base + dir, d, steps));
     }
 
-  constexpr HexCoord isPrincipal[] =
+  constexpr HexCoord::Difference isPrincipal[] =
     {
-      HexCoord (-1, 0),
-      HexCoord (1, 0),
-      HexCoord (0, -1),
-      HexCoord (0, 1),
-      HexCoord (-1, 1),
-      HexCoord (1, -1),
-      HexCoord (10, -10),
-      HexCoord (0, 42),
-      HexCoord (100, 0),
+      HexCoord::Difference (-1, 0),
+      HexCoord::Difference (1, 0),
+      HexCoord::Difference (0, -1),
+      HexCoord::Difference (0, 1),
+      HexCoord::Difference (-1, 1),
+      HexCoord::Difference (1, -1),
+      HexCoord::Difference (10, -10),
+      HexCoord::Difference (0, 42),
+      HexCoord::Difference (100, 0),
     };
   for (const auto& dir : isPrincipal)
     {
-      HexCoord d;
+      HexCoord::Difference d;
       HexCoord::IntT steps;
       ASSERT_TRUE (base.IsPrincipalDirectionTo (base + dir, d, steps));
       ASSERT_EQ (steps * d, dir);
-      ASSERT_EQ (HexCoord::DistanceL1 (HexCoord (), d), 1);
+      ASSERT_EQ (HexCoord::DistanceL1 (HexCoord (), HexCoord () + d), 1);
     }
 }
 

--- a/hexagonal/pathfinder.hpp
+++ b/hexagonal/pathfinder.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -132,7 +132,7 @@ public:
  * Utility class that resembles an "iterator" for stepping along the shortest
  * path found between two coordinates.
  */
-class PathFinder::Stepper final
+class PathFinder::Stepper
 {
 
 private:
@@ -143,9 +143,20 @@ private:
   /** The current position along the path.  */
   HexCoord position;
 
+  /** The direction we stepped previously (zero if this is the first step).  */
+  HexCoord::Difference lastDirection;
+
   inline explicit Stepper (const PathFinder& f, const HexCoord& source)
     : finder(f), position(source)
   {}
+
+  /**
+   * Checks if stepping from the current position to the given target is an
+   * optimal step (i.e. possible at all, and the edge weight matches the
+   * difference in the finder's distance man).  If it is, updates the current
+   * position to the target, and returns true.
+   */
+  bool TryStep (const HexCoord& target, DistanceT& step);
 
   friend class PathFinder;
 

--- a/hexagonal/ring.cpp
+++ b/hexagonal/ring.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -50,19 +50,19 @@ namespace
  * Direction from the centre of a ring where the starting point of the
  * iteration is located.
  */
-constexpr HexCoord RING_START_DIRECTION(1, 0);
+constexpr HexCoord::Difference RING_START_DIRECTION(1, 0);
 
 /**
  * The direction vectors of the six sides along which we iterate in order.
  */
-constexpr std::array<HexCoord, 6> RING_SIDE_DIRECTIONS =
+constexpr std::array<HexCoord::Difference, 6> RING_SIDE_DIRECTIONS =
   {
-    HexCoord (0, -1),
-    HexCoord (-1, 0),
-    HexCoord (-1, 1),
-    HexCoord (0, 1),
-    HexCoord (1, 0),
-    HexCoord (1, -1),
+    HexCoord::Difference (0, -1),
+    HexCoord::Difference (-1, 0),
+    HexCoord::Difference (-1, 1),
+    HexCoord::Difference (0, 1),
+    HexCoord::Difference (1, 0),
+    HexCoord::Difference (1, -1),
   };
 
 } // anonymous namespace

--- a/src/buildings.cpp
+++ b/src/buildings.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -43,10 +43,9 @@ GetBuildingShape (const std::string& type,
   res.reserve (roData.shape_tiles ().size ());
   for (const auto& pbTile : roData.shape_tiles ())
     {
-      HexCoord c = CoordFromProto (pbTile);
-      c = c.RotateCW (trafo.rotation_steps ()); 
-      c += pos;
-      res.push_back (c);
+      HexCoord::Difference d = CoordDiffFromProto (pbTile);
+      d = d.RotateCW (trafo.rotation_steps ());
+      res.push_back (pos + d);
     }
 
   return res;

--- a/src/buildings_tests.cpp
+++ b/src/buildings_tests.cpp
@@ -118,19 +118,19 @@ TEST_F (CanPlaceBuildingTests, Ok)
 {
   /* Some offset added to all coordinates to make the situation fit
      into one region entirely.  */
-  const HexCoord offs(-1, -5);
+  const HexCoord::Difference offs(-1, -5);
 
   tbl.CreateNew ("huesli", "", Faction::ANCIENT)
-      ->SetCentre (offs + HexCoord (-1, 0));
+      ->SetCentre (HexCoord (-1, 0) + offs);
 
   characters.CreateNew ("domob", Faction::RED)
-      ->SetPosition (offs + HexCoord (2, 0));
+      ->SetPosition (HexCoord (2, 0) + offs);
   characters.CreateNew ("andy", Faction::GREEN)
-      ->SetPosition (offs + HexCoord (0, -1));
+      ->SetPosition (HexCoord (0, -1) + offs);
   characters.CreateNew ("daniel", Faction::BLUE)
-      ->SetPosition (offs + HexCoord (0, 3));
+      ->SetPosition (HexCoord (0, 3) + offs);
 
-  EXPECT_TRUE (CanPlace ("checkmark", 0, offs));
+  EXPECT_TRUE (CanPlace ("checkmark", 0, HexCoord () + offs));
 }
 
 TEST_F (CanPlaceBuildingTests, OutOfMap)
@@ -168,7 +168,7 @@ TEST_F (CanPlaceBuildingTests, DynObstacle)
 TEST_F (CanPlaceBuildingTests, MultiRegion)
 {
   const HexCoord pos(0, 0);
-  const HexCoord outside(pos + HexCoord (0, 2));
+  const HexCoord outside(pos + HexCoord::Difference (0, 2));
   ASSERT_NE (ctx.Map ().Regions ().GetRegionId (pos),
              ctx.Map ().Regions ().GetRegionId (outside));
 

--- a/src/combat_tests.cpp
+++ b/src/combat_tests.cpp
@@ -1127,7 +1127,7 @@ TEST_F (DealDamageTests, FriendlyAttack)
 
   c = characters.CreateNew ("domob", Faction::RED);
   const auto idOutOfRange = c->GetId ();
-  c->SetPosition (NOT_SAFE + HexCoord (100, 100));
+  c->SetPosition (NOT_SAFE + HexCoord::Difference (100, 100));
   NoAttacks (*c);
   c.reset ();
 

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -178,7 +178,7 @@ GetCharacterSpeed (const Character& c)
  */
 template <typename Fcn>
   bool
-  StepCharacter (Character& c, const HexCoord& dir,
+  StepCharacter (Character& c, const HexCoord::Difference& dir,
                  const Context& ctx, Fcn edges)
 {
   const auto& pos = c.GetPosition ();
@@ -295,7 +295,7 @@ template <typename Fcn>
           nextWp = CoordFromProto (wp[0]);
         }
 
-      HexCoord dir;
+      HexCoord::Difference dir;
       {
         const auto& pos = c.GetPosition ();
         HexCoord::IntT steps;

--- a/src/movement_bench.cpp
+++ b/src/movement_bench.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -82,6 +82,7 @@ MovementLongHaul (benchmark::State& state)
   ContextForTesting ctx;
 
   const HexCoord::IntT dist = state.range (0);
+  const HexCoord::Difference diff(dist, 0);
 
   InitialiseAccount (db);
 
@@ -102,7 +103,7 @@ MovementLongHaul (benchmark::State& state)
         h->SetPosition (origin);
         auto* mv = h->MutableProto ().mutable_movement ();
         auto* wp = mv->mutable_waypoints ();
-        *wp->Add () = CoordToProto (origin + HexCoord (dist, 0));
+        *wp->Add () = CoordToProto (origin + diff);
       }
       DynObstacles dyn(db, ctx);
       state.ResumeTiming ();
@@ -114,7 +115,7 @@ MovementLongHaul (benchmark::State& state)
       while (tbl.GetById (id)->GetProto ().has_movement ());
 
       state.PauseTiming ();
-      CHECK_EQ (tbl.GetById (id)->GetPosition (), HexCoord (dist, 0) + origin);
+      CHECK_EQ (tbl.GetById (id)->GetPosition (), origin + diff);
       state.ResumeTiming ();
     }
 }

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -3011,7 +3011,7 @@ TEST_F (ProspectingMoveTests, OrderOfCharactersInAMove)
   GetTest ()->SetPosition (HexCoord (0, 0));
 
   auto c = SetupCharacter (9, "domob");
-  c->SetPosition (pos + HexCoord (1, 0));
+  c->SetPosition (pos + HexCoord::Difference (1, 0));
   c->MutableProto ().set_prospecting_blocks (10);
   c.reset ();
 

--- a/src/protoutils.hpp
+++ b/src/protoutils.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -38,6 +38,16 @@ proto::HexCoord CoordToProto (const HexCoord& c);
  * Converts a HexCoord in protocol buffer form to the real object.
  */
 HexCoord CoordFromProto (const proto::HexCoord& pb);
+
+/**
+ * Converts a coordinate difference in protocol buffer to
+ * the HexCoord::Difference instance.
+ */
+inline HexCoord::Difference
+CoordDiffFromProto (const proto::HexCoord& pb)
+{
+  return CoordFromProto (pb) - HexCoord ();
+}
 
 /**
  * Adds a vector of coordinates to a repeated field in the protocol buffer.

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -334,7 +334,7 @@ NonStateRpcServer::findpath (const Json::Value& exbuildings,
     {
       path.Next ();
 
-      HexCoord dir;
+      HexCoord::Difference dir;
       HexCoord::IntT steps;
       if (!wp.back ().IsPrincipalDirectionTo (path.GetPosition (), dir, steps))
         wp.push_back (prev);

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -60,7 +60,7 @@ RandomSpawnLocation (const HexCoord& centre, const HexCoord::IntT radius,
       const HexCoord::IntT xOffs = rnd.NextInt (2 * radius + 1) - radius;
       const HexCoord::IntT yOffs = rnd.NextInt (2 * radius + 1) - radius;
 
-      res += HexCoord (xOffs, yOffs);
+      res += HexCoord::Difference (xOffs, yOffs);
 
       if (HexCoord::DistanceL1 (res, centre) <= radius)
         {


### PR DESCRIPTION
This updates the logic in the path finder for stepping the path once the distance map has been computed.  Instead of always choosing the next direction based on a fixed order of all six principal directions, we try to stick to the previous direction as long as possible.  This is a greedy approach to minimise the number of turns taken, and thus the number of waypoints and sizes of moves.  The resulting paths are still of optimal length.

This does not affect consensus (nor would future tuning of the algorithm), since path finding is no longer part of consensus since #145).