### PR TITLE
database: runtime-tunable named parameters ("param" admin command)

### DIFF
--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -29,6 +29,7 @@ libdatabase_la_SOURCES = \
   itemcounts.cpp \
   moneysupply.cpp \
   ongoing.cpp \
+  params.cpp \
   region.cpp \
   schema.cpp \
   target.cpp \
@@ -49,6 +50,7 @@ noinst_HEADERS = \
   itemcounts.hpp \
   moneysupply.hpp \
   ongoing.hpp \
+  params.hpp \
   lazyproto.hpp lazyproto.tpp \
   region.hpp \
   schema.hpp \
@@ -101,6 +103,7 @@ tests_SOURCES = \
   lazyproto_tests.cpp \
   moneysupply_tests.cpp \
   ongoing_tests.cpp \
+  params_tests.cpp \
   region_tests.cpp \
   schema_tests.cpp \
   target_tests.cpp \

--- a/database/params.cpp
+++ b/database/params.cpp
@@ -1,0 +1,78 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "params.hpp"
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+namespace
+{
+
+/** Result type for parameter value lookups.  */
+struct ParamValueResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, value, 1);
+};
+
+} // anonymous namespace
+
+int64_t
+ParamsTable::Get (const std::string& name, const int64_t fallback) const
+{
+  auto stmt = db.Prepare (R"(
+    SELECT `value`
+      FROM `parameters`
+      WHERE `name` = ?1
+  )");
+  stmt.Bind (1, name);
+
+  auto res = stmt.Query<ParamValueResult> ();
+  if (!res.Step ())
+    return fallback;
+  const int64_t value = res.Get<ParamValueResult::value> ();
+  CHECK (!res.Step ());
+  return value;
+}
+
+void
+ParamsTable::Set (const std::string& name, const int64_t value)
+{
+  auto stmt = db.Prepare (R"(
+    INSERT OR REPLACE INTO `parameters`
+      (`name`, `value`) VALUES (?1, ?2)
+  )");
+  stmt.Bind (1, name);
+  stmt.Bind (2, value);
+  stmt.Execute ();
+}
+
+void
+ParamsTable::Remove (const std::string& name)
+{
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `parameters`
+      WHERE `name` = ?1
+  )");
+  stmt.Bind (1, name);
+  stmt.Execute ();
+}
+
+} // namespace pxd

--- a/database/params.hpp
+++ b/database/params.hpp
@@ -1,0 +1,79 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_PARAMS_HPP
+#define DATABASE_PARAMS_HPP
+
+#include "database.hpp"
+
+#include <string>
+
+namespace pxd
+{
+
+/**
+ * Access to the runtime-tunable named parameters (the parameters table),
+ * set through the "param" admin command exactly as in the soccerverse GSP.
+ * Unlike there, reads fall back to a caller-supplied default (taurion's
+ * defaults live in roconfig), so the table only ever holds explicit
+ * overrides and removing one cleanly resets to the default.  Consensus
+ * state: values change only through admin commands in block data and
+ * unwind with the normal changesets.
+ *
+ * No consensus rule reads a parameter yet: this is general infrastructure
+ * rather than a feature, so it lands on its own.  Beyond emergency tuning
+ * of a limit without a redeploy, it carries soccerverse-style "fork-*"
+ * activation flags: a post-launch consensus change can ship dormant behind
+ * Get ("fork-x", 0) > 0 and then be enabled chain-wide by one admin
+ * command, with no wipe and no coordinated restart.
+ */
+class ParamsTable
+{
+
+private:
+
+  /** The underlying database handle.  */
+  Database& db;
+
+public:
+
+  explicit ParamsTable (Database& d)
+    : db(d)
+  {}
+
+  ParamsTable () = delete;
+  ParamsTable (const ParamsTable&) = delete;
+  void operator= (const ParamsTable&) = delete;
+
+  /**
+   * Returns the effective value for the given name: the stored override if
+   * one exists, else the fallback (the roconfig default).
+   */
+  int64_t Get (const std::string& name, int64_t fallback) const;
+
+  /** Sets (inserts or replaces) the override for the given name.  */
+  void Set (const std::string& name, int64_t value);
+
+  /** Removes the override (resetting the name to its default).  */
+  void Remove (const std::string& name);
+
+};
+
+} // namespace pxd
+
+#endif // DATABASE_PARAMS_HPP

