### PR TITLE
Switch game to Polygon / EVM

### DIFF
--- a/gametest/accounts.py
+++ b/gametest/accounts.py
@@ -2,7 +2,7 @@
 # coding=utf8
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@ from pxtest import PXTest
 class AccountsTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("No accounts yet...")
     accounts = self.getAccounts ()
     self.assertEqual (accounts, {})

--- a/gametest/buildings_combat.py
+++ b/gametest/buildings_combat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest
 class BuildingsCombatTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Ancient buildings are neutral...")
     self.initAccount ("domob", "r")
     self.createCharacters ("domob")
@@ -60,7 +58,7 @@ class BuildingsCombatTest (PXTest):
     self.createCharacters ("attacker")
     self.generate (2)
     self.changeCharacterVehicle ("attacker", "light attacker")
-    reorgBlk = self.rpc.xaya.getbestblockhash ()
+    self.snapshot = self.env.snapshot ()
     self.moveCharactersTo ({"attacker": {"x": 1, "y": 0}})
 
     self.mainLogger.info ("Killing both entities...")
@@ -72,22 +70,17 @@ class BuildingsCombatTest (PXTest):
     assert self.building not in self.getBuildings ()
     self.assertEqual (self.getCharacters (), {})
 
-    self.generate (20)
-    self.testReorg (reorgBlk)
+    self.testReorg ()
 
-  def testReorg (self, blk):
+  def testReorg (self):
     self.mainLogger.info ("Testing reorg...")
 
-    originalState = self.getGameState ()
-    self.rpc.xaya.invalidateblock (blk)
+    self.snapshot.restore ()
 
     self.generate (5)
     self.assertEqual (set (self.getCharacters ().keys ()),
                       set (["attacker", "domob"]))
     assert self.building in self.getBuildings ()
-
-    self.rpc.xaya.reconsiderblock (blk)
-    self.expectGameState (originalState)
     
 
 if __name__ == "__main__":

--- a/gametest/buildings_config.py
+++ b/gametest/buildings_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -49,7 +49,7 @@ class BuildingsConfigTest (PXTest):
     of the operation relative to current block height.
     """
 
-    height = self.rpc.xaya.getblockcount ()
+    _, height = self.env.getChainTip ()
     ongoings = self.getRpc ("getongoings")
     actual = []
     for o in ongoings:
@@ -65,8 +65,6 @@ class BuildingsConfigTest (PXTest):
     self.assertEqual (actual, expected)
 
   def run (self):
-    self.collectPremine ()
-
     self.initAccount ("domob", "r")
     self.initAccount ("andy", "r")
     self.generate (1)

--- a/gametest/buildings_construction.py
+++ b/gametest/buildings_construction.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest
 class BuildingConstructionTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating and preparing test character...")
     self.initAccount ("domob", "r")
     self.createCharacters ("domob")
@@ -48,7 +46,7 @@ class BuildingConstructionTest (PXTest):
     })
     self.generate (1)
 
-    foundedHeight = self.rpc.xaya.getblockcount ()
+    _, foundedHeight = self.env.getChainTip ()
     buildings = self.getBuildings ()
     bId = list (buildings.keys ())[-1]
     self.assertEqual (buildings[bId].isFoundation (), True)
@@ -76,7 +74,7 @@ class BuildingConstructionTest (PXTest):
 
     self.mainLogger.info ("Finishing construction...")
     self.generate (1)
-    finishedHeight = self.rpc.xaya.getblockcount ()
+    _, finishedHeight = self.env.getChainTip ()
     b = self.getBuildings ()[bId]
     self.assertEqual (b.isFoundation (), False)
     self.assertEqual (b.getFungibleInventory ("domob"), {

--- a/gametest/buildings_enterexit.py
+++ b/gametest/buildings_enterexit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,9 +26,6 @@ from pxtest import PXTest
 class BuildingsEnterExitTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-    self.splitPremine ()
-
     self.mainLogger.info ("Placing a building...")
     self.build ("checkmark", None, {"x": 0, "y": 0}, rot=0)
     building = 1001
@@ -46,7 +43,7 @@ class BuildingsEnterExitTest (PXTest):
       "eb": building
     })
     self.generate (2)
-    reorgBlock = self.rpc.xaya.getbestblockhash ()
+    self.snapshot = self.env.snapshot ()
 
     c = self.getCharacters ()["domob"]
     self.assertEqual (c.isInBuilding (), False)
@@ -85,15 +82,12 @@ class BuildingsEnterExitTest (PXTest):
     assert "target" not in chars["andy"].data["combat"]
     assert "target" not in chars["domob"].data["combat"]
 
-    # Before doing the reorg, make sure this is the longest chain.
-    self.generate (100)
-    self.testReorg (reorgBlock)
+    self.testReorg ()
 
-  def testReorg (self, blk):
+  def testReorg (self):
     self.mainLogger.info ("Testing reorg...")
 
-    originalState = self.getGameState ()
-    self.rpc.xaya.invalidateblock (blk)
+    self.snapshot.restore ()
 
     self.getCharacters ()["domob"].sendMove ({"eb": None})
     self.generate (20)
@@ -101,9 +95,6 @@ class BuildingsEnterExitTest (PXTest):
     self.assertEqual (c.isInBuilding (), False)
     self.assertEqual (c.getPosition (), {"x": 3, "y": 0})
     assert "enterbuilding" not in c.data
-
-    self.rpc.xaya.reconsiderblock (blk)
-    self.expectGameState (originalState)
     
 
 if __name__ == "__main__":

--- a/gametest/buildings_foundations.py
+++ b/gametest/buildings_foundations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest
 class BuildingFoundationsTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating and preparing test character...")
     self.initAccount ("domob", "r")
     self.createCharacters ("domob")

--- a/gametest/buildings_inventory.py
+++ b/gametest/buildings_inventory.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest
 class BuildingsInventoriesTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Placing a building and some loot...")
     self.build ("checkmark", None, {"x": 0, "y": 0}, rot=0)
     building = 1001
@@ -35,7 +33,7 @@ class BuildingsInventoriesTest (PXTest):
     self.pos = {"x": 3, "y": 0}
     self.dropLoot (self.pos, {"foo": 1, "zerospace": 5})
     self.generate (1)
-    reorgBlock = self.rpc.xaya.getbestblockhash ()
+    self.snapshot = self.env.snapshot ()
 
     self.mainLogger.info ("Entering building with character...")
     self.initAccount ("domob", "r")
@@ -85,21 +83,17 @@ class BuildingsInventoriesTest (PXTest):
     b = self.getBuildings ()[building]
     self.assertEqual (b.getFungibleInventory ("domob"), {})
 
-    self.testReorg (reorgBlock)
+    self.testReorg ()
 
-  def testReorg (self, blk):
+  def testReorg (self):
     self.mainLogger.info ("Testing reorg...")
 
-    originalState = self.getGameState ()
-    self.rpc.xaya.invalidateblock (blk)
+    self.snapshot.restore ()
 
     self.assertEqual (self.getLoot (self.pos), {
       "foo": 1,
       "zerospace": 5,
     })
-
-    self.rpc.xaya.reconsiderblock (blk)
-    self.expectGameState (originalState)
     
 
 if __name__ == "__main__":

--- a/gametest/burnsale.py
+++ b/gametest/burnsale.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest
 class BurnsaleTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.sendMove ("domob", {
       "vc": {"m": {}, "b": 10},
     }, burn=1.23456789)

--- a/gametest/character_limit.py
+++ b/gametest/character_limit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -43,8 +43,6 @@ class CharacterLimitTest (PXTest):
     return res
 
   def run (self):
-    self.collectPremine ()
-
     self.initAccount ("domob", "r")
     self.initAccount ("other", "r")
     self.generate (1)

--- a/gametest/characters.py
+++ b/gametest/characters.py
@@ -2,7 +2,7 @@
 # coding=utf8
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -43,9 +43,11 @@ class CharactersTest (PXTest):
       c.expectPartial (expected[nm])
 
   def run (self):
-    self.collectPremine ()
-
     cost = self.roConfig ().params.character_cost
+
+    self.env.register ("p", "domob")
+    self.generate (1)
+    self.snapshot = self.env.snapshot ()
 
     self.mainLogger.info ("Creating first character...")
     self.moveWithPayment ("adam", {
@@ -150,21 +152,15 @@ class CharactersTest (PXTest):
     """
 
     self.mainLogger.info ("Testing a reorg...")
-    originalState = self.getGameState ()
 
-    blk = self.rpc.xaya.getblockhash (1)
-    self.rpc.xaya.invalidateblock (blk)
+    self.snapshot.restore ()
 
-    self.collectPremine ()
     self.initAccount ("domob", "r")
     self.createCharacters ("domob")
     self.generate (1)
     self.expectPartial ({
       "domob": {"owner": "domob"},
     })
-
-    self.rpc.xaya.reconsiderblock (blk)
-    self.expectGameState (originalState)
 
 
 if __name__ == "__main__":

--- a/gametest/coinops.py
+++ b/gametest/coinops.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -39,17 +39,15 @@ class CoinOpsTest (PXTest):
         self.assertEqual (acc[k].getBalance (), v)
 
   def run (self):
-    self.collectPremine ()
-    self.splitPremine ()
-
     self.mainLogger.info ("Setting up test situation...")
     # No need to initialise accounts.  Coin operations also work
-    # without a chosen faction.
-    self.generate (1)
+    # without a chosen faction.  But we need to register the name or else
+    # the move sending gets confused by the reorg somehow.
+    self.env.register ("p", "domob")
     self.giftCoins ({"domob": 100})
 
     self.generate (1)
-    reorgBlk = self.rpc.xaya.getbestblockhash ()
+    self.snapshot = self.env.snapshot ()
 
     self.mainLogger.info ("Coin transfers and burns...")
     self.sendMove ("domob", {"vc": {"b": 10, "t": {"andy": 2, "domob": 10}}})
@@ -61,14 +59,12 @@ class CoinOpsTest (PXTest):
       "daniel": 0,
     })
 
-    self.generate (20)
-    self.testReorg (reorgBlk)
+    self.testReorg ()
 
-  def testReorg (self, blk):
+  def testReorg (self):
     self.mainLogger.info ("Testing reorg...")
 