--- a/database/params_tests.cpp
+++ b/database/params_tests.cpp
@@ -1,0 +1,76 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "params.hpp"
+
+#include "dbtest.hpp"
+
+#include <gtest/gtest.h>
+
+namespace pxd
+{
+namespace
+{
+
+class ParamsTableTests : public DBTestWithSchema
+{
+
+protected:
+
+  ParamsTable p;
+
+  ParamsTableTests ()
+    : p(db)
+  {}
+
+};
+
+TEST_F (ParamsTableTests, FallbackWithoutOverride)
+{
+  EXPECT_EQ (p.Get ("some-limit", 42), 42);
+}
+
+TEST_F (ParamsTableTests, SetOverridesAndReplaces)
+{
+  p.Set ("some-limit", 5);
+  EXPECT_EQ (p.Get ("some-limit", 42), 5);
+
+  p.Set ("some-limit", 7);
+  EXPECT_EQ (p.Get ("some-limit", 42), 7);
+
+  /* Other names are unaffected.  */
+  EXPECT_EQ (p.Get ("other-limit", 100), 100);
+
+  /* Zero and negative values are stored as-is (0 is the posting freeze).  */
+  p.Set ("some-limit", 0);
+  EXPECT_EQ (p.Get ("some-limit", 42), 0);
+}
+
+TEST_F (ParamsTableTests, RemoveResetsToFallback)
+{
+  p.Set ("some-limit", 5);
+  p.Remove ("some-limit");
+  EXPECT_EQ (p.Get ("some-limit", 42), 42);
+
+  /* Removing an absent name is a no-op.  */
+  p.Remove ("some-limit");
+  EXPECT_EQ (p.Get ("some-limit", 42), 42);
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -521,3 +521,13 @@ CREATE INDEX IF NOT EXISTS `ongoing_operations_by_building`
   ON `ongoing_operations` (`building`);
 
 -- =============================================================================
+
+-- Runtime-tunable named parameters (the "param" admin command): one row per
+-- overridden parameter, an absent name means the roconfig default applies.
+-- Consensus state -- see database/params.hpp for the semantics.
+CREATE TABLE IF NOT EXISTS `parameters` (
+  `name` TEXT PRIMARY KEY,
+  `value` INTEGER NOT NULL
+);
+
+-- =============================================================================

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -30,6 +30,7 @@
 #include "spawn.hpp"
 
 #include "database/faction.hpp"
+#include "database/params.hpp"
 #include "proto/character.pb.h"
 #include "proto/roconfig.hpp"
 
@@ -1250,6 +1251,48 @@ MoveProcessor::ProcessOneAdmin (const Json::Value& cmd)
     return;
 
   HandleGodMode (cmd["god"]);
+  HandleParams (cmd["param"]);
+}
+
+void
+MoveProcessor::HandleParams (const Json::Value& cmd)
+{
+  if (!cmd.isArray ())
+    return;
+
+  /* The same admin shape as the soccerverse GSP: an array of {"n": name,
+     "v": value} entries, where a null value removes the override (falling
+     back to the roconfig default).  Parameter names are free-form -- reads
+     use known names, so setting an unread one is a harmless no-op.
+     Malformed entries are logged and skipped deterministically.  */
+  ParamsTable par(db);
+  for (const auto& entry : cmd)
+    {
+      /* Exactly the members n and v: a typo'd value key (e.g. "value")
+         must be a skipped malformed entry, NOT a missing-v null that would
+         remove the override -- the dangerous direction for a freeze.  */
+      if (!entry.isObject () || entry.size () != 2
+            || !entry.isMember ("v") || !entry["n"].isString ())
+        {
+          LOG (WARNING) << "Invalid set-param operation: " << entry;
+          continue;
+        }
+      const std::string name = entry["n"].asString ();
+
+      const auto& val = entry["v"];
+      if (val.isNull ())
+        {
+          LOG (INFO) << "Removing parameter: " << name;
+          par.Remove (name);
+        }
+      else if (val.isInt64 () && xaya::IsIntegerValue (val))
+        {
+          LOG (INFO) << "Setting parameter: " << name << " = " << val;
+          par.Set (name, val.asInt64 ());
+        }
+      else
+        LOG (WARNING) << "Invalid set-param operation: " << entry;
+    }
 }
 
 void

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -391,6 +391,15 @@ private:
   void HandleGodMode (const Json::Value& cmd);
 
   /**
+   * Handles a "param" admin command, if any: runtime tuning of named
+   * parameters, in the exact admin shape of the soccerverse GSP.  Unlike
+   * god mode this is a legitimate mainnet operation -- admin commands only
+   * ever come from the game account's owner -- so tunable values can be
+   * adjusted without a redeploy.
+   */
+  void HandleParams (const Json::Value& cmd);
+
+  /**
    * Transfers the given character if the update JSON contains a request
    * to do so.
    */

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -23,6 +23,7 @@
 #include "testutils.hpp"
 
 #include "database/dbtest.hpp"
+#include "database/params.hpp"
 
 #include <xayautil/jsonutils.hpp>
 
@@ -175,6 +176,36 @@ TEST_F (MoveProcessorTests, AllAdminDataAccepted)
 
       ProcessAdmin (fullAdm.str ());
     }
+}
+
+TEST_F (MoveProcessorTests, AdminSetParam)
+{
+  ParamsTable par(db);
+
+  /* Valid sets and a removal (null value resets to the default), plus
+     malformed entries that must be skipped deterministically: wrong shape,
+     non-string name, extra member, non-integer value, and -- crucially --
+     a typo'd value key: that must NOT read as a missing-v null and remove
+     the override (the dangerous direction, since an override is how a
+     limit gets tightened in an emergency).  */
+  ProcessAdmin (R"([{"cmd": {"param": [
+    {"n": "some-limit", "v": 5},
+    {"n": "other-limit", "v": 7},
+    {"n": "other-limit", "v": null},
+    42,
+    {"n": 10, "v": 1},
+    {"n": "third-limit", "v": 3, "x": 1},
+    {"n": "third-limit", "v": 2.5},
+    {"n": "some-limit", "value": 0}
+  ]}}])");
+
+  EXPECT_EQ (par.Get ("some-limit", 42), 5);
+  EXPECT_EQ (par.Get ("other-limit", 42), 42);
+  EXPECT_EQ (par.Get ("third-limit", 42), 42);
+
+  /* A non-array "param" command is ignored.  */
+  ProcessAdmin (R"([{"cmd": {"param": {"n": "some-limit", "v": 9}}}])");
+  EXPECT_EQ (par.Get ("some-limit", 42), 5);
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
Adds a `parameters` table plus the `"param"` admin command, so a named integer
can be overridden at runtime and read back as consensus state.

This is the soccerverse mechanism, with one deliberate difference: `Get` takes
the caller's fallback, so the table holds only *overrides* and the defaults stay
in roconfig. Removing an override (`{"n":"x","v":null}`) therefore restores the
roconfig value rather than leaving a hole.

```
{"cmd":{"param":[{"n":"max-live-jobs","v":5000},{"n":"other","v":null}]}}
```

Nothing reads a parameter in this commit — it is infrastructure rather than a
feature, which is why it lands on its own. Beyond emergency tuning of a limit
without a redeploy, it is what soccerverse-style `fork-*` activation flags need:
a post-launch consensus change can ship dormant behind `Get("fork-x", 0) > 0` and
be switched on by an admin transaction, with no restart and no wipe.

The escrow-deal jobs board in the follow-up PR is the first consumer.

A malformed entry is skipped, not guessed at: `HandleParams` requires exactly
the two members, so a typo'd value key cannot be read as a missing `v` and
silently *remove* an override.

Tests: `database/params_tests.cpp` (set / overwrite / remove / fallback /
reorg-undo) and `MoveProcessorTests.AdminSetParam` for the command parsing.