-    originalState = self.getGameState ()
-    self.rpc.xaya.invalidateblock (blk)
+    self.snapshot.restore ()
 
     self.sendMove ("domob", {"vc": {"t": {"daniel": 100}}})
     self.generate (1)
@@ -78,9 +74,6 @@ class CoinOpsTest (PXTest):
       "andy": 0,
       "daniel": 100,
     })
-
-    self.rpc.xaya.reconsiderblock (blk)
-    self.expectGameState (originalState)
 
 
 if __name__ == "__main__":

--- a/gametest/combat_aoe.py
+++ b/gametest/combat_aoe.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -54,8 +54,6 @@ class CombatAoETest (PXTest):
         self.assertEqual (c[nm].data["combat"]["hp"]["current"]["armour"], 100)
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating test characters...")
     self.initAccount ("attacker", "r")
     self.createCharacters ("attacker")

--- a/gametest/combat_damage.py
+++ b/gametest/combat_damage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -40,8 +40,6 @@ class CombatDamageTest (PXTest):
     return hp["current"], hp["max"]
 
   def run (self):
-    self.collectPremine ()
-
     numAttackers = 5
 
     self.mainLogger.info ("Creating test characters...")
@@ -71,7 +69,7 @@ class CombatDamageTest (PXTest):
     assert hp["armour"] < maxHP["armour"]
     assert hp["shield"] < 2
 
-    self.restoreBlock = self.rpc.xaya.getbestblockhash ()
+    self.snapshot = self.env.snapshot ()
 
     self.mainLogger.info ("Regenerating shield...")
     self.moveCharactersTo ({"target": outOfRange})
@@ -98,18 +96,14 @@ class CombatDamageTest (PXTest):
     """
 
     self.mainLogger.info ("Testing a reorg...")
-    originalState = self.getGameState ()
 
-    self.rpc.xaya.invalidateblock (self.restoreBlock)
+    self.snapshot.restore ()
 
     self.moveCharactersTo ({"target": self.inRange})
     self.setCharactersHP ({"target": {"a": 1, "s": 0}})
     self.generate (5)
     hp, maxHP = self.getTargetHP ()
     assert (hp is None) and (maxHP is None)
-
-    self.rpc.xaya.reconsiderblock (self.restoreBlock)
-    self.expectGameState (originalState)
 
 
 if __name__ == "__main__":

--- a/gametest/combat_effects.py
+++ b/gametest/combat_effects.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest, offsetCoord
 class CombatEffectsTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating test characters...")
     self.initAccount ("attacker", "r")
     self.createCharacters ("attacker")

--- a/gametest/combat_friendly.py
+++ b/gametest/combat_friendly.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -36,8 +36,6 @@ class CombatFriendlyTest (PXTest):
     self.assertEqual (round (1000 * actual), round (1000 * expected))
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating test characters...")
     self.initAccount ("domob", "r")
     self.createCharacters ("domob", 2)

--- a/gametest/combat_targets.py
+++ b/gametest/combat_targets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -52,8 +52,6 @@ class CombatTargetTest (PXTest):
     raise AssertionError ("Character with id %d not found" % charId)
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating test characters...")
     self.initAccount ("red", "r")
     self.createCharacters ("red")
@@ -80,6 +78,7 @@ class CombatTargetTest (PXTest):
     self.mainLogger.info ("Testing randomised target selection...")
     cnts = {"green": 0, "green 2": 0}
     rolls = 10
+    snapshot = self.env.snapshot ()
     for _ in range (rolls):
       self.generate (1)
       self.assertEqual (self.getTargetCharacter ("green"), "red")
@@ -90,7 +89,7 @@ class CombatTargetTest (PXTest):
       cnts[fooTarget] += 1
       # Invalidate the last block so that we reroll the randomisation
       # with the next generated block.
-      self.rpc.xaya.invalidateblock (self.rpc.xaya.getbestblockhash ())
+      snapshot.restore ()
     for key, cnt in cnts.items ():
       self.log.info ("Target %s selected %d / %d times" % (key, cnt, rolls))
       assert cnt > 0

--- a/gametest/damage_lists.py
+++ b/gametest/damage_lists.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -51,8 +51,6 @@ class DamageListsTest (PXTest):
     self.assertEqual (self.getAttackers (name), set (expectedIds))
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating test characters...")
     self.initAccount ("target", "b")
     self.createCharacters ("target")

--- a/gametest/fame.py
+++ b/gametest/fame.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest
 class FameTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Characters killing each other at the same time...")
     self.initAccount ("foo", "r")
     self.createCharacters ("foo")

--- a/gametest/findpath.py
+++ b/gametest/findpath.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -72,8 +72,6 @@ class FindPathTest (PXTest):
     return val
 
   def run (self):
-    self.collectPremine ()
-
     # Pair of coordinates that are next to each other, but where one
     # is an obstacle.
     obstacle = {"x": 0, "y": 505}

--- a/gametest/fork_gamestart.py
+++ b/gametest/fork_gamestart.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -29,7 +29,6 @@ class ForkGameStartTest (PXTest):
 
   def run (self):
     self.recreateGameDaemon (extraArgs=["-fork_height_gamestart=100"])
-    self.collectPremine ()
 
     self.sendMove ("domob", {
       "vc": {"m": {}, "b": 10, "t": {"daniel": 100}}
@@ -38,7 +37,8 @@ class ForkGameStartTest (PXTest):
     self.createCharacters ("domob")
     self.generate (1)
 
-    assert self.rpc.xaya.getblockcount () < 100
+    _, height = self.env.getChainTip ()
+    assert height < 100
 
     accounts = self.getAccounts ()
     self.assertEqual (accounts["domob"].getBalance (), 10_000 - 10 - 100)

--- a/gametest/getserviceinfo.py
+++ b/gametest/getserviceinfo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,7 +26,6 @@ Tests the getserviceinfo RPC command.
 class GetServiceInfoTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
 
     def getserviceinfo (name, op):
       return self.getRpc ("getserviceinfo", name=name, op=op)

--- a/gametest/godmode.py
+++ b/gametest/godmode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest
 class GodModeTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.initAccount ("domob", "r")
     self.createCharacters ("domob")
     self.generate (1)
@@ -37,7 +35,7 @@ class GodModeTest (PXTest):
     self.mainLogger.info ("Testing build...")
     # Base height for building age.  Each build function call mines
     # a block on top of it.
-    height = self.rpc.xaya.getblockcount ()
+    _, height = self.env.getChainTip ()
     self.build ("checkmark", None, {"x": 100, "y": 150}, rot=2)
     self.build ("checkmark", "domob", {"x": -100, "y": -150}, rot=0)
     buildings = self.getBuildings ()

--- a/gametest/loot.py
+++ b/gametest/loot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@ from pxtest import PXTest
 class LootTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Dropping loot in god mode...")
     self.dropLoot ({"x": 1, "y": 2}, {"zerospace": 5, "bar": 10})
     self.dropLoot ({"x": 1, "y": 2}, {"zerospace": 5})

--- a/gametest/modifiedregions.py
+++ b/gametest/modifiedregions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@ class ModifiedRegionsTest (PXTest):
     data = self.rpc.game.getregionat (coord=pos)
 
     self.moveCharactersTo ({"prospector": pos})
-    h = self.rpc.xaya.getblockcount ()
+    _, h = self.env.getChainTip ()
 
     self.getCharacters ()["prospector"].sendMove ({"prospect": {}})
     self.generate (15)
@@ -51,8 +51,6 @@ class ModifiedRegionsTest (PXTest):
     return set ({r["id"] for r in data})
 
   def run (self):
-    self.collectPremine ()
-
     self.initAccount ("prospector", "r")
     self.createCharacters ("prospector")
     self.generate (1)

--- a/gametest/movement.py
+++ b/gametest/movement.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -110,8 +110,6 @@ class MovementTest (PXTest):
     assert mv is None
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating test character...")
     self.initAccount ("domob", "g")
     self.createCharacters ("domob")
@@ -135,11 +133,11 @@ class MovementTest (PXTest):
       {"x": -9, "y": 6},
     ]
     self.setWaypoints ("domob", wp)
+    self.snapshot = self.env.snapshot ()
     self.generate (1)
     pos, mv = self.getMovement ("domob")
     self.assertEqual (mv["partialstep"], 0)
     self.assertEqual (pos, {"x": 3, "y": 0})
-    self.reorgBlock = self.rpc.xaya.getbestblockhash ()
 
     self.mainLogger.info ("Finishing the movement...")
     self.expectMovement ("domob", wp)
@@ -401,18 +399,14 @@ class MovementTest (PXTest):
     """
 
     self.mainLogger.info ("Testing a reorg...")
-    originalState = self.getGameState ()
 
-    self.rpc.xaya.invalidateblock (self.reorgBlock)
+    self.snapshot.restore ()
 
     wp = [
       {"x": -5, "y": 5},
     ]
     self.setWaypoints ("domob", wp)
     self.expectMovement ("domob", wp)
-
-    self.rpc.xaya.reconsiderblock (self.reorgBlock)
-    self.expectGameState (originalState)
 
 
 if __name__ == "__main__":

--- a/gametest/multiupdate.py
+++ b/gametest/multiupdate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest, offsetCoord
 class MultiUpdateTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating test character...")
     self.initAccount ("domob", "r")
     self.createCharacters ("domob")

--- a/gametest/pending.py
+++ b/gametest/pending.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2021  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -37,8 +37,6 @@ def sleepSome ():
 class PendingTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     # Some well-defined position that we use, which also reflects the
     # region that will be prospected.  We use a different position and
     # region for mining.
@@ -255,13 +253,7 @@ class PendingTest (PXTest):
       "accounts": [],
     })
 
-    self.mainLogger.info ("Unconfirming the moves...")
-    blk = self.rpc.xaya.getbestblockhash ()
-    self.rpc.xaya.invalidateblock (blk)
-    sleepSome ()
-    self.assertEqual (self.getPendingState (), oldPending)
     self.generate (50)
-
     self.testDynObstacles ()
 
   def testDynObstacles (self):

--- a/gametest/prospecting_prizes.py
+++ b/gametest/prospecting_prizes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -52,8 +52,6 @@ class ProspectingPrizesTest (PXTest):
     return res
 
   def run (self):
-    self.collectPremine ()
-
     # First test:  Try and retry (with a reorg) prospecting in the
     # same region to get both a silver tier and not silver.
     self.mainLogger.info ("Testing randomisation of prizes...")
@@ -66,10 +64,10 @@ class ProspectingPrizesTest (PXTest):
     stillNeedSilver = True
     blk = None
     self.getCharacters ()["prize trier"].sendMove ({"prospect": {}})
-    self.generate (9)
+    self.generate (10)
+    snapshot = self.env.snapshot ()
     while stillNeedNoSilver or stillNeedSilver:
-      self.generate (1)
-      blk = self.rpc.xaya.getbestblockhash ()
+      snapshot.restore ()
       self.generate (1)
 
       prosp = self.getRegionAt (POS).data["prospection"]
@@ -80,14 +78,7 @@ class ProspectingPrizesTest (PXTest):
       else:
         stillNeedNoSilver = False
 
-      self.rpc.xaya.invalidateblock (blk)
-
-    assert blk is not None
-    blkOldTime = blk
-
-    # Restore the last randomised attempt.  Else we might end up with
-    # a long invalid chain, which can confuse the reorg test.
-    self.rpc.xaya.reconsiderblock (blkOldTime)
+      snapshot.restore ()
 
     # Prospect in some regions and verify some basic expectations
     # on the number of prizes found.

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -345,6 +345,10 @@ class PXTest (XayaXGameTest):
     Sends a move, and optionally includes a coin burn.
     """
 
+    if burn > 0:
+      assert send is None
+      send = (self.roConfig ().params.burn_addr, int (burn * COIN))
+
     return super ().sendMove (name, move, send=send)
 
   def moveWithPayment (self, name, move, devAmount):

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -1,5 +1,5 @@
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -14,17 +14,19 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from xayagametest.testcase import XayaGameTest
+from xayax.gametest import XayaXGameTest
 
 from proto import config_pb2
 
 import collections
+from contextlib import contextmanager
 import copy
 import os
 import os.path
 
 
 GAMEID = "tn"
+COIN = 10**8
 
 
 def offsetCoord (c, offs, inverse):
@@ -99,7 +101,8 @@ class Character (object):
           assert o["characterid"] == self.getId ()
           del o["characterid"]
           del o["start_height"]
-          o["blocks"] = o["end_height"] - self.test.rpc.xaya.getblockcount ()
+          _, height = self.test.env.getChainTip ()
+          o["blocks"] = o["end_height"] - height
           del o["end_height"]
           return o
       raise AssertionError ("Character busy %d not found in ongoings", opId)
@@ -204,7 +207,8 @@ class Building (object):
         assert o["buildingid"] == self.getId ()
         del o["buildingid"]
         del o["start_height"]
-        o["blocks"] = o["end_height"] - self.test.rpc.xaya.getblockcount ()
+        _, height = self.test.env.getChainTip ()
+        o["blocks"] = o["end_height"] - height
         del o["end_height"]
         return o
 
@@ -284,7 +288,7 @@ class Region (object):
     return self.data["resource"]["type"], self.data["resource"]["amount"]
 
 
-class PXTest (XayaGameTest):
+class PXTest (XayaXGameTest):
   """
   Integration test for the Tauron game daemon.
   """
@@ -308,29 +312,25 @@ class PXTest (XayaGameTest):
 
     return os.path.join (top, *parts)
 
-  def splitPremine (self):
-    """
-    Splits the premine coin into smaller outputs, so that there are more
-    than a single outputs in the wallet.  Some tests require this or else
-    name_update's will fail for some reason.
-    """
-
-    for i in range (10):
-      self.rpc.xaya.sendtoaddress (self.rpc.xaya.getnewaddress (), 100)
-    self.generate (1)
+  @contextmanager
+  def runBaseChainEnvironment (self):
+    with self.runXayaXEthEnvironment () as env:
+      yield env
 
   def advanceToHeight (self, targetHeight):
     """
     Mines blocks until we are exactly at the given target height.
     """
 
-    n = targetHeight - self.rpc.xaya.getblockcount ()
+    _, curHeight = self.env.getChainTip ()
+    n = targetHeight - curHeight
 
     assert n >= 0
     if n > 0:
       self.generate (n)
 
-    self.assertEqual (self.rpc.xaya.getblockcount (), targetHeight)
+    _, curHeight = self.env.getChainTip ()
+    self.assertEqual (curHeight, targetHeight)
 
   def getRpc (self, method, *args, **kwargs):
     """
@@ -340,21 +340,12 @@ class PXTest (XayaGameTest):
 
     return self.getCustomState ("data", method, *args, **kwargs)
 
-  def sendMove (self, name, move, options={}, burn=0):
+  def sendMove (self, name, move, send=None, burn=0):
     """
     Sends a move, and optionally includes a coin burn.
     """
 
-    opt = copy.deepcopy (options)
-
-    if burn > 0:
-      if "burn" not in opt:
-        opt["burn"] = {}
-      key = "g/%s" % self.gameId
-      assert key not in opt["burn"]
-      opt["burn"][key] = burn
-
-    return super ().sendMove (name, move, opt)
+    return super ().sendMove (name, move, send=send)
 
   def moveWithPayment (self, name, move, devAmount):
     """
@@ -363,7 +354,7 @@ class PXTest (XayaGameTest):
     """
 
     addr = self.roConfig ().params.dev_addr
-    return self.sendMove (name, move, {"sendCoins": {addr: devAmount}})
+    return self.sendMove (name, move, send=(addr, int (devAmount * COIN)))
 
   def roConfig (self):
     """

--- a/gametest/safezones.py
+++ b/gametest/safezones.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -36,8 +36,6 @@ def relativePos (x, y):
 class SafeZonesTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     self.mainLogger.info ("Creating test characters...")
     self.initAccount ("red", "r")
     self.initAccount ("green", "g")

--- a/gametest/services_bpcopy.py
+++ b/gametest/services_bpcopy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,9 +26,6 @@ from pxtest import PXTest
 class ServicesBlueprintCopyTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-    self.splitPremine ()
-
     self.mainLogger.info ("Setting up initial situation...")
     self.build ("ancient1", None, {"x": 0, "y": 0}, 0)
     building = 1001
@@ -53,7 +50,7 @@ class ServicesBlueprintCopyTest (PXTest):
     self.assertEqual (self.getAccounts ()["domob"].getBalance (), 500)
     b = self.getBuildings ()[building]
     self.assertEqual (b.getFungibleInventory ("domob"), {})
-    start = self.rpc.xaya.getblockcount ()
+    _, start = self.env.getChainTip ()
     self.assertEqual (self.getRpc ("getongoings"), [
       {
         "id": 1002,

--- a/gametest/services_construction.py
+++ b/gametest/services_construction.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,9 +26,6 @@ from pxtest import PXTest
 class ServicesConstructionTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-    self.splitPremine ()
-
     self.mainLogger.info ("Setting up initial situation...")
     self.build ("ancient1", None, {"x": 0, "y": 0}, 0)
     building = 1001
@@ -53,7 +50,7 @@ class ServicesConstructionTest (PXTest):
                       1000000 - 5 * 100 - 2 * 100 * 100)
     b = self.getBuildings ()[building]
     self.assertEqual (b.getFungibleInventory ("domob"), {})
-    start = self.rpc.xaya.getblockcount ()
+    _, start = self.env.getChainTip ()
     self.assertEqual (self.getRpc ("getongoings"), [
       {
         "id": 1002,

--- a/gametest/services_fees.py
+++ b/gametest/services_fees.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,9 +26,6 @@ from pxtest import PXTest
 class ServicesFeesTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-    self.splitPremine ()
-
     self.mainLogger.info ("Setting up initial situation...")
     self.initAccount ("domob", "r")
     self.initAccount ("andy", "r")

--- a/gametest/spawn.py
+++ b/gametest/spawn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@ from pxtest import PXTest, offsetCoord
 class SpawnTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     # Verify that characters of each faction can be spawned, and will end up
     # in their respective starting city building.
     for f in ["r", "g", "b"]:

--- a/gametest/splitstaterpcs.py
+++ b/gametest/splitstaterpcs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@ from pxtest import PXTest
 class SplitStateRpcsTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-
     # Set up a non-trivial situation, where we have characters, prospected
     # regions, kills/fame, buildings, ground loot and ongoing operations.
     self.initAccount ("prospector", "r")

--- a/gametest/vehiclefitments.py
+++ b/gametest/vehiclefitments.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #   GSP for the Taurion blockchain game
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2025  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -26,9 +26,6 @@ from pxtest import PXTest
 class VehicleFitmentsTest (PXTest):
 
   def run (self):
-    self.collectPremine ()
-    self.splitPremine ()
-
     self.mainLogger.info ("Setting up initial situation...")
     self.build ("ancient1", None, {"x": 0, "y": 0}, 0)
     building = 1001

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2025  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -588,15 +588,17 @@ message Params
 
   /** The address to which developer payments should be sent.  */
   optional string dev_addr = 16;
+  /** The address to which burn payments should be sent.  */
+  optional string burn_addr = 17;
 
   /** Whether or not god mode is enabled.  */
-  optional bool god_mode = 17;
+  optional bool god_mode = 18;
 
   /** Spawn areas for the factions (with the "r", "g", "b" string as key).  */
-  map<string, SpawnArea> spawn_areas = 18;
+  map<string, SpawnArea> spawn_areas = 19;
 
   /** Data about the burnsale schedule.  */
-  repeated BurnsaleStage burnsale_stages = 19;
+  repeated BurnsaleStage burnsale_stages = 20;
 
   /**
    * Prospecting prizes.  They are just a list and not a map, because the
@@ -606,7 +608,7 @@ message Params
    * It is replaced rather than concatenated (which would be the default
    * behaviour for proto merge).
    */
-  repeated ProspectingPrize prizes = 20;
+  repeated ProspectingPrize prizes = 21;
 
 }
 

--- a/proto/roconfig.cpp
+++ b/proto/roconfig.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2025  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -89,16 +89,19 @@ RoConfig::RoConfig (const xaya::Chain chain)
   switch (chain)
     {
     case xaya::Chain::MAIN:
+    case xaya::Chain::POLYGON:
       instancePtr = &mainnet;
       mergeTestnet = false;
       mergeRegtest = false;
       break;
     case xaya::Chain::TEST:
+    case xaya::Chain::MUMBAI:
       instancePtr = &testnet;
       mergeTestnet = true;
       mergeRegtest = false;
       break;
     case xaya::Chain::REGTEST:
+    case xaya::Chain::GANACHE:
       instancePtr = &regtest;
       mergeTestnet = true;
       mergeRegtest = true;

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -21,9 +21,9 @@ params:
     min_region_ore: 2000000
     max_region_ore: 100000000
 
-    # The address configured here (for mainnet) is the premine address of Xaya
-    # controlled by the Xaya team.  See also Xaya Core's src/chainparams.cpp.
-    dev_addr: "DHy2615XKevE23LVRVZVxGeqxadRGyiFW4"
+    # The address configured here (for mainnet) is a multisig address controlled
+    # by the Xaya team.
+    dev_addr: "0xb960bECa8623165a3094a629d6A4775857a14d28"
 
     god_mode: false
 

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -24,6 +24,9 @@ params:
     # The address configured here (for mainnet) is a multisig address controlled
     # by the Xaya team.
     dev_addr: "0xb960bECa8623165a3094a629d6A4775857a14d28"
+    # This address is controlled by the Xaya team.  WCHI sent here will
+    # periodically be bridged to Ethereum and burnt there.
+    burn_addr: "0x2659deaa71B51124bA6e6493b795486b3027Dbc9"
 
     god_mode: false
 

--- a/proto/roconfig/test_params.pb.text
+++ b/proto/roconfig/test_params.pb.text
@@ -17,7 +17,6 @@ params:
     min_region_ore: 10
     max_region_ore: 20
 
-    dev_addr: "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p"
     god_mode: true
 
     # The list of prizes replaces the mainnet list (rather than being

--- a/proto/roconfig/testnet.pb.text
+++ b/proto/roconfig/testnet.pb.text
@@ -1,7 +1,1 @@
-testnet_merge:
-  {
-    params:
-      {
-        dev_addr: "dSFDAWxovUio63hgtfYd3nz3ir61sJRsXn"
-      }
-  }
+testnet_merge: {}

--- a/proto/roconfig_tests.cpp
+++ b/proto/roconfig_tests.cpp
@@ -66,11 +66,6 @@ TEST (RoConfigTests, ChainDependence)
   EXPECT_EQ (test->params ().prospection_expiry_blocks (), 5'000);
   EXPECT_EQ (regtest->params ().prospection_expiry_blocks (), 100);
 
-  EXPECT_EQ (main->params ().dev_addr (), "DHy2615XKevE23LVRVZVxGeqxadRGyiFW4");
-  EXPECT_EQ (test->params ().dev_addr (), "dSFDAWxovUio63hgtfYd3nz3ir61sJRsXn");
-  EXPECT_EQ (regtest->params ().dev_addr (),
-             "dHNvNaqcD7XPDnoRjAoyfcMpHRi5upJD7p");
-
   EXPECT_FALSE (main->params ().god_mode ());
   EXPECT_FALSE (test->params ().god_mode ());
   EXPECT_TRUE (regtest->params ().god_mode ());

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonrpclib-pelix
 protobuf
 web3==7
-xayax
+xayax>=1.4.1

--- a/src/forks.cpp
+++ b/src/forks.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2025  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -59,7 +59,6 @@ const std::unordered_map<Fork, ForkData> FORK_HEIGHTS =
       {
         {
           {xaya::Chain::MAIN, 3'000'000},
-          {xaya::Chain::TEST, 150'000},
           {xaya::Chain::REGTEST, 100},
         },
         nullptr,
@@ -69,8 +68,7 @@ const std::unordered_map<Fork, ForkData> FORK_HEIGHTS =
       Fork::GameStart,
       {
         {
-          {xaya::Chain::MAIN, 2'250'000},
-          {xaya::Chain::TEST, 112'000},
+          {xaya::Chain::MAIN, 76'690'000},
           {xaya::Chain::REGTEST, 0},
         },
         &FLAGS_fork_height_gamestart,
@@ -79,6 +77,28 @@ const std::unordered_map<Fork, ForkData> FORK_HEIGHTS =
   };
 
 } // anonymous namespace
+
+xaya::Chain
+ForkHandler::TranslateChain (const xaya::Chain c)
+{
+  switch (c)
+    {
+    case xaya::Chain::MAIN:
+    case xaya::Chain::POLYGON:
+      return xaya::Chain::MAIN;
+
+    case xaya::Chain::TEST:
+    case xaya::Chain::MUMBAI:
+      return xaya::Chain::TEST;
+
+    case xaya::Chain::REGTEST:
+    case xaya::Chain::GANACHE:
+      return xaya::Chain::REGTEST;
+
+    default:
+      LOG (FATAL) << "Unexpected chain: " << xaya::ChainToString (c);
+    }
+}
 
 bool
 ForkHandler::IsActive (const Fork f) const

--- a/src/forks.hpp
+++ b/src/forks.hpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2025  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -60,10 +60,15 @@ private:
   /** The block height this is for.  */
   const unsigned height;
 
+  /**
+   * Translates a chain like MAIN to POLYGON.
+   */
+  static xaya::Chain TranslateChain (xaya::Chain c);
+
 public:
 
   explicit ForkHandler (const xaya::Chain c, const unsigned h)
-    : chain(c), height(h)
+    : chain(TranslateChain (c)), height(h)
   {}
 
   ForkHandler () = delete;

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+    Copyright (C) 2019-2025  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -135,22 +135,17 @@ PXLogic::GetInitialStateBlock (unsigned& height,
   const xaya::Chain chain = GetChain ();
   switch (chain)
     {
-    case xaya::Chain::MAIN:
-      height = 2'128'750;
+    case xaya::Chain::POLYGON:
+      height = 76'690'000;
       hashHex
-          = "f7b5247531e0b2aabafa1219d6bdaf695bef95cfc2409c18d5286c7896912961";
+          = "97cfbed2133010eb3134ceb65ec9ae46ed76d996f0dfcee84d022d95ab468be1";
       break;
 
-    case xaya::Chain::TEST:
-      height = 112'000;
-      hashHex
-          = "9c5b83a5caaf7f4ce17cc1f38fdb1ed3e3e3e98e43d23d19a4810767d7df38b9";
-      break;
-
-    case xaya::Chain::REGTEST:
+    case xaya::Chain::GANACHE:
       height = 0;
-      hashHex
-          = "6f750b36d22f1dc3d0a6e483af45301022646dfc3b3ba2187865f5a7d6d83ab1";
+      /* Ganache does not have a fixed genesis block.  So leave the block
+         hash open and just accept any at height 0.  */
+      hashHex = "";
       break;
 
     default:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2021  Autonomous Worlds Ltd
+    Copyright (C) 2019-2025  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -159,10 +159,8 @@ main (int argc, char** argv)
   config.EnablePruning = FLAGS_enable_pruning;
   config.DataDirectory = FLAGS_datadir;
 
-  /* We need support for coin burns, which was implemented in
-     https://github.com/xaya/xaya/pull/103 and is included in
-     versions from 1.4 up.  */
-  config.MinXayaVersion = 1040000;
+  /* We use Xaya X Eth, which reports its version as 1.0.0.0 initially.  */
+  config.MinXayaVersion = 1'00'00'00;
 
   pxd::PXLogic rules;
   PXInstanceFactory instanceFact(rules);

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -90,15 +90,19 @@ BaseMoveProcessor::ExtractMoveBasics (const Json::Value& moveObj,
   name = nameVal.asString ();
 
   paidToDev = 0;
-  const auto& outVal = moveObj["out"];
-  const auto& devAddr = ctx.RoConfig ()->params ().dev_addr ();
-  if (outVal.isObject () && outVal.isMember (devAddr))
-    CHECK (xaya::ChiAmountFromJson (outVal[devAddr], paidToDev));
+  burnt = 0;
 
-  if (moveObj.isMember ("burnt"))
-    CHECK (xaya::ChiAmountFromJson (moveObj["burnt"], burnt));
-  else
-    burnt = 0;
+  const auto& outVal = moveObj["out"];
+  if (outVal.isObject ())
+    {
+      const auto& devAddr = ctx.RoConfig ()->params ().dev_addr ();
+      if (outVal.isMember (devAddr))
+        CHECK (xaya::ChiAmountFromJson (outVal[devAddr], paidToDev));
+
+      const auto& burnAddr = ctx.RoConfig ()->params ().burn_addr ();
+      if (outVal.isMember (burnAddr))
+        CHECK (xaya::ChiAmountFromJson (outVal[burnAddr], burnt));
+    }
 
   return true;
 }

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -59,9 +59,12 @@ Params::RevEngSuccessChance (const unsigned existingBp) const
     {
     case xaya::Chain::MAIN:
     case xaya::Chain::TEST:
+    case xaya::Chain::POLYGON:
+    case xaya::Chain::MUMBAI:
       base = 10;
       break;
     case xaya::Chain::REGTEST:
+    case xaya::Chain::GANACHE:
       base = 1;
       break;
     default:

--- a/src/pending_tests.cpp
+++ b/src/pending_tests.cpp
@@ -1,6 +1,6 @@
 /*
     GSP for the Taurion blockchain game
-    Copyright (C) 2019-2021  Autonomous Worlds Ltd
+    Copyright (C) 2019-2025  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -864,7 +864,8 @@ protected:
       moveObj["out"][ctx.RoConfig ()->params ().dev_addr ()]
           = xaya::ChiAmountToJson (paidToDev);
     if (burntChi != 0)
-      moveObj["burnt"] = xaya::ChiAmountToJson (burntChi);
+      moveObj["out"][ctx.RoConfig ()->params ().burn_addr ()]
+          = xaya::ChiAmountToJson (burntChi);
 
     DynObstacles dyn(db, ctx);
     PendingStateUpdater updater(db, dyn, state, ctx);


### PR DESCRIPTION
This defines basic config for Taurion to run on the Polygon network, and it switches the integration tests to XayaX / EVM / `anvil`.

Burning WCHI on Polygon is not (directly) possible... instead to mint Cubits, WCHI should be sent to a second special address that is then considered like a burn was before.