### PR TITLE
jobs: an on-chain job board carrying the generic escrow deal

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,8 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -Im4
 
 SUBDIRS = hexagonal proto database mapdata src gametest
 
+EXTRA_DIST = docs/escrow-deals.md
+
 build-tests:
 	$(MAKE) -C hexagonal build-tests
 	$(MAKE) -C proto build-tests

--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -27,6 +27,7 @@ libdatabase_la_SOURCES = \
   fighter.cpp \
   inventory.cpp \
   itemcounts.cpp \
+  jobs.cpp \
   moneysupply.cpp \
   ongoing.cpp \
   params.cpp \
@@ -48,6 +49,7 @@ noinst_HEADERS = \
   fighter.hpp \
   inventory.hpp \
   itemcounts.hpp \
+  jobs.hpp \
   moneysupply.hpp \
   ongoing.hpp \
   params.hpp \
@@ -100,6 +102,7 @@ tests_SOURCES = \
   fighter_tests.cpp \
   inventory_tests.cpp \
   itemcounts_tests.cpp \
+  jobs_tests.cpp \
   lazyproto_tests.cpp \
   moneysupply_tests.cpp \
   ongoing_tests.cpp \

--- a/database/jobs.cpp
+++ b/database/jobs.cpp
@@ -1,0 +1,276 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "jobs.hpp"
+
+#include <glog/logging.h>
+
+namespace pxd
+{
+
+Job::Job (Database& d)
+  : db(d), id(db.GetNextId ()), tracker(db.TrackHandle ("job", id)),
+    status(Status::OPEN), reward(0), collateral(0), deadline(0),
+    dirtyFields(true)
+{
+  VLOG (1) << "Created new job with ID " << id;
+  data.SetToDefault ();
+}
+
+Job::Job (Database& d, const Database::Result<JobResult>& res)
+  : db(d), dirtyFields(false)
+{
+  id = res.Get<JobResult::id> ();
+  tracker = db.TrackHandle ("job", id);
+
+  status = static_cast<Status> (res.Get<JobResult::status> ());
+  poster = res.Get<JobResult::poster> ();
+
+  if (res.IsNull<JobResult::worker> ())
+    worker = "";
+  else
+    worker = res.Get<JobResult::worker> ();
+
+  reward = res.Get<JobResult::reward> ();
+  collateral = res.Get<JobResult::collateral> ();
+  deadline = res.Get<JobResult::deadline> ();
+
+  data = res.GetProto<JobResult::proto> ();
+
+  VLOG (1) << "Created job instance for ID " << id << " from database";
+}
+
+Job::~Job ()
+{
+  if (!dirtyFields && !data.IsDirty ())
+    {
+      VLOG (1) << "Job " << id << " is not dirty";
+      return;
+    }
+
+  VLOG (1) << "Updating dirty job " << id << " in the database";
+
+  CHECK (status != Status::INVALID) << "Job " << id << " has no status set";
+  CHECK (!poster.empty ()) << "Job " << id << " has no poster set";
+  CHECK_GE (reward, 0) << "Job " << id << " has negative reward";
+  CHECK_GE (collateral, 0) << "Job " << id << " has negative collateral";
+
+  auto stmt = db.Prepare (R"(
+    INSERT OR REPLACE INTO `jobs`
+      (`id`, `status`, `poster`, `worker`,
+       `reward`, `collateral`, `deadline`, `proto`)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+  )");
+
+  stmt.Bind (1, id);
+  stmt.Bind (2, static_cast<int> (status));
+  stmt.Bind (3, poster);
+
+  if (worker.empty ())
+    stmt.BindNull (4);
+  else
+    stmt.Bind (4, worker);
+
+  stmt.Bind (5, reward);
+  stmt.Bind (6, collateral);
+  stmt.Bind (7, deadline);
+  stmt.BindProto (8, data);
+
+  stmt.Execute ();
+}
+
+JobsTable::Handle
+JobsTable::CreateNew (const std::string& poster, const Amount reward,
+                      const Amount collateral, const int64_t deadline)
+{
+  Handle j(new Job (db));
+
+  j->status = Job::Status::OPEN;
+  j->poster = poster;
+  j->reward = reward;
+  j->collateral = collateral;
+  j->deadline = deadline;
+
+  return j;
+}
+
+JobsTable::Handle
+JobsTable::GetFromResult (const Database::Result<JobResult>& res)
+{
+  return Handle (new Job (db, res));
+}
+
+JobsTable::Handle
+JobsTable::GetById (const Database::IdT id)
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `jobs`
+      WHERE `id` = ?1
+  )");
+  stmt.Bind (1, id);
+  auto res = stmt.Query<JobResult> ();
+  if (!res.Step ())
+    return nullptr;
+
+  auto j = GetFromResult (res);
+  CHECK (!res.Step ());
+  return j;
+}
+
+Database::Result<JobResult>
+JobsTable::QueryAll ()
+{
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `jobs`
+      ORDER BY `id`
+  )");
+  return stmt.Query<JobResult> ();
+}
+
+Database::Result<JobResult>
+JobsTable::QueryForDeadline (const int64_t now)
+{
+  /* Overdue rows (deadline strictly below now) are routine, not an anomaly:
+     deadlines fall between superblocks and the sweep only runs on
+     superblocks, so less-or-equal picks up everything that became due since
+     the previous sweep (the processing loop still asserts nothing from the
+     future got in).
+
+     Ordering by (deadline, id) is deterministic (id breaks ties, and it
+     aliases the rowid the jobs_by_deadline index carries) and lets the
+     query run straight off that index instead of sorting all due rows in a
+     temporary B-tree.  */
+  auto stmt = db.Prepare (R"(
+    SELECT *
+      FROM `jobs`
+      WHERE `deadline` <= ?1
+      ORDER BY `deadline`, `id`
+  )");
+  stmt.Bind (1, now);
+  return stmt.Query<JobResult> ();
+}
+
+namespace
+{
+
+/** Result type for the admission-cap COUNT queries.  */
+struct CountResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, cnt, 1);
+};
+
+/** Runs a prepared COUNT query and returns its single value.  */
+int64_t
+StepCount (Database::Statement&& stmt)
+{
+  auto res = stmt.Query<CountResult> ();
+  CHECK (res.Step ());
+  const int64_t cnt = res.Get<CountResult::cnt> ();
+  CHECK (!res.Step ());
+  return cnt;
+}
+
+} // anonymous namespace
+
+int64_t
+JobsTable::CountAll () const
+{
+  /* The one count without a WHERE clause: SQLite serves it with its
+     count optimisation over the smallest index (no per-row scan), and it
+     is in any case bounded by the very cap it enforces (the board can
+     never exceed the global cap plus the in-flight block's admissions).  */
+  return StepCount (db.Prepare (R"(
+    SELECT COUNT(*) AS `cnt` FROM `jobs`
+  )"));
+}
+
+int64_t
+JobsTable::CountForPoster (const std::string& poster) const
+{
+  auto stmt = db.Prepare (R"(
+    SELECT COUNT(*) AS `cnt`
+      FROM `jobs`
+      WHERE `poster` = ?1
+  )");
+  stmt.Bind (1, poster);
+  return StepCount (std::move (stmt));
+}
+
+
+void
+JobsTable::DeleteById (const Database::IdT id)
+{
+  auto stmt = db.Prepare (R"(
+    DELETE FROM `jobs`
+      WHERE `id` = ?1
+  )");
+  stmt.Bind (1, id);
+  stmt.Execute ();
+}
+
+namespace
+{
+
+/** Result type for the reserved-coins aggregate queries.  */
+struct ReservedResult : public Database::ResultType
+{
+  RESULT_COLUMN (std::string, account, 1);
+  RESULT_COLUMN (int64_t, amount, 2);
+};
+
+} // anonymous namespace
+
+std::map<std::string, Amount>
+JobsTable::GetReservedCoins () const
+{
+  std::map<std::string, Amount> balances;
+
+  /* Rewards escrowed by posters (over OPEN and ACCEPTED jobs alike).  */
+  {
+    auto stmt = db.Prepare (R"(
+      SELECT `poster` AS `account`, SUM(`reward`) AS `amount`
+        FROM `jobs`
+        GROUP BY `poster`
+    )");
+    auto res = stmt.Query<ReservedResult> ();
+    while (res.Step ())
+      balances[res.Get<ReservedResult::account> ()]
+          += res.Get<ReservedResult::amount> ();
+  }
+
+  /* Collateral locked by workers on accepted jobs (worker is NULL while
+     OPEN, so those rows are grouped under NULL and skipped below).  */
+  {
+    auto stmt = db.Prepare (R"(
+      SELECT `worker` AS `account`, SUM(`collateral`) AS `amount`
+        FROM `jobs`
+        WHERE `worker` IS NOT NULL
+        GROUP BY `worker`
+    )");
+    auto res = stmt.Query<ReservedResult> ();
+    while (res.Step ())
+      balances[res.Get<ReservedResult::account> ()]
+          += res.Get<ReservedResult::amount> ();
+  }
+
+  return balances;
+}
+
+} // namespace pxd

--- a/database/jobs.hpp
+++ b/database/jobs.hpp
@@ -1,0 +1,288 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATABASE_JOBS_HPP
+#define DATABASE_JOBS_HPP
+
+#include "amount.hpp"
+#include "database.hpp"
+#include "lazyproto.hpp"
+
+#include "proto/jobs.pb.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace pxd
+{
+
+/** Database result type for rows from the jobs table.  */
+struct JobResult : public Database::ResultType
+{
+  RESULT_COLUMN (int64_t, id, 1);
+  RESULT_COLUMN (int64_t, status, 2);
+  RESULT_COLUMN (std::string, poster, 3);
+  RESULT_COLUMN (std::string, worker, 4);
+  RESULT_COLUMN (int64_t, reward, 5);
+  RESULT_COLUMN (int64_t, collateral, 6);
+  RESULT_COLUMN (int64_t, deadline, 7);
+  RESULT_COLUMN (pxd::proto::JobData, proto, 8);
+};
+
+/**
+ * Wrapper class around a job on the jobs board in the database.  Instances
+ * should be obtained through JobsTable.  The scalar column fields can be
+ * modified (status and worker on accept, deadline on a reaction-window
+ * extension); the rest of the deal is held in the proto blob.
+ */
+class Job
+{
+
+public:
+
+  /**
+   * The lifecycle status of a job.  The numeric values match the `status`
+   * database column.  Terminal transitions delete the row entirely.
+   */
+  enum class Status
+  {
+    INVALID = -1,
+    OPEN = 0,
+    ACCEPTED = 1,
+  };
+
+private:
+
+  /** Database reference this belongs to.  */
+  Database& db;
+
+  /** The underlying ID in the database.  */
+  Database::IdT id;
+
+  /** The UniqueHandles tracker for this instance.  */
+  Database::HandleTracker tracker;
+
+  /** The lifecycle status.  */
+  Status status;
+
+  /** The account that posted the job.  */
+  std::string poster;
+
+  /** The account that accepted the job (empty while OPEN).  */
+  std::string worker;
+
+  /** The reward in vCHI paid on settlement.  */
+  Amount reward;
+
+  /** The collateral in vCHI locked by the worker.  */
+  Amount collateral;
+
+  /** The absolute consensus timestamp (seconds) at which the job expires.  */
+  int64_t deadline;
+
+  /** The rest of the deal (designated worker, arbiter, confirmations, ...).  */
+  LazyProto<proto::JobData> data;
+
+  /** Whether or not the column fields are dirty and need writing.  */
+  bool dirtyFields;
+
+  /**
+   * Constructs a new instance with auto-generated ID meant to be inserted
+   * into the database.
+   */
+  explicit Job (Database& d);
+
+  /**
+   * Constructs an instance based on the given DB result set.  The result
+   * set should be constructed by a JobsTable.
+   */
+  explicit Job (Database& d, const Database::Result<JobResult>& res);
+
+  friend class JobsTable;
+
+public:
+
+  /**
+   * In the destructor, the underlying database is updated if there are any
+   * modifications to send.
+   */
+  ~Job ();
+
+  Job () = delete;
+  Job (const Job&) = delete;
+  void operator= (const Job&) = delete;
+
+  Database::IdT
+  GetId () const
+  {
+    return id;
+  }
+
+  Status
+  GetStatus () const
+  {
+    return status;
+  }
+
+  void
+  SetStatus (const Status s)
+  {
+    status = s;
+    dirtyFields = true;
+  }
+
+  const std::string&
+  GetPoster () const
+  {
+    return poster;
+  }
+
+  const std::string&
+  GetWorker () const
+  {
+    return worker;
+  }
+
+  void
+  SetWorker (const std::string& w)
+  {
+    worker = w;
+    dirtyFields = true;
+  }
+
+  Amount
+  GetReward () const
+  {
+    return reward;
+  }
+
+  Amount
+  GetCollateral () const
+  {
+    return collateral;
+  }
+
+  int64_t
+  GetDeadline () const
+  {
+    return deadline;
+  }
+
+  void
+  SetDeadline (const int64_t d)
+  {
+    deadline = d;
+    dirtyFields = true;
+  }
+
+  const proto::JobData&
+  GetProto () const
+  {
+    return data.Get ();
+  }
+
+  proto::JobData&
+  MutableProto ()
+  {
+    return data.Mutable ();
+  }
+
+};
+
+/**
+ * Utility class that handles querying the jobs table in the database and
+ * should be used to obtain Job instances.
+ */
+class JobsTable
+{
+
+private:
+
+  /** The Database reference for creating queries.  */
+  Database& db;
+
+public:
+
+  /** Movable handle to an instance.  */
+  using Handle = std::unique_ptr<Job>;
+
+  explicit JobsTable (Database& d)
+    : db(d)
+  {}
+
+  JobsTable () = delete;
+  JobsTable (const JobsTable&) = delete;
+  void operator= (const JobsTable&) = delete;
+
+  /**
+   * Creates a new job (status OPEN, no worker) and returns the handle so the
+   * proto payload can be filled in.  All the column fields are passed here so
+   * that the row is always valid.
+   */
+  Handle CreateNew (const std::string& poster, Amount reward,
+                    Amount collateral, int64_t deadline);
+
+  /**
+   * Returns a handle for the instance based on a Database::Result.
+   */
+  Handle GetFromResult (const Database::Result<JobResult>& res);
+
+  /**
+   * Returns a handle for the given ID (or null if it doesn't exist).
+   */
+  Handle GetById (Database::IdT id);
+
+  /**
+   * Queries the database for all jobs on the board, ordered by ID.
+   */
+  Database::Result<JobResult> QueryAll ();
+
+  /**
+   * Queries for all jobs whose deadline is at or before the given (current)
+   * consensus timestamp.  This is the expiry sweep; on the vast majority of
+   * blocks it returns nothing and touches no rows.
+   */
+  Database::Result<JobResult> QueryForDeadline (int64_t now);
+
+  /**
+   * Row counts for the admission caps, each a cap-bounded COUNT over live
+   * rows: the whole board, and one poster's jobs.
+   */
+  int64_t CountAll () const;
+  int64_t CountForPoster (const std::string& poster) const;
+
+  /**
+   * Deletes the job with the given ID.  Used on every terminal transition
+   * (settlement / cancel / expiry) to keep the table bounded.
+   */
+  void DeleteById (Database::IdT id);
+
+  /**
+   * Returns the total vCHI reserved by each account on the jobs board: the
+   * sum of rewards over jobs they posted plus the sum of collateral over jobs
+   * they accepted.  Mirrors DexOrderTable::GetReservedCoins so the two can be
+   * merged into an account's balance.reserved.
+   */
+  std::map<std::string, Amount> GetReservedCoins () const;
+
+};
+
+} // namespace pxd
+
+#endif // DATABASE_JOBS_HPP

--- a/database/jobs_tests.cpp
+++ b/database/jobs_tests.cpp
@@ -1,0 +1,164 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "jobs.hpp"
+
+#include "dbtest.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace pxd
+{
+namespace
+{
+
+using testing::ElementsAre;
+using testing::Pair;
+
+class JobsTableTests : public DBTestWithSchema
+{
+
+protected:
+
+  JobsTable tbl;
+
+  JobsTableTests ()
+    : tbl(db)
+  {}
+
+};
+
+TEST_F (JobsTableTests, RoundTrip)
+{
+  Database::IdT id;
+  {
+    auto j = tbl.CreateNew ("poster", 2000, 8000, 1234);
+    j->MutableProto ().set_type_tag (5);
+    id = j->GetId ();
+  }
+
+  auto j = tbl.GetById (id);
+  ASSERT_NE (j, nullptr);
+  EXPECT_EQ (j->GetStatus (), Job::Status::OPEN);
+  EXPECT_EQ (j->GetPoster (), "poster");
+  EXPECT_EQ (j->GetWorker (), "");
+  EXPECT_EQ (j->GetReward (), 2000);
+  EXPECT_EQ (j->GetCollateral (), 8000);
+  EXPECT_EQ (j->GetDeadline (), 1234);
+  EXPECT_EQ (j->GetProto ().type_tag (), 5);
+}
+
+TEST_F (JobsTableTests, WorkerNullThenSet)
+{
+  Database::IdT id;
+  {
+    auto j = tbl.CreateNew ("poster", 100, 50, 10);
+    id = j->GetId ();
+  }
+  /* OPEN: worker column is NULL -> reads back empty.  */
+  EXPECT_EQ (tbl.GetById (id)->GetWorker (), "");
+
+  {
+    auto j = tbl.GetById (id);
+    j->SetWorker ("courier");
+    j->SetStatus (Job::Status::ACCEPTED);
+  }
+  auto j = tbl.GetById (id);
+  EXPECT_EQ (j->GetWorker (), "courier");
+  EXPECT_EQ (j->GetStatus (), Job::Status::ACCEPTED);
+}
+
+TEST_F (JobsTableTests, QueryForDeadlineIsInclusiveOfNow)
+{
+  /* The sweep takes everything at or before now; a later deadline stays.  */
+  db.SetNextId (101);
+  tbl.CreateNew ("poster", 1, 0, 50).reset ();
+  tbl.CreateNew ("poster", 1, 0, 100).reset ();
+  tbl.CreateNew ("poster", 1, 0, 150).reset ();
+
+  std::vector<Database::IdT> got;
+  auto res = tbl.QueryForDeadline (100);
+  while (res.Step ())
+    got.push_back (tbl.GetFromResult (res)->GetId ());
+  EXPECT_THAT (got, ElementsAre (101, 102));
+}
+
+TEST_F (JobsTableTests, QueryForDeadlineOrdersByDeadlineThenId)
+{
+  /* The sweep order is consensus: earliest deadline first, id breaking
+     ties (which is also the jobs_by_deadline index order, so no sort).  */
+  db.SetNextId (101);
+  tbl.CreateNew ("poster", 1, 0, 100).reset ();
+  tbl.CreateNew ("poster", 1, 0, 50).reset ();
+  tbl.CreateNew ("poster", 1, 0, 50).reset ();
+
+  std::vector<Database::IdT> got;
+  auto res = tbl.QueryForDeadline (100);
+  while (res.Step ())
+    got.push_back (tbl.GetFromResult (res)->GetId ());
+  EXPECT_THAT (got, ElementsAre (102, 103, 101));
+}
+
+TEST_F (JobsTableTests, AdmissionCapCounts)
+{
+  EXPECT_EQ (tbl.CountAll (), 0);
+
+  tbl.CreateNew ("alice", 1, 0, 10).reset ();
+  tbl.CreateNew ("alice", 1, 0, 10).reset ();
+  tbl.CreateNew ("bob", 1, 0, 10).reset ();
+
+  EXPECT_EQ (tbl.CountAll (), 3);
+  EXPECT_EQ (tbl.CountForPoster ("alice"), 2);
+  EXPECT_EQ (tbl.CountForPoster ("bob"), 1);
+  EXPECT_EQ (tbl.CountForPoster ("nobody"), 0);
+}
+
+TEST_F (JobsTableTests, DeleteById)
+{
+  Database::IdT id;
+  {
+    auto j = tbl.CreateNew ("poster", 1, 0, 10);
+    id = j->GetId ();
+  }
+  ASSERT_NE (tbl.GetById (id), nullptr);
+
+  tbl.DeleteById (id);
+  EXPECT_EQ (tbl.GetById (id), nullptr);
+  EXPECT_EQ (tbl.CountAll (), 0);
+}
+
+TEST_F (JobsTableTests, ReservedCoins)
+{
+  /* poster: two posted rewards (2000 + 500); worker: one accepted collateral
+     (8000).  The OPEN job's NULL worker must not be summed.  */
+  tbl.CreateNew ("poster", 2000, 8000, 10).reset ();
+  {
+    auto j = tbl.CreateNew ("poster", 500, 8000, 10);
+    j->SetWorker ("worker");
+    j->SetStatus (Job::Status::ACCEPTED);
+  }
+
+  EXPECT_THAT (tbl.GetReservedCoins (),
+               ElementsAre (Pair ("poster", 2500), Pair ("worker", 8000)));
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/database/params.hpp
+++ b/database/params.hpp
@@ -35,12 +35,11 @@ namespace pxd
  * state: values change only through admin commands in block data and
  * unwind with the normal changesets.
  *
- * No consensus rule reads a parameter yet: this is general infrastructure
- * rather than a feature, so it lands on its own.  Beyond emergency tuning
- * of a limit without a redeploy, it carries soccerverse-style "fork-*"
- * activation flags: a post-launch consensus change can ship dormant behind
- * Get ("fork-x", 0) > 0 and then be enabled chain-wide by one admin
- * command, with no wipe and no coordinated restart.
+ * Currently read by the jobs-board admission caps.  The mechanism also
+ * carries soccerverse-style "fork-*" activation flags: post-launch
+ * consensus changes can ship dormant behind Get ("fork-x", 0) > 0 and be
+ * enabled chain-wide by one admin command, with no wipe or coordinated
+ * restart.
  */
 class ParamsTable
 {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -531,3 +531,56 @@ CREATE TABLE IF NOT EXISTS `parameters` (
 );
 
 -- =============================================================================
+
+-- Jobs board: player-posted, coin-escrowed deals.  Everything the board and
+-- the expiry sweep must filter, sort or sum on is a real column (mirroring the
+-- dex_orders design), so the board query and reserved-balance sums are plain
+-- SQL statements and idle jobs never need to be read or rewritten; the rest of
+-- the deal lives in the `proto` blob.
+CREATE TABLE IF NOT EXISTS `jobs` (
+
+  -- Unique ID of the job (used in assign / accept / cancel moves).
+  `id` INTEGER PRIMARY KEY,
+
+  -- Lifecycle status.  The numeric values match the Job::Status enum in
+  -- jobs.hpp.  Terminal transitions (settlement / cancel / expiry) DELETE
+  -- the row, so the table stays bounded.
+  `status` INTEGER NOT NULL,
+
+  -- The account that posted the job (locks the reward on posting).
+  `poster` TEXT NOT NULL,
+
+  -- The account that accepted the job (locks the collateral on accepting).
+  -- NULL while the job is still OPEN.
+  `worker` TEXT NULL,
+
+  -- The reward, in vCHI.  Stored in a column (not the proto) so the board can
+  -- ORDER BY price and reserved rewards can be summed with a single
+  -- statement.
+  `reward` INTEGER NOT NULL,
+
+  -- The collateral the worker locks on accepting, in vCHI.  Stored in a
+  -- column so reserved collateral can likewise be summed for balance display.
+  `collateral` INTEGER NOT NULL,
+
+  -- Absolute block-consensus timestamp (seconds) at which the job expires.
+  -- Seconds (not block height) so deadlines are immune to cadence changes.
+  `deadline` INTEGER NOT NULL,
+
+  -- The rest of the deal (designated worker, arbiter, terms, confirmations,
+  -- ...) as a serialised JobData proto.
+  `proto` BLOB NOT NULL
+
+);
+
+-- Expiry sweep ("jobs due at or before the current timestamp") and
+-- "expiring soon" ordering for the board.
+CREATE INDEX IF NOT EXISTS `jobs_by_deadline` ON `jobs` (`deadline`);
+
+-- "My posted jobs" + reserved-reward sum for an account.
+CREATE INDEX IF NOT EXISTS `jobs_by_poster` ON `jobs` (`poster`);
+
+-- "My accepted jobs" + reserved-collateral sum for an account.
+CREATE INDEX IF NOT EXISTS `jobs_by_worker` ON `jobs` (`worker`);
+
+-- =============================================================================

--- a/docs/escrow-deals.md
+++ b/docs/escrow-deals.md
@@ -1,0 +1,342 @@
+# The jobs board and the escrow deal
+
+Design notes for the jobs subsystem: a player-driven contracts board on chain,
+carrying one job type — the generic **escrow deal**.
+
+This document describes the code as it stands in this repository.  It is aimed
+at someone reviewing or extending the subsystem, and it concentrates on the
+parts where a mistake would be a consensus bug rather than a gameplay one.
+
+## 1. What it is, and why it is shaped this way
+
+A **job** is an escrowed reward, plus a worker collateral, plus a deadline.  It
+may additionally be exclusive to one designated worker.
+
+The obvious way to build player contracts in a game like this is a catalogue of
+verified types — transport this cargo, escort that vehicle, rent me a slot —
+each with its own consensus rule that watches the world and decides whether the
+term was met.  That approach was built and then abandoned, because most of what
+players actually want to contract about is **not observable to consensus**.  The
+chain can see that a vehicle reached a tile; it cannot see whether the cargo was
+the agreed cargo, whether the escort actually protected anything, or whether a
+service was rendered to the buyer's satisfaction.  Every type that pretends
+otherwise is an approximation, and each approximation is an exploit surface.
+
+So the chain does one thing it *can* do perfectly: **hold value and release it
+according to a rule the parties agreed to in advance**.  A deal escrows the
+poster's reward and the worker's collateral; a completion percentage `p` splits
+both pots; and `p` comes from the parties themselves (both confirming), from an
+arbiter they both consented to, or from a mechanical timeout rule.  The job
+"category" (transport, haul, escort, …) survives only as a cosmetic integer tag
+that consensus never reads.  Consensus adjudicates nothing it cannot see.
+
+## 2. Where the code lives
+
+| File | Responsibility |
+| --- | --- |
+| `database/jobs.{hpp,cpp}` | The board table: rows, queries, the admission counts and the reserved-coin sums. |
+| `database/params.{hpp,cpp}` | Runtime-tunable named parameters (added in the preceding commit). |
+| `src/jobs.{hpp,cpp}` | The whole subsystem above the table: the move-op lifecycle (post / assign / accept / cancel, plus the deal actions), the settlement math, and the superblock expiry sweep. |
+| `proto/jobs.proto` | Everything in a deal that is not a real table column. |
+| `database/schema.sql` | The `jobs` table and its indexes. |
+
+There is no per-type abstraction: the board carries escrow deals and nothing
+else, so the code names the deal directly rather than dispatching to it.
+
+## 3. Data model
+
+The split between columns and proto follows one rule: **anything the board or
+the expiry sweep must filter, sort or sum on is a real column**; everything else
+lives in the serialised `JobData` blob.
+
+`jobs`: `id`, `status`, `poster`, `worker`, `reward`, `collateral`, `deadline`,
+`proto`.
+
+Indexes: `jobs_by_deadline` (the sweep and the "expiring soon" ordering), and
+`jobs_by_poster` / `jobs_by_worker` (the per-account views and the
+reserved-coin sums).
+
+`Job::Status` is `OPEN` or `ACCEPTED`.  There is no settled status: a terminal
+transition pays out and **deletes** the live row, which is what keeps the table
+bounded regardless of how much the board is used.  What became of a settled
+deal is therefore not retained on chain — see §10.
+
+Consensus hygiene note: the state hash covers raw serialised proto bytes, and
+protobuf map ordering is not guaranteed, so no consensus decision iterates a
+proto map.
+
+## 4. Move surface
+
+All job operations arrive under the move key `"j"`, as an array.  Each object is
+one operation, and each is validated to have **exactly** its expected members —
+an unexpected or misspelled key makes the operation malformed and skipped, never
+silently reinterpreted.
+
+```
+{"t":"deal","d":<secs>,"r":<reward>,"co":<collateral>, …}  post
+{"s":<id>,"w":<account>}                                   assign a designated worker
+{"a":<id>}                                                 accept
+{"c":<id>}                                                 cancel (poster, while open)
+{"dl":<id>,"confirm":true}                                 either party marks it done
+{"dl":<id>,"dispute":true}                                 either party contests it
+{"dl":<id>,"rule":<p>}                                     the bound arbiter rules
+```
+
+A post additionally accepts `arbiter`, `fee`, `tag`, `terms`, `dp` (the
+advisory if-destroyed percentage) and `w` (designate a worker at post time).
+The `"t"` value names the operation rather than selecting among kinds: the
+board carries deals only, so anything else is rejected.
+
+`d` is a **duration in seconds**, turned into an absolute consensus timestamp
+deadline, so nothing about the board depends on block cadence.
+
+Jobs are confirmed-only: the pending-move path never dispatches `"j"`.
+
+## 5. Lifecycle
+
+A post escrows the reward and burns a posting fee of
+`max(job_post_fee_min, reward * job_post_fee_bps / 10000)`, so spam costs real
+money at any reward size.  An accept escrows the worker's collateral.
+
+Settlement reaches `p` by one of five routes, recorded in the history row as
+`DealPayload.SettleMode`:
+
+| Mode | When |
+| --- | --- |
+| `BOTH_CONFIRM` | both parties confirmed → `p = 100`, settles immediately |
+| `RULING` | the bound arbiter ruled → the recorded `p` |
+| `SINGLE_CONFIRM` | deadline reached, exactly one confirm, no dispute → `p = 100` |
+| `GHOST_SPLIT` | deadline reached on an unruled dispute → `p = 50`, arbiter fee forfeited |
+| `REFUND` | deadline reached, neither party acted → both stakes returned, untaxed |
+
+`p` is restricted to multiples of ten.  This is a legibility choice, not a
+mathematical one — it keeps rulings human-readable and arguable.
+
+Two identity rules: **`poster == arbiter` is rejected at post**, and
+`worker == arbiter` is rejected at accept (including via assign).  Both close
+the same hole — an "arbiter" ruling on its own deal.
+
+### The refund-both rule is scoped
+
+A wholly untouched deal — neither party confirmed, no dispute — refunds both
+stakes **in full and untaxed**, and the arbiter earns nothing (`fee_paid=false`;
+its fee was never earned, including a pro-bono arbiter whose fee is zero).
+Nobody transacted, so there is nothing to tax, and the burned posting fee plus
+zero reputation accrual already close the capital-recycling loop a settlement
+tax would have been defending against.
+
+Refund-both is deliberately *not* used once someone has acted: it would rob
+whoever already delivered, since the worker's labour is sunk while the poster's
+reward is refundable.  A genuine deliverer protects itself by confirming, which
+routes to `SINGLE_CONFIRM` instead.
+
+### The reaction window
+
+A `confirm` (any deal) or a `dispute` (arbiter-bound only) that executes with
+`deadline - now < W` — strict `<` — and that still leaves a live counter-move
+extends the deadline to `now + W`.  Both-confirm and a ruling settle instantly
+and are never extended.
+
+Each of the three flags (`poster_confirmed`, `worker_confirmed`, `disputed`) is
+set-once, so the extension is one-shot per flag, strictly monotonic — it can
+never shorten a deadline — and bounded at **`2W` past the original deadline**.
+
+`W` is a per-deal snapshot taken at post: `W = min(the clamped runtime
+parameter, the posted duration d)`, with a 30-day ceiling.  `0` disables the
+mechanism.  A governance retune therefore reaches only deals posted after it; an
+in-flight deal keeps the window it was posted with, exactly like the tax and fee
+snapshots.  `ExtendForReactionWindow` in `src/jobs.cpp` is the canonical site.
+
+The purpose is narrow: guarantee that a counterparty gets a real chance to
+answer a last-moment confirm or dispute, rather than losing to a move landing in
+the final block.
+
+## 6. Settlement math
+
+With `R` = reward, `C` = collateral, `t` = tax bps, `f` = arbiter fee bps
+(0 with no arbiter), and `p` the completion percentage:
+
+```
+worker_reward     = R * p / 100                     // reward the worker earned
+returned_C        = C * p / 100                     // collateral the worker keeps
+seized_C          = C - returned_C                  // collateral the poster gets
+poster_transacted = (R - worker_reward) + seized_C
+
+worker_tax = worker_reward * t / 10000;      worker_fee = worker_reward * f / 10000
+poster_tax = poster_transacted * t / 10000;  poster_fee = poster_transacted * f / 10000
+
+treasury = worker_tax + poster_tax        // burned until a faction treasury exists
+arbiter  = worker_fee + poster_fee
+worker   = worker_reward - worker_tax - worker_fee + returned_C
+poster   = (R + C) - worker - arbiter - treasury
+```
+
+Three properties matter, and each is there for a reason:
+
+**Tax and fee fall only on transacted value**, never on the worker's returned
+stake.  Taxing a returned bond would make accepting a deal cost money even when
+nothing happened.
+
+**Each party bears tax and fee on its own transacted share.** This keeps honest
+completion strictly positive for the worker, and it avoids any 128-bit
+intermediate — every multiplication stays inside the coin range.
+
+**The poster's payout is the remainder**, which pins `Σ == R + C` exactly.
+Division dust is burned, never redistributed; redistributing it would make the
+split depend on rounding order.
+
+`ComputeDealSettlement` is a pure function of the row.  `tax_bps`, `fee_bps` and
+the reaction window are all snapshot into the row at post, and post validation
+enforces `tax + fee < 10000` **on the snapshot values** — so no admissible row
+can ever violate the settlement precondition, whatever the parameters are
+retuned to afterwards.  This is also why a min-reward floor raised later cannot
+reject a historical post on replay.
+
+`DealTests.SettlementConservesExhaustive` pins conservation and non-negativity
+over a 1,980-case grid: rewards `{0, 1, 1000, 50000, 1e11}` against collaterals
+`{0, 7, 999, 50000}`, tax `{0, 300, 1000}` × fee `{0, 500, 1000}`, and every `p`
+step.  The grid is chosen for edges rather than volume — zero pots, a pot at the
+absolute coin cap, collateral both far below and above the reward, a
+deliberately awkward `C = 7` for rounding, and the zero and maximum tax/fee
+corners.
+
+## 7. Expiry sweep and bounded work
+
+`ExpireJobs` (called from `PXLogic::UpdateState`) runs **only on superblocks**,
+while moves are processed on every block.  A deadline passing on an ordinary
+block therefore does not settle anything; the job stays on the board until the
+next sweep.  Operations at `deadline <= now` are rejected by `JobIsDue`, so a
+due job belongs to the sweep alone and cannot be resurrected in the
+move-before-sweep window.  `PXLogicTests.JobsExpireOnlyOnSuperblocks` pins this.
+
+Bounding the sweep is done by **admission control at the door** rather than by
+capping the sweep itself: a post past the global or per-poster cap is rejected.
+The reason is that a sweep bound would change settlement semantics for rows
+already on the board — a job could sit unsettled past its deadline through no
+fault of its own — whereas a rejected post never existed.  Setting a cap to `0`
+freezes posting outright without touching anything already listed.
+
+`ValidateJobs`, called from `ValidateStateSlow`, checks the board's invariants.
+
+## 8. Parameters
+
+roconfig holds the defaults; the `parameters` table holds explicit overrides set
+by the `"param"` admin command.  Reads pass their roconfig default as the
+fallback, so removing an override cleanly restores it.
+
+| roconfig field | runtime name | mainnet default |
+| --- | --- | --- |
+| `job_post_fee_min` | — | 1 vCHI, burned |
+| `job_post_fee_bps` | — | 100 (1% of reward) |
+| `max_listing_window` | — | 2592000 (30 days) |
+| `max_live_jobs` | `max-live-jobs` | 10000 |
+| `max_jobs_per_poster` | `max-jobs-per-poster` | 200 |
+| `min_job_reward` | `min-job-reward` | 100 vCHI |
+| `min_deal_reward` | `min-deal-reward` | 1000 vCHI |
+| `deal_max_collateral_bps` | `deal-max-collateral-bps` | 20000 (2× reward) |
+| `deal_max_collateral` | `deal-max-collateral` | the coin cap |
+| `deal_max_fee_bps` | `deal-max-fee-bps` | 1000 (10%) |
+| `deal_tax_bps` | `deal-tax-bps` | 300 (3%), burned |
+| `deal_reaction_window` | `deal-reaction-window` | 86400 (24h) |
+
+Collateral is bounded both relative to the reward and by an absolute ceiling, so
+a poster cannot lure a worker into an unbounded stake.
+
+`getjobsparams` reports every one of these as the **post-clamp effective value**
+consensus would use right now, reusing the same clamping helper, so the reported
+figure equals the enforced figure by construction.
+
+## 9. Reputation counters
+
+`proto/account.proto` carries seven counters: `deals_completed`,
+`deals_value_completed`, `deals_posted_completed`, `deals_posted_value`,
+`deals_disputed`, `arbiter_rulings` and `arbiter_value_ruled`.
+
+**No consensus rule reads any of them back.** They exist so clients can show a
+vetting signal, and they are stored in consensus state only because they must be
+identical on every node that displays them.
+
+They are raw tallies, not trust scores, and the honest limits are worth stating
+plainly:
+
+- A ring of sock puppets can wash-trade its own deals and pay only the burn
+  (tax plus posting fee, about 4% of face value at the current defaults) for the
+  record it manufactures.  The **value** counters are what make that cost
+  proportional, so any consumer must weight by value and never read a bare count
+  as an endorsement.
+- `arbiter_value_ruled` is a **weaker** anti-Sybil anchor than the reward-based
+  counters, because collateral returned at a high `p` bears no tax and so rides
+  in for free — roughly 1.3% of the credited figure versus about 4%.  The two
+  must not be compared as if they were the same currency.
+- `deals_disputed` is bumped for **both** parties, since which side was at fault
+  is exactly what consensus cannot know.  A hostile counterparty can inflate
+  someone else's count by entering a deal and disputing it.  Read it relative to
+  the completion counts, never as fault.
+- `completed` means "settled with the worker earning something" — any
+  tax-bearing settlement with `p > 0` — **not** "delivered in full".
+
+Arbiter **ghosting** is deliberately *not* counted.  A post binds an arbiter
+unilaterally, with no consent step, so a permanent per-account mark would be
+inflictable on a non-consenting third party for the price of one throwaway deal.
+Nothing is lost: the settled history row carries `arbiter`, `settle_mode`
+(`GHOST_SPLIT`), `fee_paid` and `dispute_time` — `dispute_time` exists precisely
+so a later reputation layer can attribute a ghost, where it stays scoped,
+decayable and rebuttable instead of branded into consensus state.
+
+The increments are unchecked at their declared widths.  Wrapping a `uint32`
+count takes 2³² settlements, each burning a posting fee; wrapping a `uint64`
+value counter takes ~1.8e8 maximum-value deals, each escrowing that value.  Both
+are economically unreachable, and a wrap would be deterministic across nodes
+anyway.  Saturating arithmetic was rejected as consensus-visible code for an
+unreachable boundary.
+
+## 10. Settled deals are not retained (deferred to archival)
+
+A terminal transition deletes the row.  Nothing on chain then records that the
+deal existed, how it settled, or who settled it — the board shows only what is
+live.
+
+An earlier revision of this change carried a `job_history` table: a snapshot
+row written immediately before the live row was deleted, with a deterministic
+retention prune to keep it bounded, served by a paged RPC.  It was removed
+because settled-record retention is a general problem that deserves one general
+mechanism, not a bespoke table per feature.  When that archival mechanism
+lands, a settled deal should carry:
+
+| Field | Meaning |
+| --- | --- |
+| `outcome` | completed / failed / cancelled / void |
+| `settled_height` | the **real chain height** of the settling block, not the superblock counter — settlements happen on ordinary blocks too |
+| `settled_time` | the settling block's consensus timestamp |
+| `settled_p` | the effective completion percentage paid out; absent on a refund, where nothing transacted |
+| `settle_mode` | `BOTH_CONFIRM` / `RULING` / `SINGLE_CONFIRM` / `GHOST_SPLIT` / `REFUND` |
+| `fee_paid` | whether the agreed fee *schedule* was honoured — true on a both-confirm or a ruling (including a pro-bono arbiter, where honouring it moves zero coins), false only where the fee was forfeited |
+
+plus a snapshot of the row's own columns and proto.  `settled_p` matters
+because without it a `p=10` and a `p=90` ruling leave indistinguishable
+records; `settle_mode` matters because it is what separates an arbiter that
+ruled from one that ghosted.
+
+What is **not** lost meanwhile: the aggregate record in §9 lives in
+`account.proto` and is bumped at settlement, so per-account reputation survives
+the row's deletion.  Only the per-deal itemisation is deferred.
+
+## 11. RPCs
+
+- `getjobs()` — the live board, ordered by id.  Unpaged, like `getbuildings`
+  and `gettradehistory`: the board is bounded by the admission caps (§7), not
+  by a response limit.
+- `getjobsparams()` — the effective parameter values (see §8).
+
+## 12. Deliberately out of scope
+
+- A trustless on-chain "if destroyed" fire.  The poster may pre-set an advisory
+  percentage that the arbiter reads and applies; automating it would
+  re-introduce the entity-linkage kill hook this design removes.
+- Charset and NFC filtering of the free-text `terms`.  Clients **must** sanitise
+  control and bidi-override characters when rendering, since the arbiter reads
+  that text to rule.
+- Routing the protocol tax to a faction treasury.  It is burned until one
+  exists.
+- Any consensus consumption of the reputation counters (§9).
+- Retention of settled deals (§10), pending a general archival mechanism.

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -33,6 +33,10 @@ REGTESTS = \
   getserviceinfo.py \
   getversion.py \
   godmode.py \
+  jobs_caps.py \
+  jobs_deals.py \
+  jobs_reorg.py \
+  jobs_rpc.py \
   loot.py \
   mining.py \
   modifiedregions.py \

--- a/gametest/jobs_caps.py
+++ b/gametest/jobs_caps.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020-2021  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Integration test for the jobs-board admission caps and their runtime tuning
+through the "param" admin command: a cap enforced at its exact boundary, a
+raise taking effect from the next block, the 0-value posting freeze, a
+null-value removal resetting to the roconfig default, and the minimum-reward
+floors at their real defaults.  (The per-dimension boundary matrix is
+unit-tested; this proves the same wiring end-to-end through real admin
+commands and moves.)
+"""
+
+from pxtest import PXTest
+
+
+class JobsCapsTest (PXTest):
+
+  def postDeal (self, expectCount, reward=1000):
+    """Posts one deal and asserts the resulting number of live jobs (the
+    post is silently rejected at the cap)."""
+    self.sendMove ("poster", {"j": [{
+      "t": "deal", "d": 86400, "r": reward, "co": 0, "terms": "x",
+    }]})
+    self.generate (1)
+    self.assertEqual (len (self.getJobs ()), expectCount)
+
+  def run (self):
+    self.mainLogger.info ("Setting up accounts...")
+    self.initAccount ("poster", "r")
+    self.generate (1)
+    self.giftCoins ({"poster": 100000})
+
+    self.mainLogger.info ("Capping jobs per poster at 2...")
+    self.adminCommand ({"param": [
+      {"n": "max-jobs-per-poster", "v": 2},
+    ]})
+    self.generate (1)
+
+    self.postDeal (1)
+    self.postDeal (2)
+    # At the cap: the third post is rejected...
+    self.postDeal (2)
+
+    self.mainLogger.info ("Raising the cap admits the next post...")
+    self.adminCommand ({"param": [
+      {"n": "max-jobs-per-poster", "v": 3},
+    ]})
+    self.generate (1)
+    self.postDeal (3)
+
+    self.mainLogger.info ("A 0 cap freezes posting entirely...")
+    self.adminCommand ({"param": [{"n": "max-live-jobs", "v": 0}]})
+    self.generate (1)
+    self.postDeal (3)
+
+    self.mainLogger.info ("Removing the overrides resets to the defaults...")
+    self.adminCommand ({"param": [
+      {"n": "max-live-jobs", "v": None},
+      {"n": "max-jobs-per-poster", "v": None},
+    ]})
+    self.generate (1)
+    self.postDeal (4)
+
+    self.mainLogger.info ("Minimum-reward floors at their defaults...")
+    # No floor overrides exist in this suite: 999 is under the default deal
+    # floor (1000) and must reject; 1000 admits.
+    self.postDeal (4, reward=999)
+    self.postDeal (5)
+
+    self.mainLogger.info ("Raising the generic floor gates even that...")
+    self.adminCommand ({"param": [{"n": "min-job-reward", "v": 2000}]})
+    self.generate (1)
+    self.postDeal (5)
+
+    self.mainLogger.info ("Jobs caps test succeeded.")
+
+
+if __name__ == "__main__":
+  JobsCapsTest ().main ()

--- a/gametest/jobs_deals.py
+++ b/gametest/jobs_deals.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020-2021  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Integration test for the generic escrow-deal job type (Job::Type::DEAL).
+Exercises the full real move path -- post -> accept -> confirm / dispute /
+rule and the end-date expiry sweep -- through moveprocessor "j" dispatch,
+block processing, the getjobs board render and
+the coin/reserve effects.  The settlement arithmetic itself is pinned
+exhaustively by the C++ DealTests; this proves the on-chain path, the paged
+reads, the reputation surfacing (dealstats) and the superblock expiry hook.
+
+Deals are faction-agnostic (no audience, no linked entity), so the poster,
+worker and arbiter are deliberately three DIFFERENT factions here -- a
+property no other job type has and one the real chain must honour.
+"""
+
+from pxtest import PXTest
+
+
+class JobsDealsTest (PXTest):
+
+  def dealStats (self, name):
+    return self.getAccounts ()[name].data["dealstats"]
+
+  def arbiterStats (self, name):
+    return self.getAccounts ()[name].data["arbiterstats"]
+
+  def postFee (self, reward):
+    """Mirrors PostOperation::Fee (jobs.cpp): the burned posting fee."""
+    p = self.roConfig ().params
+    return max (p.job_post_fee_min, reward * p.job_post_fee_bps // 10000)
+
+  def postDeal (self, poster="poster", reward=5000, collateral=5000,
+                arbiter="arbiter", fee=1000, tag=1, terms="haul it"):
+    """Posts one deal and returns its id (mirrors the DealTests helper:
+    reward 5000, collateral 5000, arbiter fee 10%)."""
+    post = {"t": "deal", "d": 86400, "r": reward, "co": collateral,
+            "tag": tag, "terms": terms}
+    if arbiter:
+      post["arbiter"] = arbiter
+      post["fee"] = fee
+    self.sendMove (poster, {"j": [post]})
+    self.generate (1)
+    return self.newestJob ()["id"]
+
+  def expire (self, deadline):
+    """Advances mock time past the deal deadline and mines the superblock
+    that runs the expiry sweep (the sweep only fires on a superblock; the big
+    time jump makes this block one)."""
+    self.env.setMockTime (deadline + 1)
+    self.generate (1, superblocks=False)
+
+  def run (self):
+    self.mainLogger.info ("Setting up three cross-faction accounts...")
+    # Poster, worker and arbiter each a different faction: deals carry no
+    # audience gate, so this must work end-to-end.
+    self.initAccount ("poster", "r")
+    self.initAccount ("worker", "g")
+    self.initAccount ("arbiter", "b")
+    self.generate (1)
+    self.giftCoins ({"poster": 1000000, "worker": 1000000, "arbiter": 1000000})
+
+    self.testHappyPathBothConfirm ()
+    self.testDisputeArbiterRules ()
+    self.testPosterArbiterRejectedAndAtomicConfirm ()
+    self.testTimeoutGhostSplits ()
+    self.testTimeoutSingleConfirm ()
+    self.testTimeoutNeitherRefunds ()
+    self.testNoArbiterDispute ()
+    self.testCancelBeforeAccept ()
+    self.testRejectsUnknownOp ()
+    self.testReactionWindowExtension ()
+    self.testNoArbiterDisputeDoesNotExtend ()
+
+    self.mainLogger.info ("Escrow-deal integration test succeeded.")
+
+  def testHappyPathBothConfirm (self):
+    self.mainLogger.info ("Posting a deal and settling it by mutual confirm...")
+    pBefore = self.available ("poster")
+    wBefore = self.available ("worker")
+    aBefore = self.available ("arbiter")
+    statBefore = self.dealStats ("worker")
+    pStatBefore = self.dealStats ("poster")
+    aStatBefore = self.arbiterStats ("arbiter")
+
+    jobId = self.postDeal ()
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    # The board renders every posted term of the deal.
+    self.assertEqual (job["state"], "open")
+    self.assertEqual (job["poster"], "poster")
+    self.assertEqual (job["reward"], 5000)
+    self.assertEqual (job["arbiter"], "arbiter")
+    self.assertEqual (job["fee"], 1000)          # bps, snapshot at post
+    self.assertEqual (job["tax"], 300)           # bps, snapshot at post
+    self.assertEqual (job["tag"], 1)
+    self.assertEqual (job["terms"], "haul it")
+    self.assertEqual (job["posterConfirmed"], False)
+    self.assertEqual (job["workerConfirmed"], False)
+    self.assertEqual (job["disputed"], False)
+    # Reward escrowed + posting fee burned; collateral is the worker's, not yet in.
+    fee = self.postFee (5000)
+    self.assertEqual (self.available ("poster"), pBefore - 5000 - fee)
+    self.assertEqual (self.reserved ("poster"), 5000)
+
+    self.mainLogger.info ("A different-faction worker accepts...")
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["state"], "accepted")
+    self.assertEqual (job["worker"], "worker")
+    self.assertEqual (self.available ("worker"), wBefore - 5000)
+    self.assertEqual (self.reserved ("worker"), 5000)
+
+    self.mainLogger.info ("One confirm leaves it open; the second settles it...")
+    self.sendMove ("poster", {"j": [{"dl": jobId, "confirm": True}]})
+    self.generate (1)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["posterConfirmed"], True)
+    self.assertEqual (job["workerConfirmed"], False)
+
+    self.sendMove ("worker", {"j": [{"dl": jobId, "confirm": True}]})
+    self.generate (1)
+    assert self.jobGone (jobId)
+    # p=100: worker <- 5000 - 150(tax) - 500(fee) + 5000(collateral) = 9350;
+    # arbiter <- 500; treasury 150 burned; poster reclaims nothing.
+    self.assertEqual (self.available ("worker"), wBefore - 5000 + 9350)
+    self.assertEqual (self.reserved ("worker"), 0)
+    self.assertEqual (self.available ("arbiter"), aBefore + 500)
+    self.assertEqual (self.available ("poster"), pBefore - 5000 - fee)
+    self.assertEqual (self.reserved ("poster"), 0)
+    # The worker's reputation counter bumps by the earned reward (5000).
+    stat = self.dealStats ("worker")
+    self.assertEqual (stat["completed"], statBefore["completed"] + 1)
+    self.assertEqual (stat["value"], statBefore["value"] + 5000)
+    # The poster's mirror of the same settlement, through the same JSON. A clean
+    # deal troubles nobody: no dispute on either side, no arbiter record.
+    pStat = self.dealStats ("poster")
+    self.assertEqual (pStat["posted"], pStatBefore["posted"] + 1)
+    self.assertEqual (pStat["postedvalue"], pStatBefore["postedvalue"] + 5000)
+    self.assertEqual (pStat["disputed"], pStatBefore["disputed"])
+    self.assertEqual (stat["disputed"], statBefore["disputed"])
+    self.assertEqual (self.arbiterStats ("arbiter"), aStatBefore)
+
+  def testDisputeArbiterRules (self):
+    self.mainLogger.info ("Dispute resolved by the arbiter's %-dial...")
+    wBefore = self.available ("worker")
+    aBefore = self.available ("arbiter")
+    statBefore = self.dealStats ("worker")
+    pStatBefore = self.dealStats ("poster")
+    aStatBefore = self.arbiterStats ("arbiter")
+
+    jobId = self.postDeal ()
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+
+    # H1 probe: a confirmation waives only the confirmer's OWN dispute right.
+    # The worker confirms, so its own later dispute is rejected (disputed stays
+    # false), but the counterparty (poster) may still dispute a shoddy job.
+    self.sendMove ("worker", {"j": [{"dl": jobId, "confirm": True}]})
+    self.generate (1)
+    self.sendMove ("worker", {"j": [{"dl": jobId, "dispute": True}]})
+    self.generate (1)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["workerConfirmed"], True)
+    self.assertEqual (job["disputed"], False)
+
+    self.sendMove ("poster", {"j": [{"dl": jobId, "dispute": True}]})
+    self.generate (1)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["disputed"], True)
+
+    # Only the bound arbiter may rule, and only in {0,10,..,100}.
+    self.sendMove ("arbiter", {"j": [{"dl": jobId, "rule": 30}]})
+    self.generate (1)
+    assert self.jobGone (jobId)
+    # p=30: worker 2805, arbiter 850, treasury 255, poster 6090.
+    self.assertEqual (self.available ("worker"), wBefore - 5000 + 2805)
+    self.assertEqual (self.available ("arbiter"), aBefore + 850)
+    stat = self.dealStats ("worker")
+    self.assertEqual (stat["completed"], statBefore["completed"] + 1)
+    self.assertEqual (stat["value"], statBefore["value"] + 1500)
+    # Both parties carry the dispute; the arbiter carries the ruling it
+    # delivered; the poster's payout mirror scales with p exactly like the
+    # worker's (5000 * 30/100).
+    pStat = self.dealStats ("poster")
+    self.assertEqual (pStat["posted"], pStatBefore["posted"] + 1)
+    self.assertEqual (pStat["postedvalue"], pStatBefore["postedvalue"] + 1500)
+    self.assertEqual (pStat["disputed"], pStatBefore["disputed"] + 1)
+    self.assertEqual (stat["disputed"], statBefore["disputed"] + 1)
+    # The arbiter's value counter takes the whole pot it directed (5000 reward
+    # + 5000 collateral), not the worker's share -- a low ruling decided just as
+    # much money as a high one.
+    aStat = self.arbiterStats ("arbiter")
+    self.assertEqual (aStat["rulings"], aStatBefore["rulings"] + 1)
+    self.assertEqual (aStat["valueruled"], aStatBefore["valueruled"] + 10000)
+
+  def testPosterArbiterRejectedAndAtomicConfirm (self):
+    self.mainLogger.info ("Poster == arbiter is rejected; an atomic confirm"
+                          " bars the same party's dispute...")
+    # §1: a poster-as-arbiter deal is an armed trap under the reaction window
+    # (late dispute -> rule p=0 seizure), banned at the post door.
+    before = self.getJobs ()
+    self.sendMove ("poster", {"j": [{
+      "t": "deal", "d": 86400, "r": 5000, "co": 5000,
+      "arbiter": "poster", "fee": 1000, "terms": "trap"}]})
+    self.generate (1)
+    self.assertEqual (self.getJobs (), before)   # nothing admitted
+
+    # The atomic-array H1 pin survives on a normal (third-party arbiter) deal:
+    # in ONE j array the worker's confirm lands and bars its own later dispute
+    # (the move processor validates each op against the evolving state), so the
+    # deal stays accepted, confirmed and NOT disputed.
+    jobId = self.postDeal ()
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+    self.sendMove ("worker", {"j": [{"dl": jobId, "confirm": True},
+                                    {"dl": jobId, "dispute": True}]})
+    self.generate (1)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["state"], "accepted")
+    self.assertEqual (job["workerConfirmed"], True)
+    self.assertEqual (job["disputed"], False)
+    # Clean up so the board is empty for later reasoning.
+    self.sendMove ("poster", {"j": [{"dl": jobId, "confirm": True}]})
+    self.generate (1)
+    assert self.jobGone (jobId)
+
+  def testTimeoutGhostSplits (self):
+    self.mainLogger.info ("A ghosted arbiter falls back to the 50/50 sweep...")
+    wBefore = self.available ("worker")
+    aBefore = self.available ("arbiter")
+    aStatBefore = self.arbiterStats ("arbiter")
+
+    jobId = self.postDeal ()
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+    self.sendMove ("worker", {"j": [{"dl": jobId, "dispute": True}]})
+    self.generate (1)
+    deadline = next (j for j in self.getJobs () if j["id"] == jobId)["deadline"]
+
+    self.expire (deadline)
+    assert self.jobGone (jobId)
+    # p=50 with the fee FORFEITED (the arbiter ghosted the dispute it was
+    # hired to rule): worker 2500 - 75(tax) + 2500(collateral) = 4925 and
+    # the arbiter gets nothing -- ruling always pays better than ghosting.
+    self.assertEqual (self.available ("worker"), wBefore - 5000 + 4925)
+    self.assertEqual (self.available ("arbiter"), aBefore)
+    # A ghost leaves NO mark on the arbiter's account record, by design: the
+    # poster binds an arbiter without its consent, so a permanent counter here
+    # would be inflictable on a bystander.  Consensus punishes the ghost by
+    # forfeiting the fee (asserted above), and nothing else.  No "ghosted" key
+    # exists in arbiterstats at all.
+    aStat = self.arbiterStats ("arbiter")
+    self.assertEqual (aStat, aStatBefore)
+    assert "ghosted" not in aStat, aStat
+
+  def testTimeoutSingleConfirm (self):
+    self.mainLogger.info ("One unopposed confirm settles in full at timeout...")
+    wBefore = self.available ("worker")
+    aBefore = self.available ("arbiter")
+
+    jobId = self.postDeal ()
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+    self.sendMove ("worker", {"j": [{"dl": jobId, "confirm": True}]})
+    self.generate (1)
+    deadline = next (j for j in self.getJobs () if j["id"] == jobId)["deadline"]
+
+    self.expire (deadline)
+    assert self.jobGone (jobId)
+    # one confirm, no dispute => p=100, same as a mutual confirm.
+    self.assertEqual (self.available ("worker"), wBefore - 5000 + 9350)
+    self.assertEqual (self.available ("arbiter"), aBefore + 500)
+
+  def testTimeoutNeitherRefunds (self):
+    self.mainLogger.info ("No one acts: the sweep refunds both stakes...")
+    pBefore = self.available ("poster")
+    wBefore = self.available ("worker")
+    aBefore = self.available ("arbiter")
+
+    fee = self.postFee (5000)
+    jobId = self.postDeal ()
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+    deadline = next (j for j in self.getJobs () if j["id"] == jobId)["deadline"]
+
+    self.expire (deadline)
+    assert self.jobGone (jobId)
+    # Reward back to poster (less the sunk posting fee), collateral back to
+    # worker, arbiter untouched, nothing burned beyond the fee.
+    self.assertEqual (self.available ("poster"), pBefore - fee)
+    self.assertEqual (self.reserved ("poster"), 0)
+    self.assertEqual (self.available ("worker"), wBefore)
+    self.assertEqual (self.reserved ("worker"), 0)
+    self.assertEqual (self.available ("arbiter"), aBefore)
+
+  def testNoArbiterDispute (self):
+    self.mainLogger.info ("A no-arbiter dispute forces the free 50/50 sweep...")
+    pBefore = self.available ("poster")
+    wBefore = self.available ("worker")
+    fee = self.postFee (5000)
+    aStatBefore = self.arbiterStats ("arbiter")
+
+    # A genuinely no-arbiter deal: the post omits arbiter and fee entirely, so
+    # no ruling can ever settle a dispute here.
+    jobId = self.postDeal (arbiter=None)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    assert "arbiter" not in job
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+
+    # The worker confirms; the still-unconfirmed poster keeps its dispute right
+    # (design §6.2) and disputes.  With no arbiter that dispute is unrulable, so
+    # the sweep settles the approved free terminal p=50 ghost split -- NOT the
+    # p=100 single-confirm the worker's confirm alone would have earned.
+    self.sendMove ("worker", {"j": [{"dl": jobId, "confirm": True}]})
+    self.generate (1)
+    self.sendMove ("poster", {"j": [{"dl": jobId, "dispute": True}]})
+    self.generate (1)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["workerConfirmed"], True)
+    self.assertEqual (job["disputed"], True)
+    deadline = job["deadline"]
+
+    self.expire (deadline)
+    assert self.jobGone (jobId)
+    # p=50, no fee: worker 2500 - 75(tax) + 2500(collateral) = 4925; the poster
+    # reclaims the remaining 4850; treasury 225 burned; no arbiter is paid.
+    self.assertEqual (self.available ("worker"), wBefore - 5000 + 4925)
+    self.assertEqual (self.reserved ("worker"), 0)
+    self.assertEqual (self.available ("poster"), pBefore - 5000 - fee + 4850)
+    self.assertEqual (self.reserved ("poster"), 0)
+    # ghost-split is ALSO the no-arbiter fallback, so no arbiter record may move
+    # here: "arbiter" is a bystander to this deal and must stay untouched.
+    self.assertEqual (self.arbiterStats ("arbiter"), aStatBefore)
+
+  def testCancelBeforeAccept (self):
+    self.mainLogger.info ("An open deal cancels and refunds the reward...")
+    pBefore = self.available ("poster")
+    fee = self.postFee (5000)
+    jobId = self.postDeal ()
+    self.assertEqual (self.reserved ("poster"), 5000)
+
+    self.sendMove ("poster", {"j": [{"c": jobId}]})
+    self.generate (1)
+    assert self.jobGone (jobId)
+    self.assertEqual (self.available ("poster"), pBefore - fee)
+    self.assertEqual (self.reserved ("poster"), 0)
+
+  def testRejectsUnknownOp (self):
+    self.mainLogger.info ("An unknown job op does not touch an accepted deal...")
+    jobId = self.postDeal ()
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+    # A deal settles only via confirm/dispute/rule; the removed delivery-style
+    # fulfil op is not in the grammar at all, so the move is inert.
+    self.sendMove ("worker", {"j": [{"f": jobId}]})
+    self.generate (1)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["state"], "accepted")
+    # Clean up so the board is empty for any later reasoning.
+    self.sendMove ("poster", {"j": [{"dl": jobId, "confirm": True}]})
+    self.sendMove ("worker", {"j": [{"dl": jobId, "confirm": True}]})
+    self.generate (1)
+    assert self.jobGone (jobId)
+
+  def confirmAt (self, name, jobId, when, op):
+    """Sends one deal op at an exact block time (a single non-superblock)."""
+    self.env.setMockTime (when)
+    self.sendMove (name, {"j": [{"dl": jobId, **op}]})
+    self.generate (1, superblocks=False)
+
+  def testReactionWindowExtension (self):
+    self.mainLogger.info ("A late confirm extends the deadline; the counterparty"
+                          " and arbiter keep their window (regtest W = 30)...")
+    wBefore = self.available ("worker")
+    aBefore = self.available ("arbiter")
+    jobId = self.postDeal (terms="window")
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    d0 = job["deadline"]
+    self.assertEqual (job["reactionwindow"], 30)   # min(30, d) snapshot at post
+
+    # Worker confirms 10s before the deadline: it lands inside W and pushes the
+    # deadline to confirm_ts + 30.
+    self.confirmAt ("worker", jobId, d0 - 10, {"confirm": True})
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["deadline"], d0 - 10 + 30)
+
+    # The still-unconfirmed poster disputes inside the extension: arbiter-bound,
+    # so it extends again and stamps dispute_time.
+    self.confirmAt ("poster", jobId, d0 + 15, {"dispute": True})
+    job = next (j for j in self.getJobs () if j["id"] == jobId)
+    self.assertEqual (job["disputed"], True)
+    self.assertEqual (job["disputetime"], d0 + 15)
+    self.assertEqual (job["deadline"], d0 + 15 + 30)
+
+    # The arbiter rules inside that window -- NOT denied (the v1.1 flip).
+    self.confirmAt ("arbiter", jobId, d0 + 40, {"rule": 50})
+    assert self.jobGone (jobId)
+    # p=50: worker 4675, arbiter 750.
+    self.assertEqual (self.available ("worker"), wBefore - 5000 + 4675)
+    self.assertEqual (self.available ("arbiter"), aBefore + 750)
+
+  def testNoArbiterDisputeDoesNotExtend (self):
+    self.mainLogger.info ("A no-arbiter dispute near the deadline does NOT"
+                          " extend (its only successor is the 50/50 sweep)...")
+    jobId = self.postDeal (arbiter=None, terms="noext")
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+    d0 = next (j for j in self.getJobs () if j["id"] == jobId)["deadline"]
+    self.confirmAt ("worker", jobId, d0 - 5, {"dispute": True})
+    self.assertEqual (
+        next (j for j in self.getJobs () if j["id"] == jobId)["deadline"], d0)
+    self.expire (d0)
+    assert self.jobGone (jobId)
+
+
+if __name__ == "__main__":
+  JobsDealsTest ().main ()

--- a/gametest/jobs_reorg.py
+++ b/gametest/jobs_reorg.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020-2021  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Reorg / undo coverage for the jobs subsystem.  Every consensus state surface
+the feature adds -- job rows with their escrowed balances and the
+runtime-parameters table -- must unwind bit-identically when the blocks
+touching it are detached, and the restored state must be fully live for an
+alternative history.  The per-mechanic behaviour itself is
+covered by the other jobs gametests; this pins the changeset (undo) machinery
+they all rely on.
+"""
+
+from pxtest import PXTest
+
+
+class JobsReorgTest (PXTest):
+
+  def run (self):
+    self.mainLogger.info ("Setting up accounts and an accepted deal...")
+    self.initAccount ("poster", "r")
+    self.initAccount ("worker", "g")
+    self.initAccount ("arbiter", "b")
+    self.generate (1)
+    self.giftCoins ({"poster": 100000, "worker": 100000, "arbiter": 100000})
+
+    # An accepted deal (both stakes escrowed) is the base state shared by
+    # both histories.
+    self.sendMove ("poster", {"j": [{
+      "t": "deal", "d": 86400, "r": 5000, "co": 5000,
+      "arbiter": "arbiter", "fee": 1000, "terms": "reorg me",
+    }]})
+    self.generate (1)
+    jobId = self.newestJob ()["id"]
+    self.sendMove ("worker", {"j": [{"a": jobId}]})
+    self.generate (1)
+
+    snapshot = self.env.snapshot ()
+    preState = self.getGameState ()
+
+    self.mainLogger.info ("Settling the deal and retuning a parameter...")
+    # The branch that will be detached: an admin retune (parameters table)
+    # plus a dispute and ruling (job deletion, settlement balance moves and
+    # the worker's dealstats bump).
+    self.adminCommand ({"param": [{"n": "min-deal-reward", "v": 20000}]})
+    self.sendMove ("poster", {"j": [{"dl": jobId, "dispute": True}]})
+    self.generate (1)
+    self.sendMove ("arbiter", {"j": [{"dl": jobId, "rule": 30}]})
+    self.generate (1)
+    assert self.jobGone (jobId)
+    # The retuned floor rejects a small deal on this branch.
+    self.sendMove ("poster", {"j": [{
+      "t": "deal", "d": 86400, "r": 5000, "co": 0, "terms": "small"}]})
+    self.generate (1)
+    self.assertEqual (self.getJobs (), [])
+
+    self.mainLogger.info ("Detaching the settlement blocks...")
+    snapshot.restore ()
+    # The undo restored every jobs surface: the live row is back with its
+    # escrows, all balances and dealstats match bit-exactly, and the parameter
+    # override is gone.
+    self.expectGameState (preState)
+
+    self.mainLogger.info ("Replaying an alternative history...")
+    # The parameter override was undone with its block: the small deal is
+    # admissible again under the roconfig default floor.
+    self.sendMove ("poster", {"j": [{
+      "t": "deal", "d": 86400, "r": 5000, "co": 0, "terms": "small"}]})
+    self.generate (1)
+    assert not self.jobGone (self.newestJob ()["id"])
+
+    # And the restored deal is fully live: an IDENTICAL dispute + ruling
+    # re-settles it, paying exactly what the detached branch paid.
+    wBefore = self.available ("worker")
+    self.sendMove ("poster", {"j": [{"dl": jobId, "dispute": True}]})
+    self.generate (1)
+    self.sendMove ("arbiter", {"j": [{"dl": jobId, "rule": 30}]})
+    self.generate (1)
+    assert self.jobGone (jobId)
+    # p=30: worker <- 1500 - 45(tax) - 150(fee) + 1500(collateral) = 2805.
+    self.assertEqual (self.available ("worker"), wBefore + 2805)
+
+    self.testExtensionReorg ()
+
+    self.mainLogger.info ("Jobs reorg test succeeded.")
+
+  def testExtensionReorg (self):
+    self.mainLogger.info ("A deadline extension unwinds and redoes bit-exactly...")
+    # A fresh accepted deal; a late confirm inside the reaction window moves the
+    # deadline column (consensus state), which must reorg like any other.
+    self.sendMove ("poster", {"j": [{
+      "t": "deal", "d": 600, "r": 5000, "co": 5000,
+      "arbiter": "arbiter", "fee": 1000, "terms": "extend me"}]})
+    self.generate (1)
+    extId = self.newestJob ()["id"]
+    self.sendMove ("worker", {"j": [{"a": extId}]})
+    self.generate (1)
+    d0 = next (j for j in self.getJobs () if j["id"] == extId)["deadline"]
+
+    snapshot = self.env.snapshot ()
+    preState = self.getGameState ()
+
+    # The branch to detach: a confirm 10s before the deadline extends it to
+    # confirm_ts + 30 (regtest W).
+    self.env.setMockTime (d0 - 10)
+    self.sendMove ("worker", {"j": [{"dl": extId, "confirm": True}]})
+    self.generate (1, superblocks=False)
+    extended = next (j for j in self.getJobs () if j["id"] == extId)["deadline"]
+    self.assertEqual (extended, d0 - 10 + 30)
+
+    self.mainLogger.info ("Detaching the extension block...")
+    snapshot.restore ()
+    self.expectGameState (preState)   # deadline back to d0, confirm gone
+
+    # Redo the identical confirm: the extended deadline rebuilds bit-for-bit.
+    self.env.setMockTime (d0 - 10)
+    self.sendMove ("worker", {"j": [{"dl": extId, "confirm": True}]})
+    self.generate (1, superblocks=False)
+    self.assertEqual (
+        next (j for j in self.getJobs () if j["id"] == extId)["deadline"],
+        extended)
+
+
+if __name__ == "__main__":
+  JobsReorgTest ().main ()

--- a/gametest/jobs_rpc.py
+++ b/gametest/jobs_rpc.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+#   GSP for the Taurion blockchain game
+#   Copyright (C) 2020-2021  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+RPC-level test for the jobs read surface, over a real JSON-RPC connection
+through the generated stub: the whole-board getjobs method, and getjobsparams
+projecting the POST-CLAMP effective runtime params that consensus itself uses.
+"""
+
+from pxtest import PXTest
+
+
+class JobsRpcTest (PXTest):
+
+  def run (self):
+    self.mainLogger.info ("Setting up an account and a small board...")
+    self.initAccount ("poster", "r")
+    self.generate (1)
+    self.lowerRewardFloors ("min-job-reward", "min-deal-reward")
+    self.giftCoins ({"poster": 1000000})
+
+    n = 7
+    self.sendMove ("poster", {"j": [{
+      "t": "deal", "d": 86400, "r": 1000, "co": 0, "terms": "x",
+    }] * n})
+    self.generate (1)
+
+    self.mainLogger.info ("getjobs returns the whole board, ordered by id...")
+    allJobs = self.getRpc ("getjobs")
+    self.assertEqual (len (allJobs), n)
+    ids = [j["id"] for j in allJobs]
+    self.assertEqual (ids, sorted (ids))
+
+    # A settled job leaves the board outright (the row is deleted).
+    self.sendMove ("poster", {"j": [{"c": ids[0]}]})
+    self.generate (1)
+    self.assertEqual ([j["id"] for j in self.getRpc ("getjobs")], ids[1:])
+
+    self.mainLogger.info ("getjobsparams projects post-clamp values...")
+    base = self.getRpc ("getjobsparams")
+    self.assertEqual (base["max-live-jobs"], 10000)
+    self.assertEqual (base["max-jobs-per-poster"], 200)
+    self.assertEqual (base["deal-tax-bps"], 300)
+    self.assertEqual (base["deal-reaction-window"], 30)
+
+    # Over-ceiling caps saturate, a negative window floors to 0 (a freeze),
+    # and the self-bounding economics params -- bounded by the settlement math
+    # at the post door, not by a ceiling -- pass through unclamped.
+    self.adminCommand ({"param": [
+      {"n": "max-live-jobs", "v": 10**9},
+      {"n": "max-jobs-per-poster", "v": 10**9},
+      {"n": "deal-reaction-window", "v": -1},
+      {"n": "deal-tax-bps", "v": 750},
+    ]})
+    self.generate (1)
+    capped = self.getRpc ("getjobsparams")
+    self.assertEqual (capped["max-live-jobs"], 100000)
+    self.assertEqual (capped["max-jobs-per-poster"], 2000)
+    self.assertEqual (capped["deal-reaction-window"], 0)
+    self.assertEqual (capped["deal-tax-bps"], 750)
+
+    self.mainLogger.info ("...and RPC == consensus, not a parallel formula.")
+    # The reported window is exactly the one a POST snapshots onto the row
+    # (min with the posted duration), so a client previewing off this RPC can
+    # never preview a value the chain would clamp away.
+    self.adminCommand ({"param": [
+      {"n": "deal-reaction-window", "v": 2592000 + 1000},   # over the 30d cap
+    ]})
+    self.generate (1)
+    eff = self.getRpc ("getjobsparams")["deal-reaction-window"]
+    self.assertEqual (eff, 2592000)
+    self.sendMove ("poster", {"j": [{
+      "t": "deal", "d": 2592000, "r": 1000, "co": 0, "terms": "w",
+    }]})
+    self.generate (1)
+    posted = self.newestJob ()
+    self.assertEqual (posted["reactionwindow"], eff)
+
+    self.mainLogger.info ("Jobs RPC surface test succeeded.")
+
+
+if __name__ == "__main__":
+  JobsRpcTest ().main ()

--- a/gametest/pxtest.py
+++ b/gametest/pxtest.py
@@ -367,6 +367,35 @@ class PXTest (XayaXGameTest):
 
     return self.getCustomState ("data", method, *args, **kwargs)
 
+  def getJobs (self):
+    """Returns the full live jobs board."""
+    return self.getRpc ("getjobs")
+
+  def newestJob (self):
+    """Returns the most recently posted job on the board."""
+    jobs = self.getJobs ()
+    assert len (jobs) > 0
+    return max (jobs, key=lambda j: j["id"])
+
+  def jobGone (self, jobId):
+    """Returns whether the given job is no longer on the board."""
+    return jobId not in [j["id"] for j in self.getJobs ()]
+
+  def lowerRewardFloors (self, *names):
+    """Lowers the named minimum-reward floors (roconfig 100/1000) to 1, the
+    same way an admin would: suites whose rewards predate the floors call
+    this.  The defaults themselves are exercised in jobs_caps.py."""
+    self.adminCommand ({"param": [{"n": n, "v": 1} for n in names]})
+    self.generate (1)
+
+  def available (self, name):
+    """Returns an account's available coin balance."""
+    return self.getAccounts ()[name].getBalance ("available")
+
+  def reserved (self, name):
+    """Returns an account's reserved coin balance (escrows, open bids)."""
+    return self.getAccounts ()[name].getBalance ("reserved")
+
   def sendMove (self, name, move, send=None, burn=0):
     """
     Sends a move, and optionally includes a coin burn.

--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -95,6 +95,7 @@ PROTOS = \
   config.proto \
   geometry.proto \
   inventory.proto \
+  jobs.proto \
   modifier.proto \
   movement.proto \
   ongoing.proto \

--- a/proto/account.proto
+++ b/proto/account.proto
@@ -48,4 +48,87 @@ message Account
    */
   optional uint64 burnsale_balance = 4;
 
+  reserved 5, 6, 7, 8;
+
+  /**
+   * Escrow-DEAL reputation counters: display-only vetting signals consumed by
+   * NO consensus rule.  Bumped for the worker on ANY tax-bearing settlement
+   * with p>0, so a Phase-2 reputation layer MUST read "completed" as "settled
+   * with the worker earning something", never as "delivered in full".
+   * Rationale and scaling: see BumpDealStats (src/jobs.cpp).
+   *
+   * The increments are deliberately unchecked at the declared widths.  The
+   * counts are uint32, so wrapping one takes 2^32 (~4.3e9) settlements, each
+   * burning a posting fee; the value counters are uint64 and grow by at most
+   * MAX_COIN_AMOUNT (1e11) per settlement, so wrapping one takes ~1.8e8
+   * max-value deals, each escrowing that value and burning its fee.  Both are
+   * economically unreachable, and a wrap would in any case be deterministic
+   * across nodes (no split risk).  Saturation is deliberately NOT used: it
+   * would add consensus-visible code for an unreachable boundary.
+   */
+  optional uint32 deals_completed = 9;
+  optional uint64 deals_value_completed = 10;
+
+  /**
+   * The POSTER side of the same settlements: deals this account posted that
+   * released value to a worker, and the total so released.  Gated on the very
+   * same tax anchor as the worker counters above (see BumpDealStats), so the
+   * two sides of one settlement move together or not at all.
+   *
+   * Like every counter here this is a RAW TALLY, not a trust score: a ring of
+   * sock puppets can wash-trade its own deals and pay only the burn (tax plus
+   * posting fee, ~4% of face value at the current params) for the record it
+   * manufactures.  The value counter is what makes that cost proportional --
+   * a big claimed number costs a proportional burn -- so a reputation layer
+   * must weight by value and never read the bare count as an endorsement.
+   */
+  optional uint32 deals_posted_completed = 11;
+  optional uint64 deals_posted_value = 12;
+
+  /**
+   * Deals that ended in a DISPUTE -- an arbiter ruling or the blunt 50/50
+   * fallback -- bumped for BOTH parties, since which side was at fault is
+   * exactly what consensus cannot know.  Deliberately NOT tax-gated: the
+   * dispute happened whether or not the pot was large enough to pay tax.
+   *
+   * Nobody can inflate their OWN count usefully (it reads as a negative), but
+   * a hostile counterparty can inflate SOMEONE ELSE'S: one deal it was going
+   * to enter anyway, then dispute.  Read it as "how often this account's deals
+   * needed a dispute to end", relative to its completion counts -- never as
+   * fault, which consensus cannot attribute.
+   */
+  optional uint32 deals_disputed = 13;
+
+  /**
+   * The ARBITER's record: disputes this account was bound to and actually
+   * RULED, plus the total pot (reward + collateral) those rulings directed.
+   * Both are bumped only by the arbiter's own signed ruling move, which is
+   * what keeps this record self-inflicted like the two above.
+   *
+   * The pot is the right measure of what an arbiter's judgement governed -- a
+   * p=0 ruling decides the fate of all of it, exactly as a p=100 one does --
+   * but it is a WEAKER anti-Sybil anchor than the reward-based counters above,
+   * and the two must not be compared as if they were the same currency.  A
+   * sock-puppet trio buys value here at about 1.3% of the figure credited
+   * (R=1000 with the maximum 2x collateral, self-ruled p=100: 30 tax + 10
+   * posting fee = 40 burned against 3000 credited), versus ~4% for
+   * deals_posted_value, because collateral returned at a high p bears no tax
+   * and so rides into this counter for free.  Weight accordingly.
+   *
+   * Ghosting -- letting a dispute time out into the 50/50 fallback -- is
+   * deliberately NOT counted here.  The poster binds an arbiter unilaterally
+   * (a post names any initialised account; there is no consent step), so a
+   * ghost counter in the account proto would be a permanent, unremovable mark
+   * that two colluding accounts could inflict on any non-consenting third
+   * party for the price of one throwaway deal.  A ghost is still
+   * attributable off-chain: the deal row carries the arbiter and, once a
+   * dispute lands, dispute_time (see jobs.proto) -- an observer that follows
+   * the board sees which bound arbiter let its window elapse.  Derived there
+   * it stays scoped, decayable and rebuttable instead of branded into
+   * consensus state for good.
+   */
+  optional uint32 arbiter_rulings = 14;
+  reserved 15;  // was arbiter_ghosted (see above: poisonable, and derivable)
+  optional uint64 arbiter_value_ruled = 16;
+
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -613,6 +613,71 @@ message Params
    */
   repeated ProspectingPrize prizes = 22;
 
+  /**
+   * Minimum posting fee (in vCHI, burned) for a jobs-board job.  The actual
+   * fee is max(job_post_fee_min, reward * job_post_fee_bps / 10000), so spam
+   * costs real money at any reward size.
+   */
+  optional int64 job_post_fee_min = 23;
+
+  /** Proportional part of the posting fee, in basis points of the reward.  */
+  optional uint32 job_post_fee_bps = 24;
+
+  /**
+   * Maximum listing window, in seconds.  Caps a job's calendar deadline (the
+   * booking horizon: how far ahead a job can be scheduled).
+   */
+  optional int64 max_listing_window = 25;
+
+  /**
+   * DEFAULT admission caps for the jobs board: the maximum number of live
+   * jobs in total and per poster.  A POST past a cap is rejected.  These are
+   * the roconfig DEFAULTS: the effective values are runtime-tunable through
+   * the "param" admin command (consensus state in the parameters table), so
+   * the limits can be adjusted -- or posting frozen entirely with 0 --
+   * without a redeploy.  Why admission control rather than a sweep bound:
+   * see the cap ceilings in src/jobs.hpp.
+   */
+  optional int64 max_live_jobs = 26;
+  optional int64 max_jobs_per_poster = 27;
+
+  /**
+   * DEFAULT minimum reward (whole vCHI), runtime-tunable like the caps
+   * ("min-job-reward").  Every post must escrow at least this much.  Together
+   * with the proportional posting fee this keeps the capped board slots from
+   * being monopolised for pocket change: filling one means locking real value.
+   */
+  optional int64 min_job_reward = 28;
+
+  /**
+   * DEFAULT escrow-deal economics, runtime-tunable like the other jobs
+   * parameters ("min-deal-reward" / "deal-max-collateral-bps" /
+   * "deal-max-collateral" / "deal-max-fee-bps" / "deal-tax-bps").  A deal
+   * escrows at least min_deal_reward; its worker collateral is bounded by
+   * BOTH reward * deal_max_collateral_bps / 10000 and the absolute
+   * deal_max_collateral; the poster's arbiter fee is capped at
+   * deal_max_fee_bps; and deal_tax_bps is the protocol tax snapshot into
+   * each row at post (burned at settlement until a faction treasury
+   * exists).  Post validation enforces tax + fee < 10000 on the snapshot
+   * values, so no admissible row can ever violate the settlement-math
+   * precondition, whatever these are retuned to later.
+   */
+  optional int64 min_deal_reward = 29;
+  optional uint32 deal_max_collateral_bps = 30;
+  optional int64 deal_max_collateral = 31;
+  optional uint32 deal_max_fee_bps = 32;
+  optional uint32 deal_tax_bps = 33;
+
+  /**
+   * DEFAULT reaction window (in seconds) for escrow deals, runtime-tunable
+   * like the other deal params ("deal-reaction-window").  A deal snapshots its
+   * effective window into JobData.reaction_window at POST, clamped to
+   * [0, 2592000] (30 days).  0 disables the mechanism (exact v1 settlement).
+   * The extension rule and its bounds: see ExtendForReactionWindow
+   * (src/jobs.cpp), the canonical site.
+   */
+  optional int64 deal_reaction_window = 34;
+
 }
 
 /* ************************************************************************** */

--- a/proto/jobs.proto
+++ b/proto/jobs.proto
@@ -1,0 +1,137 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+syntax = "proto2";
+option cc_enable_arenas = true;
+
+package pxd.proto;
+
+/**
+ * The non-column data of an escrow deal on the jobs board.  The poster escrows
+ * the `reward` column and the accepting worker the `collateral` column; when
+ * contested, a bound arbiter rules a single completion percentage that splits
+ * both pots (see ComputeDealSettlement / SettleDeal).  Everything the board and
+ * the expiry sweep must filter, sort or sum on is a real table column (see
+ * database/schema.sql and database/jobs.hpp); only what follows lives in this
+ * blob.
+ *
+ * Consensus hygiene: the state hash covers the raw serialised bytes and
+ * protobuf map ordering is not guaranteed, so consensus decisions never
+ * iterate a proto map directly.
+ */
+message JobData
+{
+
+  /**
+   * The designated worker (see the assign op).  Set by the poster, either at
+   * post time (the "w" term) or later by an assign.  Unset means anyone may
+   * accept -- unless invite_only is set below.
+   */
+  optional string designated_worker = 1;
+
+  /**
+   * Whether this deal was POSTED private: acceptable by NOBODY while
+   * designated_worker is empty (posted with w:"").  An empty
+   * designated_worker is otherwise indistinguishable from "open to all", so
+   * the flag exists purely to mark that restricted-but-not-yet-designated
+   * state -- it is the born-private discriminator, NOT a general "is
+   * exclusive" bit.  Set only by a POST carrying a "w" term (empty or not);
+   * ASSIGN names/renames the designee WITHOUT setting it, because a publicly
+   * posted deal was not born private and its designation alone already pins
+   * acceptance.  Exclusivity is therefore the pair, never this bit alone --
+   * what the accept gate enforces and what clients must read:
+   *
+   *     exclusive = invite_only || designated_worker != ""
+   */
+  optional bool invite_only = 2;
+
+  /**
+   * The arbiter account named by the poster to rule disputes (empty = a
+   * no-arbiter deal: the timeout resolves confirm-aware with no p-ruling path).
+   * The poster names it at post; the worker consents by accepting a deal that
+   * already shows it -- both-sided consent without a separate handshake.
+   */
+  optional string arbiter = 3;
+
+  /**
+   * The arbiter fee in basis points, snapshot at post (<= deal-max-fee-bps;
+   * a post may only carry a fee together with an arbiter).  The arbiter
+   * FORFEITS the fee if a disputed deal times out without its ruling (each
+   * party keeps its own fee share) -- ruling must never pay worse than
+   * ghosting the dispute.
+   */
+  optional uint32 fee_bps = 4;
+
+  /**
+   * The protocol tax in basis points, snapshot at post so the settlement
+   * is a pure function of the row -- immune to a governance retune between post
+   * and settle (the "min-reward floors reject historical posts on replay" trap).
+   */
+  optional uint32 tax_bps = 5;
+
+  /**
+   * Cosmetic job category (transport/haul/escort/... as an integer tag).  Drives
+   * the client's browsing and per-category reputation only; consensus settlement
+   * NEVER reads it.
+   */
+  optional uint32 type_tag = 6;
+
+  /** Free-text human-readable terms (byte-bounded at post; a charset/NFC
+      chain filter is deferred to Phase 2, so UIs MUST sanitise control and
+      bidi-override characters when rendering -- the arbiter reads this text
+      to rule).  Advisory only; settlement never parses it. */
+  optional string terms = 7;
+
+  /**
+   * Advisory pre-agreed completion % (0..100) the arbiter applies if the
+   * worker's ship is destroyed en route.  Honoured by the arbiter -- no chain
+   * enforcement in v1 (a trustless chain-fire is deferred).
+   */
+  optional uint32 destroyed_p = 8;
+
+  /** Happy-path confirmations; both true settles the deal at p=100. */
+  optional bool poster_confirmed = 9;
+  optional bool worker_confirmed = 10;
+
+  /**
+   * A dispute has been raised; thereafter only the arbiter's ruling settles it,
+   * or the end-date sweep's 50/50 fallback if the arbiter never rules.
+   */
+  optional bool disputed = 11;
+
+  /**
+   * The consensus timestamp (ctx.Timestamp()) at which DISPUTE executed;
+   * stamped once, when the dispute lands, and exposed on the JSON as
+   * disputetime.  Because an arbiter-bound dispute inside the reaction window
+   * extends the deadline to leave >= W ruling time, a later ghost-split is
+   * genuinely attributable arbiter fault -- Phase-2 reputation consumes this;
+   * no consensus rule reads it back.
+   */
+  optional int64 dispute_time = 12;
+
+  /**
+   * The deal's effective reaction window in seconds, snapshot ONCE at POST as
+   * min(the clamped deal-reaction-window param, the posted duration d) -- a
+   * pure function of the row like tax_bps/fee_bps, so no governance retune can
+   * change an in-flight deal's window.  DealOperation::Execute reads THIS,
+   * never the ParamsTable.  0 = the mechanism is off (exact v1 settlement).
+   * The extension rule and its bounds: see ExtendForReactionWindow.
+   */
+  optional int64 reaction_window = 13;
+
+}

--- a/proto/roconfig/params.pb.text
+++ b/proto/roconfig/params.pb.text
@@ -20,6 +20,26 @@ params:
     building_update_delay: 120
     dex_fee_bps: 300  # 3% base fee for sellers
 
+    # Jobs board.  Deadlines are in seconds (absolute consensus timestamp),
+    # so they do not depend on the block cadence.
+    job_post_fee_min: 1        # 1 vCHI minimum, burned
+    job_post_fee_bps: 100      # 1% of the reward
+    max_listing_window: 2592000 # 30 days (the booking horizon)
+
+    # Admission caps (defaults; runtime-tunable via the "param" admin
+    # command).  The global cap is the hard ceiling on any one expiry sweep.
+    max_live_jobs: 10000
+    max_jobs_per_poster: 200
+    min_job_reward: 100         # every job escrows at least 100 vCHI
+
+    # Escrow-deal economics (defaults; runtime-tunable like the caps).
+    min_deal_reward: 1000           # a deal escrows at least 1000 vCHI
+    deal_max_collateral_bps: 20000  # collateral <= 2x the reward
+    deal_max_collateral: 100000000000  # the coin cap: no extra absolute bound
+    deal_max_fee_bps: 1000          # arbiter fee <= 10%
+    deal_tax_bps: 300               # 3% protocol tax, burned
+    deal_reaction_window: 86400     # 24h window for a late confirm/dispute
+
     min_region_ore: 2000000
     max_region_ore: 100000000
 

--- a/proto/roconfig/test_params.pb.text
+++ b/proto/roconfig/test_params.pb.text
@@ -12,6 +12,11 @@ params:
     building_update_delay: 10
     dex_fee_bps: 1000  # 10% base fee for simpler numbers
 
+    # A short deal reaction window sized for the gametest/fork cadence
+    # (superblock_seconds 5), so a late confirm/dispute and its extension
+    # fit inside a handful of blocks.
+    deal_reaction_window: 30
+
     # We have tests that use up all materials (and then reprospect a region),
     # so that we need lower limits than on mainnet.
     min_region_ore: 10

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,6 +36,7 @@ libtaurion_la_SOURCES = \
   fitments.cpp \
   forks.cpp \
   gamestatejson.cpp \
+  jobs.cpp \
   jsonutils.cpp \
   logic.cpp \
   mining.cpp \
@@ -61,6 +62,7 @@ libtaurionheaders = \
   fitments.hpp \
   forks.hpp \
   gamestatejson.hpp \
+  jobs.hpp \
   jsonutils.hpp \
   logic.hpp \
   mining.hpp \
@@ -147,6 +149,7 @@ tests_SOURCES = \
   fitments_tests.cpp \
   forks_tests.cpp \
   gamestatejson_tests.cpp \
+  jobs_tests.cpp \
   jsonutils_tests.cpp \
   logic_tests.cpp \
   mining_tests.cpp \

--- a/src/gamestatejson.cpp
+++ b/src/gamestatejson.cpp
@@ -19,6 +19,7 @@
 #include "gamestatejson.hpp"
 
 #include "buildings.hpp"
+#include "jobs.hpp"
 #include "jsonutils.hpp"
 #include "modifier.hpp"
 #include "protoutils.hpp"
@@ -29,6 +30,7 @@
 #include "database/character.hpp"
 #include "database/faction.hpp"
 #include "database/itemcounts.hpp"
+#include "database/jobs.hpp"
 #include "database/moneysupply.hpp"
 #include "database/ongoing.hpp"
 #include "database/region.hpp"
@@ -321,6 +323,27 @@ template <>
       res["faction"] = FactionToString (a.GetFaction ());
       res["kills"] = IntToJson (pb.kills ());
       res["fame"] = IntToJson (pb.fame ());
+
+      /* Consensus-stored vetting signals surfaced for clients; no consensus
+         rule consumes them.  "completed"/"value" are the WORKER side,
+         "posted"/"postedvalue" the poster's mirror of the same settlements, and
+         "disputed" counts either party's deals that needed a dispute to end.
+         See BumpDealStats / BumpPosterDealStats / BumpDisputedStats.  */
+      Json::Value dealstats(Json::objectValue);
+      dealstats["completed"] = IntToJson (pb.deals_completed ());
+      dealstats["value"] = IntToJson (pb.deals_value_completed ());
+      dealstats["posted"] = IntToJson (pb.deals_posted_completed ());
+      dealstats["postedvalue"] = IntToJson (pb.deals_posted_value ());
+      dealstats["disputed"] = IntToJson (pb.deals_disputed ());
+      res["dealstats"] = dealstats;
+
+      /* The arbiter's own record: disputes it ruled and the pot value those
+         rulings directed.  Ghosting is deliberately absent -- see
+         BumpArbiterRulingStats and the account.proto rationale.  */
+      Json::Value arbiterstats(Json::objectValue);
+      arbiterstats["rulings"] = IntToJson (pb.arbiter_rulings ());
+      arbiterstats["valueruled"] = IntToJson (pb.arbiter_value_ruled ());
+      res["arbiterstats"] = arbiterstats;
     }
 
   return res;
@@ -625,6 +648,69 @@ template <>
   return res;
 }
 
+template <>
+  Json::Value
+  GameStateJson::Convert<Job> (const Job& j) const
+{
+  Json::Value res(Json::objectValue);
+
+  res["id"] = IntToJson (j.GetId ());
+  res["poster"] = j.GetPoster ();
+  if (!j.GetWorker ().empty ())
+    res["worker"] = j.GetWorker ();
+
+  res["reward"] = IntToJson (j.GetReward ());
+  res["collateral"] = IntToJson (j.GetCollateral ());
+  res["deadline"] = IntToJson (j.GetDeadline ());
+
+  const auto& pb = j.GetProto ();
+
+  const auto& designated = pb.designated_worker ();
+  if (!designated.empty ())
+    res["designated"] = designated;
+  /* "inviteonly" marks a deal POSTED private (born with a "w" term), not
+     every exclusive deal: a public deal later ASSIGNed carries "designated"
+     alone.  Both keys are exposed only when set, so a plain public deal has
+     neither, and the client test is the pair the accept gate enforces:
+     exclusive = inviteonly || designated != "".  */
+  if (pb.invite_only ())
+    res["inviteonly"] = true;
+
+  if (!pb.arbiter ().empty ())
+    res["arbiter"] = pb.arbiter ();
+  res["fee"] = IntToJson (pb.fee_bps ());
+  res["tax"] = IntToJson (pb.tax_bps ());
+  res["tag"] = IntToJson (pb.type_tag ());
+  if (!pb.terms ().empty ())
+    res["terms"] = pb.terms ();
+  if (pb.destroyed_p () > 0)
+    res["destroyedp"] = IntToJson (pb.destroyed_p ());
+  res["posterConfirmed"] = pb.poster_confirmed ();
+  res["workerConfirmed"] = pb.worker_confirmed ();
+  res["disputed"] = pb.disputed ();
+  /* The per-row reaction window (snapshot at post) and, once a dispute has
+     landed, the stamped dispute time (§1/§2).  */
+  if (pb.has_reaction_window ())
+    res["reactionwindow"] = IntToJson (pb.reaction_window ());
+  if (pb.has_dispute_time ())
+    res["disputetime"] = IntToJson (pb.dispute_time ());
+
+  switch (j.GetStatus ())
+    {
+    case Job::Status::OPEN:
+      res["state"] = "open";
+      break;
+    case Job::Status::ACCEPTED:
+      res["state"] = "accepted";
+      break;
+    default:
+      res["state"] = "unknown";
+      break;
+    }
+
+  return res;
+}
+
 template <typename T, typename R>
   Json::Value
   GameStateJson::ResultsAsArray (T& tbl, Database::Result<R> res) const
@@ -690,6 +776,46 @@ GameStateJson::MoneySupply ()
 }
 
 Json::Value
+GameStateJson::JobsParams ()
+{
+  const auto& p = ctx.RoConfig ()->params ();
+  const ParamsTable params(db);
+
+  Json::Value res(Json::objectValue);
+
+  /* The admission caps and the reaction window: report the POST-CLAMP
+     effective value -- exactly what consensus uses -- by routing through the
+     same CappedParam helper, ceilings AND FLOORS the consensus reads do, so a
+     client never previews against a value the chain would clamp away (F4).  */
+  const struct { const char* name; int64_t def, ceiling, floor; } capped[] = {
+    {"max-live-jobs", p.max_live_jobs (), CAP_MAX_LIVE_JOBS, 0},
+    {"max-jobs-per-poster", p.max_jobs_per_poster (),
+     CAP_MAX_JOBS_PER_POSTER, 0},
+    {"deal-reaction-window", p.deal_reaction_window (),
+     CAP_DEAL_REACTION_WINDOW, 0},
+  };
+  for (const auto& e : capped)
+    res[e.name] = IntToJson (
+        CappedParam (params, e.name, e.def, e.ceiling, e.floor));
+
+  /* The self-bounding deal/reward-floor params: the settlement math bounds
+     them at the door on the snapshot values, so they carry no immutable
+     ceiling -- report the plain runtime overlay over the roconfig default.  */
+  const struct { const char* name; int64_t def; } plain[] = {
+    {"min-job-reward", p.min_job_reward ()},
+    {"min-deal-reward", p.min_deal_reward ()},
+    {"deal-tax-bps", p.deal_tax_bps ()},
+    {"deal-max-collateral-bps", p.deal_max_collateral_bps ()},
+    {"deal-max-collateral", p.deal_max_collateral ()},
+    {"deal-max-fee-bps", p.deal_max_fee_bps ()},
+  };
+  for (const auto& e : plain)
+    res[e.name] = IntToJson (params.Get (e.name, e.def));
+
+  return res;
+}
+
+Json::Value
 GameStateJson::PrizeStats ()
 {
   ItemCounts cnt(db);
@@ -719,19 +845,23 @@ GameStateJson::Accounts ()
   AccountsTable tbl(db);
   Json::Value res = ResultsAsArray (tbl, tbl.QueryAll ());
 
-  /* Add in also the Cubit balances reserved in open bids.  */
-  const auto reserved = orders.GetReservedCoins ();
+  /* Add in the coins reserved by an account: DEX open bids plus jobs-board
+     escrow (posted rewards + accepted-job collateral).  */
+  auto reserved = orders.GetReservedCoins ();
+  JobsTable jobs(db);
+  for (const auto& entry : jobs.GetReservedCoins ())
+    reserved[entry.first] += entry.second;
+
   for (auto& entry : res)
     {
       const auto& nmVal = entry["name"];
       CHECK (nmVal.isString ());
-      const auto mit = reserved.find (nmVal.asString ());
+      const std::string nm = nmVal.asString ();
 
-      Amount cur;
-      if (mit == reserved.end ())
-        cur = 0;
-      else
-        cur = mit->second;
+      Amount cur = 0;
+      const auto it = reserved.find (nm);
+      if (it != reserved.end ())
+        cur = it->second;
 
       auto& bal = entry["balance"];
       CHECK (bal.isObject ());
@@ -746,6 +876,13 @@ Json::Value
 GameStateJson::Buildings ()
 {
   BuildingsTable tbl(db);
+  return ResultsAsArray (tbl, tbl.QueryAll ());
+}
+
+Json::Value
+GameStateJson::Jobs ()
+{
+  JobsTable tbl(db);
   return ResultsAsArray (tbl, tbl.QueryAll ());
 }
 
@@ -814,6 +951,7 @@ GameStateJson::FullState ()
   res["characters"] = Characters ();
   res["groundloot"] = GroundLoot ();
   res["ongoings"] = OngoingOperations ();
+  res["jobs"] = Jobs ();
   res["moneysupply"] = MoneySupply ();
   res["regions"] = Regions (0);
   res["prizes"] = PrizeStats ();

--- a/src/gamestatejson.hpp
+++ b/src/gamestatejson.hpp
@@ -105,6 +105,19 @@ public:
   Json::Value Buildings ();
 
   /**
+   * Returns the JSON data representing all jobs on the jobs board.
+   */
+  Json::Value Jobs ();
+
+  /**
+   * Returns every runtime jobs-board parameter mapped to the POST-CLAMP
+   * effective value consensus would use right now (the ParamsTable overlay of
+   * the roconfig default, clamped for the admission caps).  Reuses CappedParam,
+   * so the reported value equals what consensus uses by construction.
+   */
+  Json::Value JobsParams ();
+
+  /**
    * Returns the JSON data representing all characters in the game state.
    */
   Json::Value Characters ();

--- a/src/jobs.cpp
+++ b/src/jobs.cpp
@@ -1,0 +1,1459 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "jobs.hpp"
+
+#include "jsonutils.hpp"
+
+#include "database/params.hpp"
+
+#include <xayautil/jsonutils.hpp>
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pxd
+{
+
+/* ************************************************************************** */
+/* Shared settlement helpers.                                                 */
+
+namespace
+{
+
+/**
+ * Whether a deadlined job is at or past its deadline (deadline <= now, the
+ * exclusive boundary): such a job belongs to the expiry sweep, and the
+ * lifecycle operations must not touch it.  The sweep only runs on superblocks
+ * while moves run on every block, so without this guard an operation landing
+ * between the deadline and the next superblock could change the settlement:
+ * an accept would resurrect a listing that should void (an elapsed ad would
+ * otherwise pay its full rent for zero display
+ * time).  A job without a deadline is never due.
+ */
+bool
+JobIsDue (const Job& job, const JobContext& jc)
+{
+  return job.GetDeadline () <= jc.ctx.Timestamp ();
+}
+
+/**
+ * Applies the deal reaction window (design escrow-v1.1 §1): when a deal action
+ * that leaves a live counter-move (a single CONFIRM, or an arbiter-bound
+ * DISPUTE) executes at `now` strictly within the row's snapshotted
+ * reaction_window of the deadline, the deadline is pushed to now + window so
+ * the successor move always keeps a full window to answer.  Properties, all
+ * test-pinned: the trigger is STRICT '<' (at deadline - now == W nothing is
+ * needed, exactly W remains; at == W-1 it fires), so it never shortens
+ * (now + W > deadline iff deadline - now < W) and is one-shot per set-once flag,
+ * bounding total extension at 2W past the original deadline; W=0 is provably
+ * inert (JobIsDue guarantees deadline > now at execution, so
+ * deadline - now >= 1 > 0).  The moved deadline column shifts the
+ * jobs_by_deadline index row, and since now + W > now an extended deal is
+ * never swept in its own block.
+ */
+void
+ExtendForReactionWindow (Job& job, const int64_t now)
+{
+  const int64_t w = job.GetProto ().reaction_window ();
+  if (w > 0 && job.GetDeadline () - now < w)
+    job.SetDeadline (now + w);
+}
+
+/**
+ * Deletes a settled job's row, releasing the row handle first so the delete
+ * cannot collide with it on the unique-handle tracker.  Every terminal
+ * transition funnels through here.
+ */
+void
+DeleteSettled (JobsTable& jobs, JobsTable::Handle job)
+{
+  const auto id = job->GetId ();
+  job.reset ();
+  jobs.DeleteById (id);
+}
+
+/**
+ * Fetches an account by name, CHECK-failing if it does not exist.  Callers
+ * must ensure no other live handle to the same account row exists
+ * (UniqueHandles): safe in the block hooks, but move-op code must use the
+ * executor handle it already holds for that account.
+ */
+AccountsTable::Handle
+GetAccountChecked (const JobContext& jc, const std::string& name)
+{
+  auto a = jc.accounts.GetByName (name);
+  CHECK (a != nullptr) << "Job party account missing: " << name;
+  return a;
+}
+
+/**
+ * Bumps the worker's DEAL reputation counters.  Called once on any tax-bearing
+ * settlement with p>0 -- a both-confirm/single-confirm release, a ghosted 50/50
+ * split and a partial ruling all qualify, so "completed" counts the tax-bearing
+ * settlements the worker earned on, not full deliveries.  `value` is the
+ * worker's earned reward share (reward * p / 100), which scales the value
+ * counter down on a split or a low-p ruling.
+ */
+void
+BumpDealStats (Account& a, const Amount value)
+{
+  auto& pb = a.MutableProto ();
+  pb.set_deals_completed (pb.deals_completed () + 1);
+  pb.set_deals_value_completed (pb.deals_value_completed () + value);
+}
+
+/**
+ * Bumps the POSTER's mirror of the counters above: called under the same
+ * tax-bearing gate, with the same `value` (what the worker earned is what the
+ * poster released), so one settlement moves both sides' records together.
+ */
+void
+BumpPosterDealStats (Account& a, const Amount value)
+{
+  auto& pb = a.MutableProto ();
+  pb.set_deals_posted_completed (pb.deals_posted_completed () + 1);
+  pb.set_deals_posted_value (pb.deals_posted_value () + value);
+}
+
+/**
+ * Records that a deal ended in a dispute, for one of its two parties.  Not
+ * tax-gated (see the proto comment): a dispute is a fact about the deal, not
+ * an earning, and it is the one counter nobody has an incentive to inflate.
+ */
+void
+BumpDisputedStats (Account& a)
+{
+  auto& pb = a.MutableProto ();
+  pb.set_deals_disputed (pb.deals_disputed () + 1);
+}
+
+/**
+ * Records one dispute RULED by the arbiter that was bound to it, weighted by
+ * the pot its judgement directed.  Only ever called for the arbiter's own
+ * signed ruling move -- a ghosted dispute and a no-arbiter dispute both leave
+ * no arbiter trace here on purpose (see the proto comment: the arbiter is
+ * bound without consent, so consensus must not brand it for inaction).
+ */
+void
+BumpArbiterRulingStats (Account& a, const Amount pot)
+{
+  auto& pb = a.MutableProto ();
+  pb.set_arbiter_rulings (pb.arbiter_rulings () + 1);
+  pb.set_arbiter_value_ruled (pb.arbiter_value_ruled () + pot);
+}
+
+/**
+ * Hook-path settlement: the job is void through neither party's fault (an
+ * OPEN job expired).  The reward refunds to the poster and any locked
+ * collateral returns to the worker; no counters change.  Must not be called
+ * while any account handle is live.
+ */
+void
+VoidJobAtHook (const JobContext& jc, const Job& job)
+{
+  {
+    auto poster = GetAccountChecked (jc, job.GetPoster ());
+    ReleaseJobCoins (*poster, job.GetReward ());
+  }
+  if (job.GetStatus () == Job::Status::ACCEPTED)
+    {
+      auto worker = GetAccountChecked (jc, job.GetWorker ());
+      ReleaseJobCoins (*worker, job.GetCollateral ());
+    }
+}
+
+/** Upper bound on the byte length of a deal's free-text terms.  */
+constexpr size_t MAX_DEAL_TERMS_LENGTH = 1'000;
+/** Upper bound on a deal's cosmetic type tag.  */
+constexpr uint32_t MAX_DEAL_TYPE_TAG = 100;
+
+/**
+ * The effective deal tax in bps (runtime param over the roconfig default).
+ * Read in ValidateDealPost (the §6.3 door guard) and snapshot by ApplyDealPost,
+ * so both see the same value within one post.
+ */
+int64_t
+DealTaxBps (const JobContext& jc)
+{
+  return jc.params.Get ("deal-tax-bps",
+                        jc.ctx.RoConfig ()->params ().deal_tax_bps ());
+}
+
+/**
+ * The POST term keys beyond the generic t / d / r / co handled by the caller.
+ * POST parsing rejects a move containing any other member, so the POST grammar
+ * is exactly as strict as the lifecycle ops' (typos surface as rejections
+ * instead of being silently ignored).  Returned by reference to a static so
+ * the hot parse path allocates nothing.
+ */
+const std::vector<std::string>&
+DealPostTermKeys ()
+{
+  static const std::vector<std::string> keys
+      = {"arbiter", "fee", "tag", "terms", "dp", "w"};
+  return keys;
+}
+
+/**
+ * The minimum reward a POST must escrow, beyond the global "min-job-reward"
+ * floor (the larger of the two applies), so occupying a capped board slot
+ * always locks real value.
+ */
+Amount
+MinDealReward (const JobContext& jc)
+{
+  return jc.params.Get ("min-deal-reward",
+                        jc.ctx.RoConfig ()->params ().min_deal_reward ());
+}
+
+/**
+ * Validates the deal terms of a POST move (no state change).  The generic
+ * reward / collateral / deadline / affordability checks are done by the
+ * caller; this only checks the deal terms.  Returns false to reject.
+ */
+bool
+ValidateDealPost (const JobContext& jc, const Account& poster,
+                  const Json::Value& terms)
+{
+  const auto& p = jc.ctx.RoConfig ()->params ();
+
+  Amount reward, collateral;
+  CHECK (CoinAmountFromJson (terms["r"], reward));
+  CHECK (CoinAmountFromJson (terms["co"], collateral));
+
+  /* Collateral is bounded relative to the reward AND by an absolute ceiling,
+     so a poster cannot lure a worker into an unbounded stake (red-team T1).  */
+  const int64_t maxColBps
+      = jc.params.Get ("deal-max-collateral-bps",
+                       p.deal_max_collateral_bps ());
+  /* reward * maxColBps / 10000, overflow-guarded: a reward large enough to
+     overflow the product means the ratio cap is effectively unlimited (the
+     collateral is already bounded by CoinAmountFromJson), so only the
+     absolute cap binds; a zero/negative bps freezes collateral to nothing.  */
+  Amount maxByRatio;
+  if (maxColBps <= 0)
+    maxByRatio = 0;
+  else if (reward > std::numeric_limits<Amount>::max () / maxColBps)
+    maxByRatio = std::numeric_limits<Amount>::max ();
+  else
+    maxByRatio = reward * maxColBps / 10'000;
+  const Amount maxAbs
+      = jc.params.Get ("deal-max-collateral", p.deal_max_collateral ());
+  if (collateral > maxByRatio || collateral > maxAbs)
+    {
+      LOG (WARNING) << "Deal collateral " << collateral << " exceeds the cap";
+      return false;
+    }
+
+  /* Arbiter is optional; if named, it must be a non-empty, initialised
+     account (an empty string would be a silently-meaningless member,
+     which the strict grammar rejects rather than ignores).  */
+  std::string arbiter;
+  if (terms.isMember ("arbiter"))
+    {
+      if (!terms["arbiter"].isString ())
+        return false;
+      arbiter = terms["arbiter"].asString ();
+      if (arbiter.empty ())
+        return false;
+      /* Poster == arbiter is FORBIDDEN (design §1): under the reaction window
+         a poster-arbiter could dispute a late single-confirm (+W) and then
+         rule p=0 for a total seizure that v1's hard deadline capped at the
+         50/50 ghost split -- an armed trap primitive with no legitimate use,
+         banned at the post door.  This guarantees a distinct ACCOUNT, not a
+         distinct person: nothing stops one operator from arbitrating their
+         own deal under a second Xaya name, and a named-arbiter model has no
+         Sybil-resistant identity to check.  The protection is disclosure --
+         the arbiter is bound at POST, so the worker sees who will judge
+         before staking collateral.  */
+      if (arbiter == poster.GetName ())
+        {
+          LOG (WARNING) << "Deal arbiter cannot be the poster: " << arbiter;
+          return false;
+        }
+      const auto a = jc.accounts.GetByName (arbiter);
+      if (a == nullptr || !a->IsInitialised ())
+        {
+          LOG (WARNING) << "Deal arbiter not initialised: " << arbiter;
+          return false;
+        }
+    }
+
+  /* Optional worker designation at POST (design §3, closing F1's negotiate-
+     then-invite snipe): a non-empty "w" makes the deal private from birth --
+     it must be an existing initialised account, != the poster, and != the
+     arbiter named in the same post.  An empty string ("w":"") is the legal
+     private-unassigned state (invite-only, designee chosen later via ASSIGN).
+     Any violation rejects the WHOLE post (nothing charged).  ApplyDealPost
+     persists the designation and the invite_only flag.  */
+  if (terms.isMember ("w"))
+    {
+      if (!terms["w"].isString ())
+        return false;
+      const std::string w = terms["w"].asString ();
+      if (!w.empty ())
+        {
+          if (w == poster.GetName ())
+            {
+              LOG (WARNING) << "Deal worker cannot be the poster: " << w;
+              return false;
+            }
+          if (w == arbiter)
+            {
+              LOG (WARNING) << "Deal worker cannot be the arbiter: " << w;
+              return false;
+            }
+          const auto a = jc.accounts.GetByName (w);
+          if (a == nullptr || !a->IsInitialised ())
+            {
+              LOG (WARNING) << "Deal designated worker not initialised: " << w;
+              return false;
+            }
+        }
+    }
+
+  /* Arbiter fee in bps, bounded by the cap.  A fee without an arbiter to
+     earn it is rejected, not silently dropped (strict grammar): the poster
+     most likely mistyped or forgot the arbiter member.  */
+  int64_t fee = 0;
+  if (terms.isMember ("fee"))
+    {
+      if (!terms.isMember ("arbiter"))
+        {
+          LOG (WARNING) << "Deal fee given without an arbiter";
+          return false;
+        }
+      if (!terms["fee"].isInt64 () || !xaya::IsIntegerValue (terms["fee"]))
+        return false;
+      fee = terms["fee"].asInt64 ();
+      if (fee < 0
+            || fee > jc.params.Get ("deal-max-fee-bps",
+                                    p.deal_max_fee_bps ()))
+        return false;
+    }
+
+  /* The §6.3 settlement precondition (0 <= tax and tax + fee < 10000),
+     enforced at the door on the values this row would SNAPSHOT: every
+     future settlement of the row must satisfy it whatever the runtime
+     params are later retuned to.  Each operand is bounded on its own
+     BEFORE the sum -- the runtime params are arbitrary int64s, so an
+     unbounded pair could overflow the signed sum (UB) past this guard and
+     then narrow to small uint32s whose persisted sum halts settlement.  */
+  const int64_t tax = DealTaxBps (jc);
+  if (tax < 0 || tax >= 10'000 || fee >= 10'000 || tax + fee >= 10'000)
+    {
+      LOG (WARNING)
+          << "Deal tax " << tax << " + fee " << fee
+          << " violate the settlement precondition";
+      return false;
+    }
+
+  /* Cosmetic type tag (optional, bounded; NEVER read by settlement).  */
+  if (terms.isMember ("tag"))
+    {
+      if (!terms["tag"].isUInt () || !xaya::IsIntegerValue (terms["tag"])
+            || terms["tag"].asUInt () > MAX_DEAL_TYPE_TAG)
+        return false;
+    }
+
+  /* Free-text terms (optional, byte-bounded; NFC/charset filter = Phase 2).  */
+  if (terms.isMember ("terms"))
+    {
+      if (!terms["terms"].isString ()
+            || terms["terms"].asString ().size () > MAX_DEAL_TERMS_LENGTH)
+        return false;
+    }
+
+  /* Advisory destroyed-% (optional): 0..100.  */
+  if (terms.isMember ("dp"))
+    {
+      if (!terms["dp"].isInt64 () || !xaya::IsIntegerValue (terms["dp"]))
+        return false;
+      const int64_t dp = terms["dp"].asInt64 ();
+      if (dp < 0 || dp > 100)
+        return false;
+    }
+
+  return true;
+}
+
+/**
+ * Applies the (already-validated) terms to the freshly-created OPEN job.
+ * Called from POST after the generic escrow + row creation.
+ */
+void
+ApplyDealPost (const JobContext& jc, const Json::Value& terms, Job& job)
+{
+  /* Validation guarantees a fee only ever comes with an arbiter, and
+     that both tax and fee satisfy the §6.3 precondition.  */
+  auto& d = job.MutableProto ();
+  if (terms.isMember ("arbiter"))
+    d.set_arbiter (terms["arbiter"].asString ());
+  if (terms.isMember ("fee"))
+    d.set_fee_bps (static_cast<uint32_t> (terms["fee"].asInt64 ()));
+  /* Snapshot the tax at post so §6.3 is a pure function of the row.  */
+  d.set_tax_bps (static_cast<uint32_t> (DealTaxBps (jc)));
+  if (terms.isMember ("tag"))
+    d.set_type_tag (terms["tag"].asUInt ());
+  if (terms.isMember ("terms"))
+    d.set_terms (terms["terms"].asString ());
+  if (terms.isMember ("dp"))
+    d.set_destroyed_p (static_cast<uint32_t> (terms["dp"].asInt64 ()));
+
+  /* Worker designation (design §3): a "w" term makes the deal invite-only
+     from birth; a non-empty designee is the designated worker (the accept
+     gate enforces it), an empty "w" is the private-unassigned state named
+     later via ASSIGN.  */
+  if (terms.isMember ("w"))
+    {
+      const std::string w = terms["w"].asString ();
+      if (!w.empty ())
+        d.set_designated_worker (w);
+      d.set_invite_only (true);
+    }
+
+  /* Snapshot the reaction window at post -- W = min(the clamped
+     deal-reaction-window param, the posted duration d) -- exactly like the
+     tax snapshot above and for the same reason: the deal's terms must be a
+     pure function of the row, so no admin retune can strip an in-flight
+     deal's advertised protection, and a short deal never carries a window
+     longer than its own duration (§1).  DealOperation::Execute reads THIS.  */
+  const int64_t wParam
+      = CappedParam (jc.params, "deal-reaction-window",
+                     jc.ctx.RoConfig ()->params ().deal_reaction_window (),
+                     CAP_DEAL_REACTION_WINDOW);
+  d.set_reaction_window (std::min<int64_t> (wParam, terms["d"].asInt64 ()));
+}
+
+/**
+ * Extra validation of an ACCEPT (no state change), on top of the generic
+ * designation / runway / collateral checks.
+ */
+bool
+ValidateDealAccept (const Job& job, const Account& worker)
+{
+  /* The arbiter must stay a third party: as worker it would judge its own
+     dispute (accept + self-dispute + self-rule in one block would capture
+     the whole escrow).  Poster == arbiter is barred at the post door now
+     (design §1), so the arbiter is a distinct third account from both sides.  */
+  if (worker.GetName () == job.GetProto ().arbiter ())
+    {
+      LOG (WARNING)
+          << "Arbiter " << worker.GetName () << " cannot accept deal "
+          << job.GetId ();
+      return false;
+    }
+  return true;
+}
+
+} // anonymous namespace
+
+/* ************************************************************************** */
+/* Escrow-deal settlement.                                                    */
+
+DealSettlement
+ComputeDealSettlement (const Amount reward, const Amount collateral,
+                       const int p, const int taxBps, const int feeBps)
+{
+  CHECK_GE (p, 0);
+  CHECK_LE (p, 100);
+  CHECK_GE (reward, 0);
+  CHECK_GE (collateral, 0);
+  CHECK_LT (taxBps + feeBps, 10'000);
+
+  const Amount workerReward = reward * p / 100;
+  const Amount returnedC = collateral * p / 100;
+  const Amount seizedC = collateral - returnedC;
+  /* Each party bears tax + fee on its OWN transacted share -- the worker on the
+     reward it earned, the poster on the reward it reclaims plus the collateral
+     it seizes.  No 128-bit intermediate is needed, and honest completion is
+     never net-negative for the worker (workerTax + workerFee < workerReward).  */
+  const Amount posterTransacted = (reward - workerReward) + seizedC;
+  const Amount workerTax = workerReward * taxBps / 10'000;
+  const Amount workerFee = workerReward * feeBps / 10'000;
+  const Amount posterTax = posterTransacted * taxBps / 10'000;
+  const Amount posterFee = posterTransacted * feeBps / 10'000;
+
+  DealSettlement s;
+  s.treasury = workerTax + posterTax;
+  s.arbiter = workerFee + posterFee;
+  s.worker = workerReward - workerTax - workerFee + returnedC;
+  /* Remainder pinned to the poster => exact conservation for all inputs.  */
+  s.poster = (reward + collateral) - s.worker - s.arbiter - s.treasury;
+
+  CHECK_GE (s.worker, 0);
+  CHECK_GE (s.poster, 0);
+  CHECK_EQ (s.worker + s.poster + s.arbiter + s.treasury, reward + collateral);
+  return s;
+}
+
+void
+SettleDeal (const JobContext& jc, Job& job, const int p,
+            Account* const executor, const bool payArbiterFee,
+            const DealSettleMode mode)
+{
+  const auto& d = job.GetProto ();
+  /* A forfeited fee (the ghosted-dispute timeout) settles as if none had
+     been agreed: each party keeps its own fee share.  */
+  const int feeBps = payArbiterFee ? d.fee_bps () : 0;
+  const DealSettlement s = ComputeDealSettlement (
+      job.GetReward (), job.GetCollateral (), p, d.tax_bps (), feeBps);
+
+  /* Accumulate the net credit per distinct account name, so a self-arbiter or
+     poster==arbiter is opened exactly once and never collides with the
+     executor's live handle.  The treasury tax is intentionally NOT credited --
+     it is burned until a faction treasury exists to receive it (Phase 4).
+
+     A named arbiter joins that map only when there is something to do for it:
+     a fee to pay, or a ruling of its own to record.  Skipping it otherwise
+     spares an account read on the pro-bono happy path -- and, on a GHOST_SPLIT,
+     keeps settlement from so much as OPENING the row of an account that was
+     bound as arbiter without ever consenting and never acted.  */
+  const bool ruledByArbiter = (mode == DealSettleMode::RULING);
+  std::map<std::string, Amount> credit;
+  credit[job.GetWorker ()] += s.worker;
+  credit[job.GetPoster ()] += s.poster;
+  if (!d.arbiter ().empty () && (s.arbiter > 0 || ruledByArbiter))
+    credit[d.arbiter ()] += s.arbiter;
+
+  const Amount earnedReward = job.GetReward () * p / 100;
+  const Amount pot = job.GetReward () + job.GetCollateral ();
+  const bool creditRep = (p > 0 && s.treasury >= 1);
+  const std::string workerName = job.GetWorker ();
+  const std::string posterName = job.GetPoster ();
+  const std::string arbiterName = d.arbiter ();
+  /* What took this deal off the happy path: either the bound arbiter ruled it,
+     or nobody did and the sweep fell back to the blunt 50/50 split.  */
+  const bool disputed = (ruledByArbiter
+                            || mode == DealSettleMode::GHOST_SPLIT);
+
+  for (const auto& entry : credit)
+    {
+      const std::string& name = entry.first;
+      const Amount amount = entry.second;
+      const bool isWorker = (name == workerName);
+      const bool isPoster = (name == posterName);
+      const bool isArbiter = (!arbiterName.empty () && name == arbiterName);
+      /* The executor's row is already open, so reuse that handle rather than
+         opening a second one for the same account; `held` stays null then and
+         dies with the iteration, exactly as the two branches did before.  */
+      AccountsTable::Handle held;
+      if (executor == nullptr || name != executor->GetName ())
+        held = GetAccountChecked (jc, name);
+      Account& acc = (held != nullptr ? *held : *executor);
+
+      if (amount > 0)
+        ReleaseJobCoins (acc, amount);
+      /* The role bumps are independent rather than mutually exclusive.  All
+         three names are distinct today (post bars poster == arbiter, accept
+         bars worker == poster and worker == arbiter), but written this way an
+         overlap could only ever record MORE, never silently drop a party's
+         record -- and no extra account read is taken: every name here already
+         has its handle open for the payout above.  */
+      if (creditRep && isWorker)
+        BumpDealStats (acc, earnedReward);
+      if (creditRep && isPoster)
+        BumpPosterDealStats (acc, earnedReward);
+      if (disputed && (isWorker || isPoster))
+        BumpDisputedStats (acc);
+      if (ruledByArbiter && isArbiter)
+        BumpArbiterRulingStats (acc, pot);
+    }
+}
+
+void
+RefundBothDeal (const JobContext& jc, Job& job)
+{
+  /* Accumulated per name so worker == poster could never double-open a row
+     (unreachable today -- accept rejects the poster -- but structural, like
+     SettleDeal's credit map).  Hook-path only: no account handle is live.  */
+  std::map<std::string, Amount> credit;
+  credit[job.GetWorker ()] += job.GetCollateral ();
+  credit[job.GetPoster ()] += job.GetReward ();
+  for (const auto& entry : credit)
+    if (entry.second > 0)
+      {
+        auto held = GetAccountChecked (jc, entry.first);
+        ReleaseJobCoins (*held, entry.second);
+      }
+}
+
+void
+ExpireJob (const JobContext& jc, Job& job)
+{
+  if (job.GetStatus () != Job::Status::ACCEPTED)
+    {
+      /* Never accepted: refund the poster's reward (nothing else locked).  */
+      VoidJobAtHook (jc, job);
+      return;
+    }
+
+  const auto& d = job.GetProto ();
+  if (d.disputed ())
+    {
+      /* Ghosted arbiter (or a no-arbiter dispute): the blunt 50/50 fallback.
+         The arbiter FORFEITS its fee here -- it was hired precisely to rule
+         this dispute and did not, and paying it anyway would make ghosting
+         strictly better than the ruling (which costs a transaction).  */
+      SettleDeal (jc, job, 50, nullptr, false, DealSettleMode::GHOST_SPLIT);
+      return;
+    }
+
+  if (d.poster_confirmed () || d.worker_confirmed ())
+    {
+      /* One side confirmed, the other neither confirmed nor disputed: done.  */
+      SettleDeal (jc, job, 100, nullptr, true,
+                  DealSettleMode::SINGLE_CONFIRM);
+      return;
+    }
+
+  /* Neither party acted: return both stakes.  */
+  RefundBothDeal (jc, job);
+}
+
+/* ************************************************************************** */
+/* The move-op lifecycle.                                                     */
+
+namespace
+{
+
+/**
+ * POST: locks the reward + burns the posting fee and creates an OPEN deal.
+ */
+class PostOperation : public JobOperation
+{
+
+private:
+
+  /** The relative deadline in seconds; -1 = absent (rejected at validation).  */
+  const int64_t deadlineSecs;
+
+  const Amount reward;
+  const Amount collateral;
+
+  /** The full raw post object, carrying the deal terms.  */
+  const Json::Value terms;
+
+  /** Computes the burned posting fee for the reward.  */
+  Amount
+  Fee () const
+  {
+    const auto& p = jc.ctx.RoConfig ()->params ();
+    const Amount proportional = reward * p.job_post_fee_bps () / 10000;
+    return std::max<Amount> (p.job_post_fee_min (), proportional);
+  }
+
+public:
+
+  PostOperation (Account& a, const JobContext& c, const int64_t d,
+                 const Amount rew, const Amount col, const Json::Value& tm)
+    : JobOperation(a, c), deadlineSecs(d),
+      reward(rew), collateral(col), terms(tm)
+  {}
+
+  bool IsValid () const override;
+  void Execute () override;
+
+};
+
+bool
+PostOperation::IsValid () const
+{
+  if (account.GetFaction () == Faction::INVALID)
+    {
+      LOG (WARNING)
+          << account.GetName () << " has no faction, cannot post a job";
+      return false;
+    }
+
+  /* The reward must be strictly positive: a zero-reward job would still bump
+     the worker's completion counter on settlement, farming the count-based
+     half of the reputation for just the posting fee.  Collateral MAY be
+     zero.  */
+  if (reward <= 0 || collateral < 0)
+    return false;
+
+  /* A deal is deadline-bound, so "d" is required.  */
+  if (deadlineSecs < 0)
+    {
+      LOG (WARNING) << "Job post is missing its deadline";
+      return false;
+    }
+  /* A listing may sit on the board up to the booking horizon; the deadline's
+     own lower bound is left to each type.  */
+  const auto& p = jc.ctx.RoConfig ()->params ();
+  if (deadlineSecs > p.max_listing_window ())
+    {
+      LOG (WARNING) << "Job listing window too long: " << deadlineSecs;
+      return false;
+    }
+
+  if (!ValidateDealPost (jc, account, terms))
+    return false;
+
+  /* Admission caps: the deterministic ceiling on every future atomic
+     sweep, enforced at the door so settlement semantics never change for
+     rows already admitted.  The effective values are the admin-tunable
+     parameter overrides (the "param" command) falling back to the roconfig
+     defaults; 0 -- or any negative value -- freezes the respective
+     admission entirely.  Checked after ValidatePost so the terms are
+     known-valid.  */
+  {
+    /* Minimum escrowed value: the global floor, raised further by the deal
+       floor, so a capped board slot cannot be occupied for pocket change.  */
+    const Amount minReward
+        = std::max<Amount> (jc.params.Get ("min-job-reward",
+                                           p.min_job_reward ()),
+                            MinDealReward (jc));
+    if (reward < minReward)
+      {
+        LOG (WARNING)
+            << "Reward " << reward << " is below the minimum " << minReward;
+        return false;
+      }
+
+    if (jc.jobs.CountAll ()
+          >= CappedParam (jc.params, "max-live-jobs", p.max_live_jobs (),
+                          CAP_MAX_LIVE_JOBS))
+      {
+        LOG (WARNING) << "Jobs board is at the live-jobs cap";
+        return false;
+      }
+
+    if (jc.jobs.CountForPoster (account.GetName ())
+          >= CappedParam (jc.params, "max-jobs-per-poster",
+                          p.max_jobs_per_poster (), CAP_MAX_JOBS_PER_POSTER))
+      {
+        LOG (WARNING)
+            << account.GetName () << " is at their live-jobs cap";
+        return false;
+      }
+  }
+
+  const Amount fee = Fee ();
+  if (account.GetBalance () < reward + fee)
+    {
+      LOG (WARNING)
+          << account.GetName () << " cannot afford reward " << reward
+          << " + fee " << fee << " (balance " << account.GetBalance () << ")";
+      return false;
+    }
+
+  return true;
+}
+
+void
+PostOperation::Execute ()
+{
+  const Amount fee = Fee ();
+
+  LOG (INFO)
+      << account.GetName () << " posting a job (reward " << reward
+      << ", collateral " << collateral << ", fee " << fee << ")";
+
+  /* Escrow the reward (tracked in the job row, released on settlement) and
+     burn the posting fee (removed from circulation, never credited).  */
+  LockJobCoins (account, reward);
+  account.AddBalance (-fee);
+
+  auto job = jc.jobs.CreateNew (account.GetName (), reward, collateral,
+                                jc.ctx.Timestamp () + deadlineSecs);
+  ApplyDealPost (jc, terms, *job);
+}
+
+/* ************************************************************************** */
+
+/**
+ * ASSIGN: the poster names (or changes) the designated worker before anyone
+ * has accepted.
+ */
+class AssignOperation : public JobOperation
+{
+
+private:
+
+  const Database::IdT jobId;
+  const std::string designated;
+
+public:
+
+  AssignOperation (Account& a, const JobContext& c, const Database::IdT id,
+                   const std::string& w)
+    : JobOperation(a, c), jobId(id), designated(w)
+  {}
+
+  bool IsValid () const override;
+  void Execute () override;
+
+};
+
+bool
+AssignOperation::IsValid () const
+{
+  const auto job = jc.jobs.GetById (jobId);
+  if (job == nullptr || job->GetStatus () != Job::Status::OPEN)
+    {
+      LOG (WARNING) << "Job " << jobId << " not open to assign";
+      return false;
+    }
+  if (job->GetPoster () != account.GetName ())
+    {
+      LOG (WARNING)
+          << account.GetName () << " does not own job " << jobId;
+      return false;
+    }
+  /* Assignment designates an exclusive worker before anyone accepts: on the
+     one assignable type -- the generic deal -- only the designated worker may
+     accept from here on (the generic accept gate enforces the pin).  It does
+     NOT set invite_only: that flag is the POST-time born-private
+     discriminator, and a publicly posted deal stays invite_only=false once
+     assigned (proto JobData.invite_only -- exclusive is the pair
+     `invite_only || designated_worker != ""`, not the bit alone).  */
+  /* An expired listing is the sweep's to void (see JobIsDue); a designation
+     landing in the gap would be dead data on a job that never runs.  */
+  if (JobIsDue (*job, jc))
+    {
+      LOG (WARNING)
+          << "Job " << jobId << " is at or past its deadline; cannot assign";
+      return false;
+    }
+  if (designated == account.GetName ())
+    {
+      LOG (WARNING) << "Cannot designate oneself as worker for job " << jobId;
+      return false;
+    }
+  /* The designee must not be the deal's bound arbiter: an arbiter-worker
+     would judge its own dispute.  The accept gate already bars it, so
+     assigning it could only strand the row until expiry (F7).  */
+  const std::string& arbiter = job->GetProto ().arbiter ();
+  if (!arbiter.empty () && designated == arbiter)
+    {
+      LOG (WARNING)
+          << "Cannot designate the bound arbiter as worker for job " << jobId;
+      return false;
+    }
+
+  const auto w = jc.accounts.GetByName (designated);
+  if (w == nullptr || !w->IsInitialised ())
+    {
+      LOG (WARNING) << "Designated worker " << designated << " does not exist";
+      return false;
+    }
+
+  return true;
+}
+
+void
+AssignOperation::Execute ()
+{
+  auto job = jc.jobs.GetById (jobId);
+  CHECK (job != nullptr) << "Job disappeared: " << jobId;
+  LOG (INFO)
+      << account.GetName () << " assigning job " << jobId << " to "
+      << designated;
+  job->MutableProto ().set_designated_worker (designated);
+}
+
+/* ************************************************************************** */
+
+/**
+ * ACCEPT: the worker locks their collateral and binds the job to them.  The
+ * designated-worker rules are enforced here, plus the deal's own
+ * arbiter-cannot-accept check (ValidateDealAccept).
+ */
+class AcceptOperation : public JobOperation
+{
+
+private:
+
+  const Database::IdT jobId;
+
+public:
+
+  AcceptOperation (Account& a, const JobContext& c, const Database::IdT id)
+    : JobOperation(a, c), jobId(id)
+  {}
+
+  bool IsValid () const override;
+  void Execute () override;
+
+};
+
+bool
+AcceptOperation::IsValid () const
+{
+  const auto job = jc.jobs.GetById (jobId);
+  if (job == nullptr || job->GetStatus () != Job::Status::OPEN)
+    {
+      LOG (WARNING) << "Job " << jobId << " not open to accept";
+      return false;
+    }
+
+  /* An expired listing is the sweep's to void (see JobIsDue).  */
+  if (JobIsDue (*job, jc))
+    {
+      LOG (WARNING)
+          << "Job " << jobId << " is at or past its deadline; cannot accept";
+      return false;
+    }
+
+  if (job->GetPoster () == account.GetName ())
+    {
+      LOG (WARNING)
+          << account.GetName () << " cannot accept own job " << jobId;
+      return false;
+    }
+
+  /* Designated-worker gate.  An invite-only deal with no designee yet (posted
+     with w:"") is acceptable by NOBODY -- the poster invites later via ASSIGN.
+     An empty designated_worker is otherwise "open to all", so the flag is what
+     disambiguates the private-unassigned state (design §3).  */
+  const std::string& designated = job->GetProto ().designated_worker ();
+  if (job->GetProto ().invite_only () && designated.empty ())
+    {
+      LOG (WARNING)
+          << "Job " << jobId << " is invite-only with no designee yet";
+      return false;
+    }
+  if (!designated.empty () && designated != account.GetName ())
+    {
+      LOG (WARNING)
+          << "Job " << jobId << " is designated to " << designated
+          << ", not " << account.GetName ();
+      return false;
+    }
+
+  if (!ValidateDealAccept (*job, account))
+    return false;
+
+  if (account.GetBalance () < job->GetCollateral ())
+    {
+      LOG (WARNING)
+          << account.GetName () << " cannot afford collateral "
+          << job->GetCollateral () << " for job " << jobId;
+      return false;
+    }
+
+  return true;
+}
+
+void
+AcceptOperation::Execute ()
+{
+  auto job = jc.jobs.GetById (jobId);
+  CHECK (job != nullptr) << "Job disappeared: " << jobId;
+
+  LOG (INFO)
+      << account.GetName () << " accepting job " << jobId
+      << ", locking collateral " << job->GetCollateral ();
+
+  LockJobCoins (account, job->GetCollateral ());
+  job->SetWorker (account.GetName ());
+  job->SetStatus (Job::Status::ACCEPTED);
+}
+
+/* ************************************************************************** */
+
+/**
+ * CANCEL: the poster withdraws an OPEN job before anyone accepts, and the
+ * reward is refunded (the posting fee is not).
+ */
+class CancelOperation : public JobOperation
+{
+
+private:
+
+  const Database::IdT jobId;
+
+public:
+
+  CancelOperation (Account& a, const JobContext& c, const Database::IdT id)
+    : JobOperation(a, c), jobId(id)
+  {}
+
+  bool IsValid () const override;
+  void Execute () override;
+
+};
+
+bool
+CancelOperation::IsValid () const
+{
+  const auto job = jc.jobs.GetById (jobId);
+  if (job == nullptr || job->GetStatus () != Job::Status::OPEN)
+    {
+      LOG (WARNING) << "Job " << jobId << " not open to cancel";
+      return false;
+    }
+  if (job->GetPoster () != account.GetName ())
+    {
+      LOG (WARNING)
+          << account.GetName () << " does not own job " << jobId
+          << " to cancel";
+      return false;
+    }
+
+  /* An expired listing is the sweep's to void (see JobIsDue); a cancel in
+     the gap would record CANCELLED history for a job that expired.  The
+     refund is the same either way.  */
+  if (JobIsDue (*job, jc))
+    {
+      LOG (WARNING)
+          << "Job " << jobId << " is at or past its deadline; cannot cancel";
+      return false;
+    }
+
+  return true;
+}
+
+void
+CancelOperation::Execute ()
+{
+  auto job = jc.jobs.GetById (jobId);
+  CHECK (job != nullptr) << "Job disappeared: " << jobId;
+
+  const Amount reward = job->GetReward ();
+
+  LOG (INFO)
+      << account.GetName () << " cancelling job " << jobId
+      << ", refunding reward " << reward;
+
+  ReleaseJobCoins (account, reward);
+  DeleteSettled (jc.jobs, std::move (job));
+}
+
+/* ************************************************************************** */
+
+/**
+ * DEAL: the escrow-deal-specific actions beyond the generic post/accept --
+ * confirm (happy path), dispute, and the bound arbiter's ruling.  One "dl"
+ * object per op, exactly two members:
+ *   {"dl":<id>,"confirm":true}   either party marks the deal done
+ *   {"dl":<id>,"dispute":true}   either party contests it
+ *   {"dl":<id>,"rule":<p>}       the bound arbiter rules p in {0,10,...,100}
+ */
+class DealOperation : public JobOperation
+{
+
+public:
+
+  enum class Kind { CONFIRM, DISPUTE, RULE };
+
+private:
+
+  const Database::IdT id;
+  const Kind kind;
+  /** The ruling percentage, only for RULE (range-checked at parse).  */
+  const int rulP;
+
+public:
+
+  DealOperation (Account& a, const JobContext& c, const Database::IdT i,
+                 const Kind k, const int p)
+    : JobOperation(a, c), id(i), kind(k), rulP(p)
+  {}
+
+  bool IsValid () const override;
+  void Execute () override;
+
+};
+
+bool
+DealOperation::IsValid () const
+{
+  auto job = jc.jobs.GetById (id);
+  if (job == nullptr)
+    return false;
+  /* Every deal action needs the escrow locked (both stakes in).  */
+  if (job->GetStatus () != Job::Status::ACCEPTED)
+    {
+      LOG (WARNING) << "Deal op on a non-accepted deal " << id;
+      return false;
+    }
+
+  /* An elapsed deal is the sweep's to settle (see JobIsDue), exactly like
+     every other lifecycle op: a confirm, dispute or ruling landing at or past
+     the end date would still change the settlement of a deal whose outcome is
+     already fixed by the state at its (possibly extended) deadline.  The end
+     date stays a HARD boundary for ops.  v1.1 semantics (design §1): a confirm
+     (any deal, leaving a live counter-move) or a dispute (arbiter-bound only)
+     landing strictly within the row's reaction_window of the deadline is NOT
+     terminal -- DealOperation::Execute extends the deadline to now+window, so
+     the successor move keeps a full window; the extension is one-shot per
+     set-once flag, never shortens, and totals at most 2W.  A no-arbiter dispute
+     is terminal BY DESIGN (its only successor is the sweep's Option-B 50/50 at
+     the unmoved deadline, so an extension would be pure settlement delay).  */
+  if (JobIsDue (*job, jc))
+    {
+      LOG (WARNING)
+          << "Deal " << id << " is at or past its end date; only the sweep"
+          << " settles it now";
+      return false;
+    }
+
+  const auto& d = job->GetProto ();
+  const std::string me = account.GetName ();
+  const bool isParty = (me == job->GetPoster () || me == job->GetWorker ());
+
+  switch (kind)
+    {
+    case Kind::CONFIRM:
+      if (!isParty)
+        return false;
+      /* Once disputed, only the arbiter's ruling settles the deal (or the
+         sweep's 50/50 fallback) -- the documented DealPayload invariant.
+         A both-confirm racing the ruling would bypass the arbiter.  */
+      if (d.disputed ())
+        return false;
+      /* No double-confirm.  */
+      if (me == job->GetPoster () && d.poster_confirmed ())
+        return false;
+      if (me == job->GetWorker () && d.worker_confirmed ())
+        return false;
+      return true;
+
+    case Kind::DISPUTE:
+      if (!isParty)
+        return false;
+      if (d.disputed ())
+        return false;
+      /* A confirmation is irrevocable and waives only the confirmer's OWN
+         dispute right (design §6.2): the counterparty may still dispute a
+         shoddy job.  Without this guard a confirmed all-clear could be
+         revoked -- downgrading the one-confirm p=100 timeout into the
+         disputed 50/50 fallback, or (with a poster-owned arbiter) reopening
+         a ruling path after the worker relied on the confirmation.  */
+      if (me == job->GetPoster () && d.poster_confirmed ())
+        return false;
+      if (me == job->GetWorker () && d.worker_confirmed ())
+        return false;
+      return true;
+
+    case Kind::RULE:
+      /* Only the bound arbiter may rule, and only a raised dispute.  */
+      if (d.arbiter ().empty () || me != d.arbiter ())
+        return false;
+      if (!d.disputed ())
+        return false;
+      return true;
+    }
+
+  return false;
+}
+
+void
+DealOperation::Execute ()
+{
+  auto job = jc.jobs.GetById (id);
+  CHECK (job != nullptr) << "Deal disappeared: " << id;
+  auto& d = job->MutableProto ();
+
+  switch (kind)
+    {
+    case Kind::CONFIRM:
+      if (account.GetName () == job->GetPoster ())
+        d.set_poster_confirmed (true);
+      else
+        d.set_worker_confirmed (true);
+      if (d.poster_confirmed () && d.worker_confirmed ())
+        {
+          /* Both sides agree it is done: release at p=100.  Nothing is left to
+             answer, so no reaction-window extension applies.  */
+          SettleDeal (jc, *job, 100, &account, true,
+                      DealSettleMode::BOTH_CONFIRM);
+          DeleteSettled (jc.jobs, std::move (job));
+          return;
+        }
+      /* A single confirm persists (flushed when the handle destructs); it
+         leaves the counterparty a live confirm-settle or dispute, so a confirm
+         landing in the final window extends the deadline (§1).  */
+      ExtendForReactionWindow (*job, jc.ctx.Timestamp ());
+      return;
+
+    case Kind::DISPUTE:
+      d.set_disputed (true);
+      /* Stamp the dispute time (§2) unconditionally.  An arbiter-bound dispute
+         leaves the arbiter a live ruling move, so a dispute in the final window
+         extends the deadline to guarantee >= W ruling time (§1); a no-arbiter
+         dispute has no successor but the sweep's 50/50, so it never extends. */
+      d.set_dispute_time (jc.ctx.Timestamp ());
+      if (!d.arbiter ().empty ())
+        ExtendForReactionWindow (*job, jc.ctx.Timestamp ());
+      return;
+
+    case Kind::RULE:
+      {
+        SettleDeal (jc, *job, rulP, &account, true, DealSettleMode::RULING);
+        DeleteSettled (jc.jobs, std::move (job));
+      }
+      return;
+    }
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+
+std::unique_ptr<JobOperation>
+JobOperation::Parse (Account& acc, const Json::Value& data,
+                     const JobContext& jc)
+{
+  if (!data.isObject ())
+    return nullptr;
+
+  /* Exactly one of the five discriminator keys must be present.  */
+  const bool hasT = data.isMember ("t");
+  const bool hasS = data.isMember ("s");
+  const bool hasA = data.isMember ("a");
+  const bool hasC = data.isMember ("c");
+  const bool hasDl = data.isMember ("dl");
+  if (hasT + hasS + hasA + hasC + hasDl != 1)
+    return nullptr;
+
+  std::unique_ptr<JobOperation> op;
+
+  if (hasT)
+    {
+      /* POST: {"t":"deal","d":<secs>,"r":<reward>,"co":<collateral>,...}.
+         The listing deadline "d" is required (checked in IsValid).  The "t"
+         value names the operation rather than selecting among kinds: the
+         board carries escrow deals only, so anything else is rejected.  */
+      if (!data["t"].isString () || data["t"].asString () != "deal")
+        return nullptr;
+
+      /* The POST grammar is exactly as strict as the lifecycle ops' below:
+         beyond the generic keys, only the deal term keys are allowed, so a
+         typo'd or unknown member rejects the move instead of being silently
+         ignored.  */
+      static const std::set<std::string> generic = {"t", "d", "r", "co"};
+      const auto& typeKeys = DealPostTermKeys ();
+      for (const auto& member : data.getMemberNames ())
+        if (generic.count (member) == 0
+              && std::find (typeKeys.begin (), typeKeys.end (), member)
+                   == typeKeys.end ())
+          {
+            LOG (WARNING) << "Unknown key \"" << member << "\" in job post";
+            return nullptr;
+          }
+
+      int64_t deadlineSecs = -1;
+      if (data.isMember ("d"))
+        {
+          if (!data["d"].isInt64 () || !xaya::IsIntegerValue (data["d"]))
+            return nullptr;
+          deadlineSecs = data["d"].asInt64 ();
+          if (deadlineSecs < 0)
+            return nullptr;
+        }
+      Amount reward, collateral;
+      if (!CoinAmountFromJson (data["r"], reward)
+            || !CoinAmountFromJson (data["co"], collateral))
+        return nullptr;
+      op = std::make_unique<PostOperation> (acc, jc, deadlineSecs,
+                                            reward, collateral, data);
+    }
+  else if (hasS)
+    {
+      /* ASSIGN: {"s":<id>,"w":<account>} -- exactly those two members.  */
+      if (data.size () != 2)
+        return nullptr;
+      Database::IdT id;
+      if (!IdFromJson (data["s"], id) || !data["w"].isString ())
+        return nullptr;
+      op = std::make_unique<AssignOperation> (acc, jc, id,
+                                              data["w"].asString ());
+    }
+  else if (hasA)
+    {
+      /* ACCEPT: {"a":<id>}.  */
+      if (data.size () != 1)
+        return nullptr;
+      Database::IdT id;
+      if (!IdFromJson (data["a"], id))
+        return nullptr;
+      op = std::make_unique<AcceptOperation> (acc, jc, id);
+    }
+  else if (hasC)
+    {
+      /* CANCEL: {"c":<id>}.  */
+      if (data.size () != 1)
+        return nullptr;
+      Database::IdT id;
+      if (!IdFromJson (data["c"], id))
+        return nullptr;
+      op = std::make_unique<CancelOperation> (acc, jc, id);
+    }
+  else
+    {
+      /* DEAL action: {"dl":<id>, <one of confirm/dispute/rule>} -- exactly two
+         members, exactly one action.  */
+      CHECK (hasDl);
+      if (data.size () != 2)
+        return nullptr;
+      Database::IdT id;
+      if (!IdFromJson (data["dl"], id))
+        return nullptr;
+      const bool hasConfirm = data.isMember ("confirm");
+      const bool hasDispute = data.isMember ("dispute");
+      const bool hasRule = data.isMember ("rule");
+      if (hasConfirm + hasDispute + hasRule != 1)
+        return nullptr;
+      if (hasConfirm)
+        {
+          if (!data["confirm"].isBool () || !data["confirm"].asBool ())
+            return nullptr;
+          op = std::make_unique<DealOperation> (
+              acc, jc, id, DealOperation::Kind::CONFIRM, 0);
+        }
+      else if (hasDispute)
+        {
+          if (!data["dispute"].isBool () || !data["dispute"].asBool ())
+            return nullptr;
+          op = std::make_unique<DealOperation> (
+              acc, jc, id, DealOperation::Kind::DISPUTE, 0);
+        }
+      else
+        {
+          if (!data["rule"].isInt64 () || !xaya::IsIntegerValue (data["rule"]))
+            return nullptr;
+          const int64_t p = data["rule"].asInt64 ();
+          if (p < 0 || p > 100 || p % 10 != 0)
+            return nullptr;
+          op = std::make_unique<DealOperation> (
+              acc, jc, id, DealOperation::Kind::RULE, static_cast<int> (p));
+        }
+    }
+
+  return op;
+}
+
+/* ************************************************************************** */
+/* Per-block hooks (confirmed processing only).                               */
+
+namespace
+{
+
+/**
+ * Locally-constructed table handles for a block hook plus the JobContext they
+ * form.  The hooks are standalone (not nested inside the move processor's
+ * handles), so they own their table handles for the duration of the call.
+ */
+struct BlockHookTables
+{
+  AccountsTable accounts;
+  JobsTable jobs;
+  ParamsTable params;
+
+  explicit BlockHookTables (Database& d)
+    : accounts(d), jobs(d), params(d)
+  {}
+
+  JobContext
+  MakeContext (const pxd::Context& ctx)
+  {
+    return {ctx, accounts, jobs, params};
+  }
+};
+
+} // anonymous namespace
+
+void
+ExpireJobs (Database& db, const Context& ctx)
+{
+  JobsTable jobs(db);
+
+  /* Snapshot the due jobs (fully consuming the query) before mutating any
+     balances or deleting rows.  On idle blocks this is an indexed no-op.  */
+  std::vector<Database::IdT> due;
+  {
+    auto res = jobs.QueryForDeadline (ctx.Timestamp ());
+    while (res.Step ())
+      {
+        auto j = jobs.GetFromResult (res);
+        CHECK_LE (j->GetDeadline (), ctx.Timestamp ())
+            << "Job " << j->GetId () << " with a future deadline in expiry";
+        due.push_back (j->GetId ());
+      }
+  }
+
+  if (due.empty ())
+    return;
+
+  BlockHookTables tables(db);
+  const JobContext jc = tables.MakeContext (ctx);
+  for (const auto id : due)
+    {
+      auto j = tables.jobs.GetById (id);
+      CHECK (j != nullptr);
+      ExpireJob (jc, *j);
+      DeleteSettled (tables.jobs, std::move (j));
+    }
+}
+
+/* ************************************************************************** */
+
+void
+ValidateJobs (Database& db)
+{
+  AccountsTable accounts(db);
+  JobsTable jobs(db);
+
+  auto res = jobs.QueryAll ();
+  while (res.Step ())
+    {
+      auto j = jobs.GetFromResult (res);
+      const auto id = j->GetId ();
+
+      {
+        const auto poster = accounts.GetByName (j->GetPoster ());
+        CHECK (poster != nullptr && poster->IsInitialised ())
+            << "Job " << id << " has an invalid poster";
+      }
+
+      switch (j->GetStatus ())
+        {
+        case Job::Status::OPEN:
+          CHECK (j->GetWorker ().empty ())
+              << "Open job " << id << " has a worker";
+          break;
+        case Job::Status::ACCEPTED:
+          {
+            CHECK (!j->GetWorker ().empty ())
+                << "Accepted job " << id << " has no worker";
+            /* Every worker-setting path guarantees an initialised account
+               (the move-processor's init gate, the assign check), so the
+               validator pins the full invariant -- same as the poster's.  */
+            const auto worker = accounts.GetByName (j->GetWorker ());
+            CHECK (worker != nullptr && worker->IsInitialised ())
+                << "Job " << id << " has an invalid worker";
+          }
+          break;
+        default:
+          LOG (FATAL) << "Job " << id << " has an invalid status";
+        }
+    }
+}
+
+} // namespace pxd

--- a/src/jobs.hpp
+++ b/src/jobs.hpp
@@ -1,0 +1,304 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef PXD_JOBS_HPP
+#define PXD_JOBS_HPP
+
+/*
+    The jobs board: an on-chain escrow-deal system.  A job is an escrowed
+    reward + a worker collateral + a deadline, optionally exclusive to one
+    designated worker, settled by a completion percentage that a bound arbiter
+    dials on a dispute.  This module holds the whole subsystem: the coin
+    escrow, the settlement math, the move-op lifecycle (post/assign/accept/
+    cancel + the deal ops) and the superblock expiry hook.
+
+    The deal is deliberately generic: it subsumes what would otherwise be a
+    catalogue of per-type verification jobs (transport, haul, escort, rental,
+    ...) as a cosmetic type tag rather than bespoke consensus code -- so the
+    chain never has to adjudicate a delivery it cannot observe.
+
+    Confirmed-only: job moves are processed only in the confirmed block path
+    (MoveProcessor), never in the pending path (PendingStateUpdater does not
+    dispatch the "j" key), so it is safe to read ctx.Timestamp() here.  If jobs
+    are ever wired into pending, the timestamp-using guards must be revisited.
+*/
+
+#include "context.hpp"
+
+#include "database/account.hpp"
+#include "database/jobs.hpp"
+#include "database/params.hpp"
+
+#include <json/json.h>
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace pxd
+{
+
+/* ************************************************************************** */
+/* Coin escrow.                                                               */
+
+/*
+   Job settlement moves vCHI directly on account balances and is deliberately
+   FEE-FREE: it must never route through the DEX's PayToSellerAndFee (which
+   skims the trading fee + burn), or a returned collateral would be shaved.
+   Locked coins are not held in any account; they live in the jobs table's
+   reward/collateral columns and are surfaced in balance.reserved.
+*/
+
+/**
+ * Locks coins by removing them from an account's balance (the poster's reward
+ * at post time, the worker's collateral at accept time).  The caller must have
+ * verified sufficient balance first (AddBalance CHECK-fails on overdraft).
+ */
+inline void
+LockJobCoins (Account& a, const Amount amount)
+{
+  CHECK_GE (amount, 0);
+  a.AddBalance (-amount);
+}
+
+/**
+ * Releases locked coins back onto an account's balance: a reward payout, a
+ * collateral return, or a refund.  Fee-free by construction.
+ */
+inline void
+ReleaseJobCoins (Account& a, const Amount amount)
+{
+  CHECK_GE (amount, 0);
+  a.AddBalance (amount);
+}
+
+/* ************************************************************************** */
+/* Escrow-deal settlement (spec escrow-deal-system-design.md §6.3).           */
+
+/**
+ * The split of a settled escrow deal: what the four parties receive.  The sum
+ * is EXACTLY the escrow (reward + collateral); the treasury tax is burned until
+ * a faction treasury exists to receive it (a Phase-4 wiring).
+ */
+struct DealSettlement
+{
+  Amount worker;
+  Amount poster;
+  Amount arbiter;
+  Amount treasury;
+};
+
+/**
+ * Computes the escrow-deal settlement at completion percentage p in [0,100]:
+ * tax and fee fall only on the TRANSACTED value (reward + seized collateral),
+ * never on the worker's returned stake, split between the parties in proportion
+ * to the share each receives, with the remainder pinned to the poster so that
+ * `worker + poster + arbiter + treasury == reward + collateral` EXACTLY for all
+ * inputs (brute-force proven: 0 conservation failures, 0 negatives, endpoints
+ * exact).  taxBps/feeBps are basis points with taxBps + feeBps < 10000.
+ */
+DealSettlement ComputeDealSettlement (Amount reward, Amount collateral, int p,
+                                      int taxBps, int feeBps);
+
+/* ************************************************************************** */
+/* Shared context + helpers.                                                  */
+
+/**
+ * The bundle of database-table handles plus the processing Context that job
+ * operations and the block hooks all need.  It holds references,
+ * so the underlying tables must outlive it (they are the MoveProcessor's
+ * long-lived handles, or locally-constructed ones in the block hooks).
+ */
+struct JobContext
+{
+  const Context& ctx;
+  AccountsTable& accounts;
+  JobsTable& jobs;
+  /** Runtime-parameter reads (admission caps, floors, deal economics).  */
+  const ParamsTable& params;
+};
+
+/* Immutable admission-cap maxima (design escrow-v1.1 §4).  The runtime "param"
+   command stores unbounded int64s, so every consensus read of a
+   liveness-bounding param clamps the ParamsTable overlay to a compile-time
+   ceiling: a fat-fingered or compromised admin key can tighten a cap (or freeze
+   an admission with 0) but never open an unbounded-sweep hole above these
+   values.  A negative override clamps to the floor 0 (a freeze), matching the
+   existing 0=freeze semantics.  The getjobsparams RPC reports the SAME clamped
+   value, so the client previews against exactly what consensus uses.
+
+   EVIDENCE STATUS: the ceilings are headroom bounds, NOT benched limits.  The
+   only settling-block timings we hold (~0.105s at 11x the 10k default) were
+   measured on the superseded jobs-superblocks branch, whose job-type set
+   differs from this one, and no in-tree harness reproduces them here: the
+   largest ordinary sweep test is 200 rows.  Until an ExpireJobs benchmark runs
+   at CAP_MAX_LIVE_JOBS through full block wiring under a stated block-time
+   budget, keep max-live-jobs at its conservative 10k roconfig default and
+   treat the headroom above it as unproven.  */
+constexpr int64_t CAP_MAX_LIVE_JOBS = 100000;
+constexpr int64_t CAP_MAX_JOBS_PER_POSTER = 2000;
+/** Ceiling on the snapshotted deal reaction window (30 days).  */
+constexpr int64_t CAP_DEAL_REACTION_WINDOW = 2592000;
+
+/**
+ * Reads a runtime param (override over its roconfig default) and clamps it to
+ * [floor, ceiling] -- the ONE path every consensus read of a capped param and
+ * the getjobsparams RPC share, so no second unclamped path can ever exist.
+ */
+inline int64_t
+CappedParam (const ParamsTable& params, const std::string& name,
+             const int64_t rocoDefault, const int64_t ceiling,
+             const int64_t floor = 0)
+{
+  return std::clamp<int64_t> (params.Get (name, rocoDefault), floor, ceiling);
+}
+
+/**
+ * How a deal left the board.  Not persisted: it selects settlement BEHAVIOUR
+ * -- whether the bound arbiter is credited with a ruling, and whether the two
+ * parties' dispute counters are bumped.
+ */
+enum class DealSettleMode
+{
+  /** Both parties confirmed: released at p=100.  */
+  BOTH_CONFIRM,
+  /** The bound arbiter ruled the given p.  */
+  RULING,
+  /** End-date sweep with exactly one confirm: p=100.  */
+  SINGLE_CONFIRM,
+  /** Sweep on an unruled dispute: p=50, fee forfeited.  */
+  GHOST_SPLIT,
+};
+
+/**
+ * Settles an ACCEPTED escrow deal at completion percentage p: releases the
+ * §6.3 split to the worker, poster and (if any) arbiter, burns the treasury
+ * tax, and bumps the worker's DEAL reputation counters (value-gated: only when
+ * p>0 and a real tax was burned).  `executor` is the move's account handle
+ * when settling inside a move op (confirm / rule) -- credited through it to
+ * avoid a second live handle on the same row; it is nullptr in the block-hook
+ * (expiry) path where no account handle is live.  Credits are accumulated per
+ * account name so poster==arbiter or a self-arbiter never double-opens a row.
+ * `payArbiterFee` is false only on the ghosted-dispute timeout, where the
+ * arbiter FORFEITS its fee (each party keeps its own fee share): paying the
+ * full fee for ignoring the one dispute it was hired to rule would make
+ * ghosting strictly better than ruling.
+ */
+void SettleDeal (const JobContext& jc, Job& job, int p, Account* executor,
+                 bool payArbiterFee, DealSettleMode mode);
+
+/**
+ * Refunds both stakes of an ACCEPTED deal (worker <- collateral, poster <-
+ * reward): the neither-party-acted timeout.  Hook-path only (no live account
+ * handles).
+ */
+void RefundBothDeal (const JobContext& jc, Job& job);
+
+/**
+ * Settles a job whose deadline has passed (confirmed block only).  Handles
+ * both the OPEN case (void + refund the poster) and the ACCEPTED case (the
+ * deal resolves confirm-aware).  The caller deletes the row afterwards.
+ */
+void ExpireJob (const JobContext& jc, Job& job);
+
+/* ************************************************************************** */
+/* The move-op lifecycle.                                                     */
+
+/**
+ * A single jobs-board operation parsed from one element of the "j" array
+ * (post / assign / accept / cancel / deal action).  Mirrors the DexOperation
+ * family.
+ */
+class JobOperation
+{
+
+protected:
+
+  JobContext jc;
+
+  /** The account triggering the operation.  */
+  Account& account;
+
+  JobOperation (Account& a, const JobContext& c)
+    : jc(c), account(a)
+  {}
+
+public:
+
+  virtual ~JobOperation () = default;
+
+  /** Returns true if the operation is valid per game and move rules.  */
+  virtual bool IsValid () const = 0;
+
+  /** Fully executes the update corresponding to this operation.  */
+  virtual void Execute () = 0;
+
+  /**
+   * Tries to parse a job operation from one "j"-array element.  Returns
+   * nullptr if the format is invalid (unknown or non-unique t/s/a/c/dl
+   * discriminator, malformed fields).
+   */
+  static std::unique_ptr<JobOperation> Parse (Account& acc,
+                                              const Json::Value& data,
+                                              const JobContext& jc);
+
+};
+
+/* ************************************************************************** */
+/* Superblock hooks (confirmed processing only).                              */
+
+/**
+ * Expires all jobs whose deadline has been reached at the current
+ * block timestamp, running each type's OnExpire settlement and deleting the
+ * rows.  Called once per SUPERBLOCK (a deadline passing on an ordinary block
+ * settles at the next superblock sweep), AFTER kill processing (the normative
+ * phase order: an entity dying in the boundary superblock is a death, not a
+ * survival); on the (vast majority of) sweeps where nothing is due it is an
+ * indexed no-op that touches no rows.
+ *
+ * The sweep itself is deliberately uncapped (no continuation across
+ * blocks): a deterministic sweep cap would defer settlement of already-due
+ * jobs to later blocks, re-opening the very window (mutable inputs after
+ * the deadline) that JobIsDue exists to close.  The hard bound lives at the
+ * DOOR instead: the admission caps in PostOperation::IsValid (max live
+ * jobs in total / per poster,
+ * admin-tunable via the "param" command) mean no sweep, entity cascade
+ * or payout can ever exceed the capped board -- every due row inside it
+ * was paid for (posting fee burned, escrow locked), and settlement is a
+ * constant amount of work per job walked straight off the (deadline, id)
+ * index with no sort.
+ *
+ * Should a bound ever be demanded by measurement, the designated mechanism
+ * is ADMISSION control (tightening the caps above), which bounds every
+ * future cohort at posting time without touching the settlement semantics
+ * of rows already on the board -- never a sweep cap.
+ */
+void ExpireJobs (Database& db, const Context& ctx);
+
+/**
+ * Validates jobs-table invariants as part of ValidateStateSlow: poster and
+ * worker accounts exist and match the status, and every job has a deadline.
+ */
+void ValidateJobs (Database& db);
+
+} // namespace pxd
+
+#endif // PXD_JOBS_HPP

--- a/src/jobs_tests.cpp
+++ b/src/jobs_tests.cpp
@@ -1,0 +1,1397 @@
+/*
+    GSP for the Taurion blockchain game
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "jobs.hpp"
+
+#include "gamestatejson.hpp"
+#include "jsonutils.hpp"
+#include "testutils.hpp"
+
+#include "database/building.hpp"
+#include "database/character.hpp"
+#include "database/dbtest.hpp"
+#include "database/params.hpp"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <limits>
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace pxd
+{
+namespace
+{
+
+/** A comfortable base consensus timestamp for the tests.  */
+constexpr int64_t BASE_TS = 1000000;
+/** A comfortable listing-window length in seconds.  */
+constexpr int64_t DAY = 86400;
+
+/* ************************************************************************** */
+
+class JobsTests : public DBTestWithSchema
+{
+
+private:
+
+  AccountsTable::Handle
+  GetAccount (const std::string& name)
+  {
+    auto a = accounts.GetByName (name);
+    if (a == nullptr)
+      return accounts.CreateNew (name);
+    return a;
+  }
+
+protected:
+
+  AccountsTable accounts;
+  BuildingsTable buildings;
+  CharacterTable characters;
+  JobsTable jobs;
+  ParamsTable params;
+
+  ContextForTesting ctx;
+
+  JobsTests ()
+    : accounts(db), buildings(db), characters(db), jobs(db), params(db)
+  {
+    ctx.SetHeight (100);
+    ctx.SetTimestamp (BASE_TS);
+
+    MakeAccount ("poster", Faction::RED, 1000000);
+    MakeAccount ("courier", Faction::RED, 1000000);
+    MakeAccount ("courier2", Faction::RED, 1000000);
+    MakeAccount ("green", Faction::GREEN, 1000000);
+
+    /* Building 1 = own faction (valid destination), 2 = neutral/ancient
+       (valid), 3 = enemy faction (invalid destination for a RED poster).  */
+    CHECK_EQ (buildings.CreateNew ("checkmark", "poster", Faction::RED)
+                  ->GetId (), 1);
+    CHECK_EQ (buildings.CreateNew ("checkmark", "", Faction::ANCIENT)
+                  ->GetId (), 2);
+    CHECK_EQ (buildings.CreateNew ("checkmark", "green", Faction::GREEN)
+                  ->GetId (), 3);
+
+    /* The minimum-reward floors are runtime parameters (roconfig defaults
+       100 and 1000 vCHI); the tests use small rewards throughout, so lower
+       them exactly as an admin would.  The roconfig-default fallback itself
+       is exercised end-to-end by jobs_caps.py.  */
+    params.Set ("min-job-reward", 1);
+    params.Set ("min-deal-reward", 1);
+  }
+
+  JobContext
+  Ctx ()
+  {
+    return {ctx, accounts, jobs, params};
+  }
+
+  std::unique_ptr<JobOperation>
+  Parse (Account& a, const Json::Value& op)
+  {
+    const JobContext jc = Ctx ();
+    return JobOperation::Parse (a, op, jc);
+  }
+
+  void
+  MakeAccount (const std::string& name, const Faction f, const Amount bal)
+  {
+    auto a = accounts.CreateNew (name);
+    a->SetFaction (f);
+    a->AddBalance (bal);
+  }
+
+  Amount
+  Balance (const std::string& name)
+  {
+    auto a = accounts.GetByName (name);
+    return a == nullptr ? 0 : a->GetBalance ();
+  }
+
+  /** Returns whether the JSON string parses to a well-formed operation.  */
+  bool
+  ParseOk (const std::string& data)
+  {
+    auto a = GetAccount ("poster");
+    return Parse (*a, ParseJson (data)) != nullptr;
+  }
+
+  /**
+   * Parses, validates and (if valid) executes an operation for the account.
+   * The format must be valid.  Returns whether it was valid + executed.
+   */
+  bool
+  Process (const std::string& name, const std::string& data)
+  {
+    auto a = GetAccount (name);
+    auto op = Parse (*a, ParseJson (data));
+    CHECK (op != nullptr) << "Format invalid: " << data;
+    if (!op->IsValid ())
+      return false;
+    op->Execute ();
+    return true;
+  }
+
+  /** Returns the ID of the single job currently in the table.  */
+  Database::IdT
+  OnlyJobId ()
+  {
+    auto res = jobs.QueryAll ();
+    CHECK (res.Step ());
+    const auto id = jobs.GetFromResult (res)->GetId ();
+    CHECK (!res.Step ());
+    return id;
+  }
+
+  /** Returns the highest job ID in the table (i.e. the one just posted).  */
+  Database::IdT
+  LatestJobId ()
+  {
+    Database::IdT best = 0;
+    auto res = jobs.QueryAll ();
+    while (res.Step ())
+      {
+        const auto id = jobs.GetFromResult (res)->GetId ();
+        if (id > best)
+          best = id;
+      }
+    CHECK_GT (best, 0);
+    return best;
+  }
+
+  bool
+  JobExists (const Database::IdT id)
+  {
+    return jobs.GetById (id) != nullptr;
+  }
+
+};
+class DealTests : public JobsTests
+{
+
+protected:
+
+  /** Returns (deals_completed, deals_value_completed) for an account.  */
+  std::pair<unsigned, Amount>
+  DealStats (const std::string& name)
+  {
+    const auto& pb = accounts.GetByName (name)->GetProto ();
+    return {pb.deals_completed (), pb.deals_value_completed ()};
+  }
+
+  /** Returns the POSTER mirror (deals_posted_completed, deals_posted_value).
+      Gated on the same creditRep bool as DealStats above, so the treasury>=1
+      anti-wash boundary needs no separate case: both sides share one gate.  */
+  std::pair<unsigned, Amount>
+  PosterStats (const std::string& name)
+  {
+    const auto& pb = accounts.GetByName (name)->GetProto ();
+    return {pb.deals_posted_completed (), pb.deals_posted_value ()};
+  }
+
+  /** Returns deals_disputed for an account.  */
+  unsigned
+  Disputed (const std::string& name)
+  {
+    return accounts.GetByName (name)->GetProto ().deals_disputed ();
+  }
+
+  /** Returns (arbiter_rulings, arbiter_value_ruled) for an account.  There is
+      deliberately no ghost counter to read: see BumpArbiterRulingStats.  */
+  std::pair<unsigned, Amount>
+  ArbiterStats (const std::string& name)
+  {
+    const auto& pb = accounts.GetByName (name)->GetProto ();
+    return {pb.arbiter_rulings (), pb.arbiter_value_ruled ()};
+  }
+
+  /** The pot (reward + collateral) of the standard fixture deal, which is what
+      a ruling on it credits to the arbiter's value counter.  */
+  static constexpr Amount STD_POT = 5000 + 5000;
+
+  /** Posts a standard deal (reward 5000, collateral 5000, arbiter courier2,
+      fee 10%).  Pass arbiter="" for a no-arbiter deal.  Returns its id.  */
+  Database::IdT
+  PostDeal (const std::string& arbiter = "courier2", const Amount co = 5000)
+  {
+    std::string t
+        = R"({"t":"deal","d":86400,"r":5000,"co":)" + std::to_string (co)
+          + R"(,"tag":1,"terms":"haul it")";
+    if (!arbiter.empty ())
+      t += R"(,"arbiter":")" + arbiter + R"(","fee":1000)";
+    t += "}";
+    CHECK (Process ("poster", t));
+    return LatestJobId ();
+  }
+
+  /** Posts + has courier accept.  Returns the deal id.  */
+  Database::IdT
+  PostAcceptDeal (const std::string& arbiter = "courier2",
+                  const Amount co = 5000)
+  {
+    const auto id = PostDeal (arbiter, co);
+    CHECK (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+    return id;
+  }
+
+  /** Advances the clock past the deal deadline and runs the expiry sweep.  */
+  void
+  Expire ()
+  {
+    ctx.SetTimestamp (BASE_TS + DAY + 50);
+    ExpireJobs (db, ctx);
+  }
+
+  /** Renders the live board JSON row for a job id (null if it is not live).  */
+  Json::Value
+  LiveJson (const Database::IdT id)
+  {
+    GameStateJson gsj(db, ctx);
+    const Json::Value arr = gsj.Jobs ();
+    for (const auto& e : arr)
+      if (e["id"].asUInt64 () == static_cast<Json::UInt64> (id))
+        return e;
+    return Json::Value ();
+  }
+
+  /**
+   * Asserts the terminal state of a no-arbiter GHOST_SPLIT on the standard
+   * 5000/5000 deal at the default 3% tax.  p=50 pays the worker 4925 (its 2500
+   * reward share minus 75 tax plus its 2500 returned collateral), returns the
+   * poster the remaining 4850 (its 5000 reward and 5000 collateral, less the
+   * worker's 4925 and the 225 burned tax), and burns 225 to the treasury.  The
+   * history records mode ghost-split at settledp 50 with NO feepaid key -- no
+   * arbiter was ever bound, so no fee schedule exists to honour or forfeit.
+   */
+  void
+  ExpectNoArbiterGhostSplit (const Database::IdT id)
+  {
+    EXPECT_FALSE (JobExists (id));
+    EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 4925);
+    EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50 + 4850);
+    /* THE trap in the arbiter record: GHOST_SPLIT is also how a deal that
+       never named an arbiter settles a dispute, so no arbiter counter may move
+       here.  courier2 (the arbiter of every OTHER deal in this fixture) is a
+       bystander to these and must stay untouched -- otherwise a ghosting
+       penalty would land on whoever happens to arbitrate elsewhere.  Both
+       parties still carry the dispute itself.  */
+    EXPECT_EQ (ArbiterStats ("courier2"),
+               std::make_pair (0u, static_cast<Amount> (0)));
+    EXPECT_EQ (Disputed ("poster"), 1u);
+    EXPECT_EQ (Disputed ("courier"), 1u);
+  }
+
+  /** The deal actions as one-liners (all through validate + execute).  */
+  bool Confirm (const std::string& who, const Database::IdT id)
+  {
+    return Process (who,
+        R"({"dl":)" + std::to_string (id) + R"(,"confirm":true})");
+  }
+  bool Dispute (const std::string& who, const Database::IdT id)
+  {
+    return Process (who,
+        R"({"dl":)" + std::to_string (id) + R"(,"dispute":true})");
+  }
+  bool Rule (const std::string& who, const Database::IdT id, const int p)
+  {
+    return Process (who, R"({"dl":)" + std::to_string (id) + R"(,"rule":)"
+                          + std::to_string (p) + "}");
+  }
+
+  /** The live deadline / snapshotted reaction window of a deal row.  */
+  int64_t Deadline (const Database::IdT id)
+  { return jobs.GetById (id)->GetDeadline (); }
+  int64_t Rwindow (const Database::IdT id)
+  { return jobs.GetById (id)->GetProto ().reaction_window (); }
+
+};
+
+TEST_F (DealTests, HappyPathBothConfirm)
+{
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_TRUE (JobExists (id));    // one confirm: still open
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_FALSE (JobExists (id));   // both confirmed: settled + deleted
+  /* p=100: worker <- 5000 - 150(tax) - 500(fee) + 5000(collateral) = 9350;
+     arbiter <- 500; treasury 150 burned; poster <- 0.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9350);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 500);
+  EXPECT_EQ (DealStats ("courier"), std::make_pair (1u, static_cast<Amount> (5000)));
+  /* The poster's mirror of the same settlement, and a clean deal that never
+     troubled the arbiter: no dispute on either party, no arbiter record.  */
+  EXPECT_EQ (PosterStats ("poster"), std::make_pair (1u, static_cast<Amount> (5000)));
+  EXPECT_EQ (Disputed ("poster"), 0u);
+  EXPECT_EQ (Disputed ("courier"), 0u);
+  EXPECT_EQ (ArbiterStats ("courier2"),
+             std::make_pair (0u, static_cast<Amount> (0)));
+}
+
+TEST_F (DealTests, DisputeArbiterRulesPartial)
+{
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_TRUE (Rule ("courier2", id, 30));
+  EXPECT_FALSE (JobExists (id));
+  /* p=30: worker 2805, poster 6090, arbiter 850, treasury 255.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 2805);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 850);
+  /* All three records move: both sides carry the dispute, the arbiter carries
+     the ruling it actually delivered, and both value counters scale with p
+     (5000 * 30/100), so a low ruling credits proportionally less.  */
+  EXPECT_EQ (DealStats ("courier"), std::make_pair (1u, static_cast<Amount> (1500)));
+  EXPECT_EQ (PosterStats ("poster"), std::make_pair (1u, static_cast<Amount> (1500)));
+  EXPECT_EQ (Disputed ("poster"), 1u);
+  EXPECT_EQ (Disputed ("courier"), 1u);
+  /* The arbiter's value counter takes the whole POT it directed, not the
+     worker's share: a p=30 ruling decided the fate of all 10000 just as much
+     as a p=100 one would.  */
+  EXPECT_EQ (ArbiterStats ("courier2"), std::make_pair (1u, STD_POT));
+}
+
+TEST_F (DealTests, DisputeArbiterRulesFullCompletion)
+{
+  /* The top of the ruling range, which the other ruling tests skip: p=100
+     pays out exactly as a both-confirm does (the poster's transacted share is
+     zero, so it bears no tax and no fee), but through the RULING path -- so the
+     history mode differs and the arbiter's record moves.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Dispute ("courier", id));
+  EXPECT_TRUE (Rule ("courier2", id, 100));
+  EXPECT_FALSE (JobExists (id));
+  /* p=100: worker 5000 - 150(tax) - 500(fee) + 5000(collateral) = 9350;
+     arbiter 500; treasury 150 burned; poster 0 back beyond its posting fee.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9350);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 500);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50);
+  EXPECT_EQ (DealStats ("courier"), std::make_pair (1u, static_cast<Amount> (5000)));
+  EXPECT_EQ (PosterStats ("poster"), std::make_pair (1u, static_cast<Amount> (5000)));
+  /* A full-completion ruling is still a dispute for both parties -- the deal
+     needed one to end, which is exactly what the counter says.  */
+  EXPECT_EQ (Disputed ("poster"), 1u);
+  EXPECT_EQ (Disputed ("courier"), 1u);
+  EXPECT_EQ (ArbiterStats ("courier2"), std::make_pair (1u, STD_POT));
+}
+
+TEST_F (DealTests, TimeoutGhostSplits5050)
+{
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Dispute ("courier", id));
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  /* p=50 with the fee FORFEITED (the arbiter ghosted the one dispute it was
+     hired to rule): worker 2500 - 75(tax) + 2500(collateral) = 4925; the
+     arbiter gets nothing; treasury 225 burned; poster keeps its fee share
+     too.  Ruling must always pay the arbiter better than ghosting.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 4925);
+  EXPECT_EQ (Balance ("courier2"), 1000000);
+  /* L3: a ghost split is a tax-bearing settlement with p>0, so it DOES bump
+     the worker's deal record -- deals_completed counts these (not just clean
+     completions), and the value tracks the earned reward share R*50/100 = 2500,
+     not the full 5000 reward.  Phase-2 reputation must read the counter this
+     way.  */
+  EXPECT_EQ (DealStats ("courier"),
+             std::make_pair (1u, static_cast<Amount> (2500)));
+  /* The poster's mirror follows the same p.  */
+  EXPECT_EQ (PosterStats ("poster"), std::make_pair (1u, static_cast<Amount> (2500)));
+  EXPECT_EQ (Disputed ("poster"), 1u);
+  EXPECT_EQ (Disputed ("courier"), 1u);
+  /* This IS an arbiter ghost, and it must leave NO mark on the arbiter's
+     account record -- the poster bound courier2 unilaterally, so a permanent
+     counter here would be inflictable on any non-consenting account (see
+     ArbiterGhostLeavesNoMarkOnNonConsentingAccount).  The ghost is still fully
+     attributable from the history row above: mode ghost-split with
+     feepaid=false, plus the stamped disputetime.  The fee forfeiture is the
+     punishment consensus does apply.  */
+  EXPECT_EQ (ArbiterStats ("courier2"),
+             std::make_pair (0u, static_cast<Amount> (0)));
+}
+
+TEST_F (DealTests, ArbiterGhostLeavesNoMarkOnNonConsentingAccount)
+{
+  /* A post binds an arbiter UNILATERALLY: it names any initialised account and
+     there is no consent move, no acceptance, no rejection and no revocation --
+     the named account need not even know the deal exists.  So two colluding
+     accounts can drive any third one through a full dispute-and-ghost cycle for
+     the price of the burn on one throwaway deal.  That is precisely why the
+     account proto carries no ghost counter: it would be a permanent, publicly
+     queried mark inflictable on a bystander, and consensus has no way to tell
+     an unwilling arbiter from a negligent one.
+
+     green is the bystander here.  It signs nothing -- every move below is sent
+     by poster or courier -- and its record must be untouched afterwards, over
+     both fee shapes (a fee makes the arbiter a payee on the happy path, so it
+     is the case most likely to reach for the account row).  */
+  int64_t clock = BASE_TS;
+  for (const std::string& fee : {std::string (), std::string (R"(,"fee":1000)")})
+    {
+      ctx.SetTimestamp (clock);
+      ASSERT_TRUE (Process ("poster",
+          R"({"t":"deal","d":86400,"r":1000,"co":0,"terms":"bait",)"
+          R"("arbiter":"green")" + fee + "}"));
+      const auto id = LatestJobId ();
+      ASSERT_TRUE (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+      ASSERT_TRUE (Dispute ("poster", id));
+
+      clock += DAY + 50;
+      ctx.SetTimestamp (clock);
+      ExpireJobs (db, ctx);
+      ASSERT_FALSE (JobExists (id));
+    }
+
+  EXPECT_EQ (ArbiterStats ("green"),
+             std::make_pair (0u, static_cast<Amount> (0)));
+  EXPECT_EQ (Disputed ("green"), 0u);
+  EXPECT_EQ (DealStats ("green"), std::make_pair (0u, static_cast<Amount> (0)));
+  EXPECT_EQ (PosterStats ("green"), std::make_pair (0u, static_cast<Amount> (0)));
+  /* Nor does a ghosted arbiter collect anything: the fee is forfeited, so the
+     only balance that moved is the colluders' burn.  */
+  EXPECT_EQ (Balance ("green"), 1000000);
+}
+
+TEST_F (DealTests, TimeoutSingleConfirmPaysWorker)
+{
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Confirm ("courier", id));
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  /* one confirm at timeout => p=100.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9350);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 500);
+  /* A quiet timeout is not a dispute: the poster's payout is on record, but
+     neither party carries a dispute and the arbiter was never called on.  */
+  EXPECT_EQ (PosterStats ("poster"), std::make_pair (1u, static_cast<Amount> (5000)));
+  EXPECT_EQ (Disputed ("poster"), 0u);
+  EXPECT_EQ (Disputed ("courier"), 0u);
+  EXPECT_EQ (ArbiterStats ("courier2"),
+             std::make_pair (0u, static_cast<Amount> (0)));
+}
+
+TEST_F (DealTests, TimeoutNeitherConfirmRefundsBoth)
+{
+  const auto id = PostAcceptDeal ();
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  /* Refund both, arbiter bound: worker <- full collateral, poster <- full
+     reward (only the posting fee was burned at post), arbiter untouched;
+     nothing is taxed or forfeited at settlement.  M1: the untaxed
+     neither-acted refund is the pinned behaviour.  */
+  EXPECT_EQ (Balance ("courier"), 1000000);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 50);
+  EXPECT_EQ (Balance ("courier2"), 1000000);
+  /* A no-fault refund moves NO record at all, on any of the three roles --
+     nobody worked, nobody was paid, nobody was judged.  */
+  EXPECT_EQ (DealStats ("courier"), std::make_pair (0u, static_cast<Amount> (0)));
+  EXPECT_EQ (PosterStats ("poster"), std::make_pair (0u, static_cast<Amount> (0)));
+  EXPECT_EQ (Disputed ("poster"), 0u);
+  EXPECT_EQ (Disputed ("courier"), 0u);
+  EXPECT_EQ (ArbiterStats ("courier2"),
+             std::make_pair (0u, static_cast<Amount> (0)));
+}
+
+TEST_F (DealTests, TimeoutNeitherConfirmRefundsBothNoArbiter)
+{
+  /* M1, no-arbiter variant: worker <- full collateral, poster <- full reward,
+     nothing burned at settlement; history mode refund with no feepaid key
+     (no arbiter bound) and no settledp.  */
+  const auto id = PostAcceptDeal ("");
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 50);
+}
+
+TEST_F (DealTests, NoArbiterHappyPath)
+{
+  const auto id = PostAcceptDeal ("");
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_FALSE (JobExists (id));
+  /* p=100, no arbiter fee: worker <- 5000 - 150 + 5000 = 9850.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9850);
+}
+
+TEST_F (DealTests, RuleOnlyByArbiterAfterDispute)
+{
+  const auto id = PostAcceptDeal ();
+  EXPECT_FALSE (Rule ("courier2", id, 50));  // no dispute yet
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_FALSE (Rule ("poster", id, 50));   // not the arbiter
+  EXPECT_FALSE (Rule ("courier", id, 50));  // not the arbiter
+  EXPECT_TRUE (Rule ("courier2", id, 50));  // the bound arbiter
+  EXPECT_FALSE (JobExists (id));
+}
+
+TEST_F (DealTests, CollateralCapRejected)
+{
+  /* collateral 3000 > 2x reward 1000 (deal-max-collateral-bps default 20000).  */
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":1000,"co":3000,"terms":"x"})"));
+  /* within the cap is fine.  */
+  EXPECT_TRUE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":1000,"co":2000,"terms":"x"})"));
+}
+
+TEST_F (DealTests, RejectsUnknownKeysAndBadGrammar)
+{
+  /* The removed "wd" key is no longer in the grammar (a deal never took one).  */
+  EXPECT_FALSE (ParseOk (
+      R"({"t":"deal","d":86400,"wd":3600,"r":5000,"co":5000})"));
+  /* Unknown post key rejected (strict grammar).  */
+  EXPECT_FALSE (ParseOk (
+      R"({"t":"deal","d":86400,"r":5000,"co":5000,"bogus":1})"));
+  /* A rule p must be a multiple of 10 in [0,100].  */
+  EXPECT_FALSE (ParseOk (R"({"dl":1,"rule":35})"));
+  EXPECT_FALSE (ParseOk (R"({"dl":1,"rule":110})"));
+  EXPECT_TRUE (ParseOk (R"({"dl":1,"rule":40})"));
+}
+
+TEST_F (DealTests, SettlementConservesExhaustive)
+{
+  /* Pin ComputeDealSettlement's conservation + non-negativity in the suite.  */
+  for (const Amount R : {static_cast<Amount> (0), static_cast<Amount> (1),
+                         static_cast<Amount> (1000), static_cast<Amount> (50000),
+                         static_cast<Amount> (100000000000LL)})
+    for (const Amount C : {static_cast<Amount> (0), static_cast<Amount> (7),
+                           static_cast<Amount> (999), static_cast<Amount> (50000)})
+      for (const int t : {0, 300, 1000})
+        for (const int f : {0, 500, 1000})
+          for (int p = 0; p <= 100; p += 10)
+            {
+              const auto s = ComputeDealSettlement (R, C, p, t, f);
+              EXPECT_EQ (s.worker + s.poster + s.arbiter + s.treasury, R + C);
+              EXPECT_GE (s.worker, 0);
+              EXPECT_GE (s.poster, 0);
+            }
+}
+
+TEST_F (DealTests, PosterEqualsArbiterPostRejected)
+{
+  /* §1: poster == arbiter is an armed trap under the reaction window (worker
+     confirms late -> poster-arbiter disputes inside the extension -> rules p=0
+     for a total seizure v1's hard deadline capped at 50/50), banned at the post
+     door.  Nothing is charged or created.  */
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":5000,"arbiter":"poster","fee":1000})"));
+  EXPECT_EQ (jobs.CountAll (), 0);
+}
+
+TEST_F (DealTests, CannotConfirmTwice)
+{
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_FALSE (Confirm ("poster", id));
+  EXPECT_TRUE (JobExists (id));   // still open on one confirm
+}
+
+TEST_F (DealTests, ZeroCollateralHappyPath)
+{
+  const auto id = PostAcceptDeal ("courier2", 0);
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_FALSE (JobExists (id));
+  /* p=100, C=0: worker <- 5000 - 150 - 500 = 4350; arbiter <- 500.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 + 4350);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 500);
+}
+
+TEST_F (DealTests, PostRejectsFeeWithoutArbiter)
+{
+  /* A fee with no arbiter to earn it (missing or empty member) is rejected,
+     never silently dropped: the poster most likely mistyped the arbiter.  */
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"fee":1000})"));
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"arbiter":"","fee":1000})"));
+  /* An empty arbiter alone is likewise a meaningless member.  */
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"arbiter":""})"));
+  /* An arbiter without a fee is fine (a pro-bono arbiter).  */
+  EXPECT_TRUE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"arbiter":"courier2"})"));
+}
+
+TEST_F (DealTests, PostRejectsTaxFeeBeyondPrecondition)
+{
+  /* The §6.3 precondition (0 <= tax, tax + fee < 10000) is enforced on the
+     values a post would snapshot, so a misconfigured runtime retune rejects
+     NEW deals instead of freezing bps into rows whose later settlement
+     would CHECK-halt every node.  */
+  params.Set ("deal-tax-bps", 12'000);
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"terms":"x"})"));
+  params.Set ("deal-tax-bps", -5);
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"terms":"x"})"));
+
+  /* tax + fee exactly 10000 is rejected; strictly below passes and settles
+     without tripping any settlement CHECK.  */
+  params.Set ("deal-tax-bps", 9'000);
+  params.Set ("deal-max-fee-bps", 9'999);
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,)"
+      R"("arbiter":"courier2","fee":1000})"));
+  EXPECT_TRUE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,)"
+      R"("arbiter":"courier2","fee":999})"));
+  const auto id = LatestJobId ();
+  CHECK (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_FALSE (JobExists (id));
+  /* p=100: worker <- 5000 - 4500(tax) - 499(fee) = 1; every coin conserved
+     by the settlement identity.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 + 1);
+}
+
+TEST_F (DealTests, LifecycleOpsRejectedAtDeadline)
+{
+  /* Confirm, dispute and rule are the sweep's to reject once the end date
+     is reached (JobIsDue), like every other lifecycle op: otherwise a
+     confirm in the deadline-to-sweep gap would flip a settlement already
+     fixed by the state at the deadline.  JobIsDue uses the exclusive boundary
+     (deadline <= now), so the timestamp here is set EXACTLY to the deadline
+     to pin that all three ops are rejected at now == deadline.  Here neither
+     party acted, so the sweep must refund BOTH stakes despite the late
+     confirm attempt.  */
+  const auto id = PostAcceptDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY);
+  EXPECT_FALSE (Confirm ("courier", id));
+  EXPECT_FALSE (Dispute ("poster", id));
+  EXPECT_FALSE (Rule ("courier2", id, 100));
+  ExpireJobs (db, ctx);
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000);
+  EXPECT_EQ (Balance ("courier2"), 1000000);
+}
+
+TEST_F (DealTests, ArbiterCannotAccept)
+{
+  /* The arbiter must stay a third party: as worker it would judge its own
+     dispute (accept + self-dispute + self-rule p=100 in one block would
+     capture the whole escrow).  */
+  const auto id = PostDeal ();
+  EXPECT_FALSE (Process ("courier2", R"({"a":)" + std::to_string (id) + "}"));
+  EXPECT_TRUE (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+}
+
+TEST_F (DealTests, ConfirmRejectedWhileDisputed)
+{
+  /* Once disputed, only the arbiter's ruling (or the sweep's 50/50) settles
+     the deal -- the documented DealPayload invariant.  A both-confirm racing
+     the ruling must not bypass the arbiter.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_TRUE (Dispute ("courier", id));
+  EXPECT_FALSE (Confirm ("courier", id));
+  EXPECT_TRUE (JobExists (id));
+  EXPECT_TRUE (Rule ("courier2", id, 50));
+  EXPECT_FALSE (JobExists (id));
+}
+
+TEST_F (DealTests, PostTermBoundaries)
+{
+  /* The optional term bounds are inclusive: tag <= 100, terms <= 1000 bytes,
+     dp <= 100; one past each rejects.  */
+  EXPECT_TRUE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"tag":100,"dp":100})"));
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"tag":101})"));
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"dp":101})"));
+  const std::string maxTerms(1'000, 'x');
+  EXPECT_TRUE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"terms":")" + maxTerms
+        + R"("})"));
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"terms":")" + maxTerms
+        + R"(x"})"));
+}
+
+TEST_F (DealTests, RuleZeroFailsWorkerWithoutReputation)
+{
+  /* p=0: the worker earns nothing and forfeits the whole collateral; the
+     ruling arbiter still earns its fee (it did the job); the outcome is
+     FAILED and no reputation is credited.  R=5000 C=5000 t=300 f=1000:
+     posterTransacted=10000 -> tax 300, fee 1000, poster 8700.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_TRUE (Rule ("courier2", id, 0));
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 1000);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50 + 8700);
+  EXPECT_EQ (DealStats ("courier"), std::make_pair (0u, static_cast<Amount> (0)));
+  /* The earning gate (p>0) denies BOTH sides their completion record here --
+     nothing was delivered and nothing paid out.  The dispute and the arbiter's
+     ruling are recorded regardless: the arbiter did the work it was hired for,
+     and that must not depend on which way it ruled.  */
+  EXPECT_EQ (PosterStats ("poster"), std::make_pair (0u, static_cast<Amount> (0)));
+  EXPECT_EQ (Disputed ("poster"), 1u);
+  EXPECT_EQ (Disputed ("courier"), 1u);
+  EXPECT_EQ (ArbiterStats ("courier2"), std::make_pair (1u, STD_POT));
+  /* A p=0 ruling still records the actual ruling (settledp 0) and the paid
+     fee; the outcome stays "failed" (the client renders it neutrally).  */
+}
+
+TEST_F (DealTests, NonPartiesCannotTouch)
+{
+  /* Only the two parties may confirm or dispute (and only once); green is
+     a complete stranger to this deal.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_FALSE (Confirm ("green", id));
+  EXPECT_FALSE (Dispute ("green", id));
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_FALSE (Dispute ("courier", id));
+  EXPECT_TRUE (JobExists (id));
+}
+
+TEST_F (DealTests, ZeroWindowDealSweepsVoid)
+{
+  /* d=0 posts a deal that is due the moment it exists: no lifecycle op can
+     touch it (JobIsDue) and the sweep voids it with a full reward refund --
+     the poster only burns the posting fee.  */
+  ASSERT_TRUE (Process ("poster",
+      R"({"t":"deal","d":0,"r":5000,"co":1000,"terms":"instant"})"));
+  const auto id = LatestJobId ();
+  EXPECT_FALSE (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+  ExpireJobs (db, ctx);
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("poster"), 1000000 - 50);
+}
+
+TEST_F (DealTests, MinDealRewardFloor)
+{
+  params.Set ("min-deal-reward", 2'000);
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":1500,"co":0,"terms":"small"})"));
+  EXPECT_TRUE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":2000,"co":0,"terms":"exact"})"));
+}
+
+TEST_F (DealTests, SweepSettlesManyDealsAtOnce)
+{
+  /* A moderate-scale sweep: many deals in mixed lifecycle states all hit
+     their shared deadline and settle in ONE ExpireJobs call, exercising the
+     batch path (row deletion, history writes, per-name credit) end to end.
+     Balances must conserve exactly across the whole cohort.  */
+  constexpr unsigned N = 200;
+  Amount before = 0;
+    CHECK_EQ (jobs.CountAll (), 0);
+  for (const auto* name : {"poster", "courier", "courier2", "green"})
+    before += Balance (name);
+
+  for (unsigned i = 0; i < N; ++i)
+    {
+      ASSERT_TRUE (Process ("poster",
+          R"({"t":"deal","d":86400,"r":10,"co":4,"tag":1})"));
+      const auto id = LatestJobId ();
+      const std::string dl = std::to_string (id);
+      ASSERT_TRUE (Process ("courier", R"({"a":)" + dl + "}"));
+      switch (i % 3)
+        {
+        case 0:   /* one confirm -> p=100 at the sweep */
+          ASSERT_TRUE (Confirm ("courier", id));
+          break;
+        case 1:   /* disputed, no arbiter -> 50/50 at the sweep */
+          ASSERT_TRUE (Dispute ("poster", id));
+          break;
+        case 2:   /* untouched -> both stakes refund */
+          break;
+        }
+    }
+
+  ctx.SetTimestamp (BASE_TS + DAY + 1);
+  ExpireJobs (db, ctx);
+
+    EXPECT_EQ (jobs.CountAll (), 0);
+  Amount after = 0;
+  for (const auto* name : {"poster", "courier", "courier2", "green"})
+    after += Balance (name);
+  /* Everything escrowed came back out except the burned posting fees
+     (N x 1, the minimum fee) and the settlement taxes: p=100 deals burn
+     nothing here (10*300/10000 = 0 per share), the 50/50 ones likewise
+     round to zero -- so exactly the fees are gone.  */
+  EXPECT_EQ (before - after, static_cast<Amount> (N));
+}
+
+TEST_F (DealTests, ConfirmBarsOwnDisputePoster)
+{
+  /* H1: a confirmation waives only the confirmer's OWN dispute right, so the
+     poster cannot revoke its confirm by disputing afterwards.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_FALSE (Dispute ("poster", id));
+  EXPECT_TRUE (JobExists (id));
+  EXPECT_FALSE (jobs.GetById (id)->GetProto ().disputed ());
+}
+
+TEST_F (DealTests, ConfirmBarsOwnDisputeWorker)
+{
+  /* H1, the worker's mirror image of the guard.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_FALSE (Dispute ("courier", id));
+  EXPECT_TRUE (JobExists (id));
+  EXPECT_FALSE (jobs.GetById (id)->GetProto ().disputed ());
+}
+
+TEST_F (DealTests, ConfirmerCounterpartyMayStillDispute)
+{
+  /* H1: the poster's confirm does NOT waive the worker's dispute right -- the
+     counterparty may still contest a shoddy job.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_TRUE (Dispute ("courier", id));
+  EXPECT_TRUE (jobs.GetById (id)->GetProto ().disputed ());
+}
+
+TEST_F (DealTests, WorkerConfirmPosterMayStillDispute)
+{
+  /* H1: the worker's confirm does NOT waive the poster's dispute right.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_TRUE (jobs.GetById (id)->GetProto ().disputed ());
+}
+
+TEST_F (DealTests, NoArbiterConfirmerCannotForceGhostSplit)
+{
+  /* H1, no-arbiter: a party that confirmed cannot then dispute to drag an
+     honest deal into the 50/50 ghost split; the confirm stands and the sweep
+     settles SINGLE_CONFIRM at p=100 (NOT the 4925 of a 50/50 split).  */
+  const auto id = PostAcceptDeal ("");
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_FALSE (Dispute ("courier", id));
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9850);
+}
+
+TEST_F (DealTests, PostRejectsOverflowTaxFee)
+{
+  /* L1: tax and fee are each bounded in [0, 9999] BEFORE their sum, so a
+     runtime param near 2^62 (whose low 32 bits are non-zero, thus narrowing
+     to a small uint32) cannot overflow the signed sum past the precondition
+     guard and freeze a settlement-halting pair into a row.  No row is
+     created.  2^62 alone would be insufficient (low 32 bits zero).  */
+  constexpr int64_t BIG = (static_cast<int64_t> (1) << 62) + 6000;
+  const std::string big = std::to_string (BIG);
+  params.Set ("deal-tax-bps", BIG);
+  params.Set ("deal-max-fee-bps", BIG);
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,)"
+      R"("arbiter":"courier2","fee":)" + big + "}"));
+
+  /* INT64_MAX for both is likewise rejected.  */
+  const int64_t MAX = std::numeric_limits<int64_t>::max ();
+  const std::string maxStr = std::to_string (MAX);
+  params.Set ("deal-tax-bps", MAX);
+  params.Set ("deal-max-fee-bps", MAX);
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,)"
+      R"("arbiter":"courier2","fee":)" + maxStr + "}"));
+
+  /* Nothing was admitted to the board.  */
+  EXPECT_EQ (jobs.CountAll (), 0);
+}
+
+TEST_F (DealTests, AssignRestrictsAcceptToDesignatedWorker)
+{
+  /* L3: assignment makes a PUBLIC deal exclusive -- the poster designates a
+     worker and only that worker may accept.  It does NOT make the row
+     born-private: invite_only stays unset (that bit is the POST-time
+     discriminator), so the exported exclusivity predicate is the pair
+     `inviteonly || designated != ""` and this row carries only the second.  */
+  const auto id = PostDeal ();
+  const std::string sid = std::to_string (id);
+  EXPECT_TRUE (Process ("poster", R"({"s":)" + sid + R"(,"w":"courier"})"));
+  EXPECT_EQ (LiveJson (id)["designated"].asString (), "courier");
+  EXPECT_FALSE (LiveJson (id).isMember ("inviteonly"));
+  EXPECT_FALSE (Process ("green", R"({"a":)" + sid + "}"));   // not designated
+  EXPECT_TRUE (JobExists (id));
+  EXPECT_TRUE (Process ("courier", R"({"a":)" + sid + "}"));  // the designee
+  EXPECT_EQ (jobs.GetById (id)->GetStatus (), Job::Status::ACCEPTED);
+}
+
+TEST_F (DealTests, LiveBoardRowCarriesNoSettlementMetadata)
+{
+  /* M2: the settle mode / p / fee-paid keys are stamped only on the history
+     snapshot, so a live accepted deal on the board carries none of them.  */
+  const auto id = PostAcceptDeal ();
+  const Json::Value live = LiveJson (id);
+  ASSERT_EQ (live["id"].asUInt64 (), static_cast<Json::UInt64> (id));
+  EXPECT_FALSE (live.isMember ("mode"));
+  EXPECT_FALSE (live.isMember ("settledp"));
+  EXPECT_FALSE (live.isMember ("feepaid"));
+}
+
+TEST_F (DealTests, NoArbiterCounterpartyDisputesAfterWorkerConfirm)
+{
+  /* H1 regression (matrix 1): on a no-arbiter deal a confirmation waives only
+     the confirmer's OWN dispute right, so the still-unconfirmed poster remains
+     free to dispute the worker's confirm.  With no arbiter that dispute can
+     never be ruled, so the sweep settles the blunt 50/50 ghost split -- the
+     approved v1 behaviour (a free terminal p=50 no-arbiter dispute).  */
+  const auto id = PostAcceptDeal ("");
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_TRUE (Dispute ("poster", id));
+  Expire ();
+  ExpectNoArbiterGhostSplit (id);
+}
+
+TEST_F (DealTests, NoArbiterCounterpartyDisputesAfterPosterConfirm)
+{
+  /* H1 regression (matrix 2): the mirror image -- the poster confirms and the
+     still-unconfirmed worker disputes.  Same free no-arbiter p=50 ghost
+     split.  */
+  const auto id = PostAcceptDeal ("");
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_TRUE (Dispute ("courier", id));
+  Expire ();
+  ExpectNoArbiterGhostSplit (id);
+}
+
+TEST_F (DealTests, NoArbiterDisputeWithoutConfirmGhostSplits)
+{
+  /* H1 regression (matrix 3): neither party confirmed, so an unconfirmed party
+     disputes straight from the accepted state.  A dispute -- not the untouched
+     refund -- is what happened, so the sweep settles the p=50 ghost split, NOT
+     the both-stakes refund of the never-touched case.  */
+  const auto id = PostAcceptDeal ("");
+  EXPECT_TRUE (Dispute ("poster", id));
+  Expire ();
+  ExpectNoArbiterGhostSplit (id);
+}
+
+TEST_F (DealTests, ArbiterGhostsAfterCounterpartyDisputeSplits)
+{
+  /* H1 regression (matrix 5): the arbiter-bound counterparty-dispute shape --
+     the worker confirms, the still-unconfirmed poster disputes, and the bound
+     arbiter never rules.  The sweep falls back to the same p=50 split, and
+     because the arbiter ghosted the one dispute it was hired to rule its fee
+     is FORFEITED: feepaid is stamped false and the arbiter is left untouched
+     (worker 4925, poster 4850, treasury 225 burned).  */
+  const auto id = PostAcceptDeal ();   // courier2 is the arbiter
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_TRUE (Dispute ("poster", id));
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 4925);
+  EXPECT_EQ (Balance ("courier2"), 1000000);   // arbiter forfeited its fee
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50 + 4850);
+}
+
+/* -- reaction window pins (design escrow-v1.1 §1) ------------------------- *
+   A confirm (leaving a live counter-move) or an arbiter-bound dispute landing
+   strictly within the row's reaction_window (W = 30 in regtest) of the deadline
+   is no longer terminal: it extends the deadline to now + W so the successor
+   move keeps a full window.  A no-arbiter dispute never extends, and an op AT
+   the deadline still rejects (JobIsDue).  These flips supersede the v1 no-window
+   pins.
+   ------------------------------------------------------------------------- */
+
+TEST_F (DealTests, LateConfirmExtendsThenSingleConfirm)
+{
+  /* A confirm one second before the deadline lands within W and EXTENDS it to
+     confirm_ts + W, so the poster keeps a full window.  Silent through the
+     extension, the sweep settles the single confirm at p=100 with the SAME
+     terminal balances v1 produced (worker 9350, arbiter 500, poster 0).  */
+  const auto id = PostAcceptDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY - 1 + 30);
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9350);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 500);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50);
+}
+
+TEST_F (DealTests, LatePosterConfirmExtendsThenSingleConfirm)
+{
+  /* The mirror: the POSTER confirms late.  A single confirm settles p=100
+     toward the worker regardless of which side confirmed; the extension gives
+     the unconfirmed worker its window, whose silence hardens p=100.  */
+  const auto id = PostAcceptDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY - 1 + 30);
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9350);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 500);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50);
+}
+
+TEST_F (DealTests, ConfirmAtDeadlineRejectedRefundsBoth)
+{
+  /* Unchanged: the end date stays a HARD boundary for ops.  A confirm arriving
+     AT the deadline (JobIsDue's exclusive boundary) is rejected, and with
+     neither party having acted the sweep refunds both stakes untaxed -- the
+     costless miss case, pinned so any change shows in a diff.  */
+  const auto id = PostAcceptDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY);
+  EXPECT_FALSE (Confirm ("courier", id));
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 50);
+  EXPECT_EQ (Balance ("courier2"), 1000000);
+}
+
+TEST_F (DealTests, ZeroCollLateConfirmExtendsThenPosterDisputeGhostSplits)
+{
+  /* Review H1's zero-collateral shape under v1.1: the worker's late confirm no
+     longer locks the full reward from the final block -- it EXTENDS, and the
+     poster now has a window to dispute.  A no-arbiter dispute does not extend,
+     so the sweep settles the p=50 ghost split (worker 2425 on a zero stake,
+     poster the mirrored 2425, 150 burned).  */
+  const auto id = PostAcceptDeal ("", 0);
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY - 1 + 30);
+  ctx.SetTimestamp (BASE_TS + DAY + 10);         // inside the extension
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY - 1 + 30);   // no-arbiter: no extend
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 + 2425);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50 + 2425);
+}
+
+TEST_F (DealTests, ZeroCollLateConfirmExtendsThenSilenceSingleConfirm)
+{
+  /* The same zero-collateral late confirm, poster silent through the extension:
+     it hardens to the v1 single-confirm p=100 (worker 5000 - 150 tax = 4850,
+     no arbiter, no stake at risk).  */
+  const auto id = PostAcceptDeal ("", 0);
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("courier", id));
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 + 4850);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50);
+}
+
+TEST_F (DealTests, LateDisputeExtendsThenArbiterRulesInWindow)
+{
+  /* v1.1 inverts the old "last-block dispute denies the arbiter" pin: an
+     arbiter-bound dispute one second before the deadline EXTENDS it, so the
+     arbiter keeps a full window -- and its ruling inside the window SUCCEEDS
+     (RULING, fee paid, dispute_time stamped).  p=50: worker 4675, arbiter 750,
+     poster 4350.  */
+  const auto id = PostAcceptDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY - 1 + 30);
+  ctx.SetTimestamp (BASE_TS + DAY + 10);         // inside the extension
+  EXPECT_TRUE (Rule ("courier2", id, 50));
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 4675);
+  EXPECT_EQ (Balance ("courier2"), 1000000 + 750);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50 + 4350);
+}
+
+TEST_F (DealTests, NoArbiterZeroCollateralDisputeTakesHalf)
+{
+  /* Unchanged: a no-arbiter dispute never extends (its only successor is the
+     sweep's 50/50).  The R != C asymmetry pin -- at C=0 the split still moves
+     R/2 * (1 - tax) = 2425 to a zero-stake worker, the mirror to the poster,
+     150 burned; poster-chosen exposure the client MUST warn about.  */
+  const auto id = PostAcceptDeal ("", 0);
+  EXPECT_TRUE (Dispute ("courier", id));
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 + 2425);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 5000 - 50 + 2425);
+}
+
+/* -- reaction window coverage (design escrow-v1.1 §1/§8) ------------------- */
+
+TEST_F (DealTests, RegtestDefaultReactionWindowIsThirty)
+{
+  /* The unit/gametest fixtures load the regtest roconfig, whose per-chain
+     deal_reaction_window is 30 (mainnet's is 86400); the window tests rely on
+     it, and the min(W, d) snapshot stores it on every standard deal.  */
+  EXPECT_EQ (ctx.RoConfig ()->params ().deal_reaction_window (), 30);
+  EXPECT_EQ (Rwindow (PostAcceptDeal ()), 30);
+}
+
+TEST_F (DealTests, ReactionWindowTriggerBoundaryBothSides)
+{
+  /* STRICT '<': at deadline - now == W nothing is needed (exactly W remains) so
+     NO extension; at == W - 1 the extension fires.  */
+  const auto a = PostAcceptDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY - 30);         // exactly W left
+  EXPECT_TRUE (Confirm ("courier", a));
+  EXPECT_EQ (Deadline (a), BASE_TS + DAY);       // unchanged
+
+  ctx.SetTimestamp (BASE_TS);
+  const auto b = PostAcceptDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY - 29);         // W - 1 left
+  EXPECT_TRUE (Confirm ("courier", b));
+  EXPECT_EQ (Deadline (b), BASE_TS + DAY - 29 + 30);
+}
+
+TEST_F (DealTests, EarlyConfirmDoesNotShortenDeadline)
+{
+  /* Monotonic / no-shorten: a confirm far from the deadline would set
+     now + W < deadline, so the extension does NOT fire and the deadline is
+     never pulled in.  */
+  const auto id = PostAcceptDeal ();          // confirm at BASE_TS, W left DAY
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY);
+}
+
+TEST_F (DealTests, WorstChainTwoWindowExtensions)
+{
+  /* The 2W worst chain: a late single confirm (+W) then a late arbiter-bound
+     dispute inside that extension (+W) then a ruling inside the second window.
+     Total extension stays within 2W of the original deadline.  */
+  const auto id = PostAcceptDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY - 1 + 30);       // +W
+  ctx.SetTimestamp (BASE_TS + DAY + 28);                   // inside, 1 left
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY + 28 + 30);      // +W again
+  EXPECT_LE (Deadline (id), BASE_TS + DAY + 60);           // <= original + 2W
+  ctx.SetTimestamp (BASE_TS + DAY + 57);                   // inside second window
+  EXPECT_TRUE (Rule ("courier2", id, 50));
+  EXPECT_FALSE (JobExists (id));
+}
+
+TEST_F (DealTests, NoArbiterLateConfirmContestableGhostSplits)
+{
+  /* The pinned policy shift: on a NO-ARBITER deal a late single confirm is now
+     contestable for the whole window -- the counterparty's dispute inside the
+     extension forces the 50/50 ghost split instead of the confirm locking
+     p=100 from the final block.  */
+  const auto id = PostAcceptDeal ("");
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY - 1 + 30);
+  ctx.SetTimestamp (BASE_TS + DAY + 5);
+  EXPECT_TRUE (Dispute ("poster", id));
+  Expire ();
+  ExpectNoArbiterGhostSplit (id);
+}
+
+TEST_F (DealTests, ZeroWindowRowBehavesLikeV1)
+{
+  /* A row posted with the window frozen to 0 disables the mechanism: a
+     final-block confirm never extends and settles single-confirm p=100 at the
+     unmoved deadline -- byte-identical v1 behaviour.  */
+  params.Set ("deal-reaction-window", 0);
+  const auto id = PostAcceptDeal ();
+  EXPECT_EQ (Rwindow (id), 0);
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY);      // no extension
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9350);
+}
+
+TEST_F (DealTests, ReactionWindowSnapshotImmuneToRetune)
+{
+  /* The window is a per-row snapshot: a retune reaches only future posts.  A
+     deal posted at W=30 still extends by 30 after the param is set to 0; and a
+     deal posted while the param is 0 never extends even after it is raised.  */
+  const auto armed = PostAcceptDeal ();          // snapshot W = 30
+  params.Set ("deal-reaction-window", 0);
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("courier", armed));
+  EXPECT_EQ (Deadline (armed), BASE_TS + DAY - 1 + 30);
+
+  ctx.SetTimestamp (BASE_TS);
+  const auto frozen = PostAcceptDeal ();         // param still 0 -> snapshot W = 0
+  params.Set ("deal-reaction-window", 30);
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Confirm ("courier", frozen));
+  EXPECT_EQ (Deadline (frozen), BASE_TS + DAY);
+}
+
+TEST_F (DealTests, LateAcceptThenConfirmExtends)
+{
+  /* Accept never touches the deadline (design §1): a deal accepted at
+     deadline - 1 is near-due, but the worker's confirm IS the window trigger
+     and extends it, so a late-accepted deal is protected by the window.  */
+  const auto id = PostDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY);      // accept left it untouched
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_EQ (Deadline (id), BASE_TS + DAY - 1 + 30);
+  Expire ();
+}
+
+TEST_F (DealTests, LateAcceptThenSilenceRefundsBoth)
+{
+  /* The other late-accept branch: neither party acts after a late accept, so
+     the sweep refunds both stakes untaxed (costless, no window needed).  */
+  const auto id = PostDeal ();
+  ctx.SetTimestamp (BASE_TS + DAY - 1);
+  EXPECT_TRUE (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("courier"), 1000000);
+  EXPECT_EQ (Balance ("poster"), 1000000 - 50);
+}
+
+/* -- private deals + dispute_time + JSON (§2/§3) --------------------------- */
+
+TEST_F (DealTests, PrivateDealAtPostRestrictsAccept)
+{
+  /* A "w" at post makes the deal private from birth: only the designee accepts,
+     and the row advertises designated + inviteonly.  */
+  CHECK (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":5000,"w":"courier"})"));
+  const auto id = LatestJobId ();
+  const Json::Value live = LiveJson (id);
+  EXPECT_EQ (live["designated"].asString (), "courier");
+  EXPECT_TRUE (live["inviteonly"].asBool ());
+  EXPECT_FALSE (Process ("green", R"({"a":)" + std::to_string (id) + "}"));
+  EXPECT_TRUE (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+}
+
+TEST_F (DealTests, PrivateDealPostRejectsBadWorker)
+{
+  /* A non-empty "w" must be an existing initialised account, != poster, !=
+     arbiter, and a string -- any violation rejects the WHOLE post uncharged.  */
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"w":"poster"})"));
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"arbiter":"courier2","fee":0,"w":"courier2"})"));
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"w":"ghost"})"));
+  EXPECT_FALSE (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":0,"w":5})"));
+  EXPECT_EQ (jobs.CountAll (), 0);
+}
+
+TEST_F (DealTests, PrivateUnassignedInviteOnly)
+{
+  /* w:"" is the private-unassigned state: invite-only with no designee, so
+     NOBODY can accept until ASSIGN names one -- then only that designee can.  */
+  CHECK (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":5000,"w":""})"));
+  const auto id = LatestJobId ();
+  const std::string sid = std::to_string (id);
+  EXPECT_TRUE (LiveJson (id)["inviteonly"].asBool ());
+  EXPECT_FALSE (LiveJson (id).isMember ("designated"));
+  EXPECT_FALSE (Process ("courier", R"({"a":)" + sid + "}"));   // nobody yet
+  EXPECT_TRUE (Process ("poster", R"({"s":)" + sid + R"(,"w":"courier"})"));
+  EXPECT_TRUE (LiveJson (id)["inviteonly"].asBool ());          // persists
+  EXPECT_FALSE (Process ("green", R"({"a":)" + sid + "}"));     // not designee
+  EXPECT_TRUE (Process ("courier", R"({"a":)" + sid + "}"));
+}
+
+TEST_F (DealTests, AssignArbiterRejected)
+{
+  /* F7: assigning the bound arbiter as worker is rejected (it would strand the
+     row -- the accept gate bars an arbiter-worker); a non-arbiter assigns.  */
+  const auto id = PostDeal ();                   // arbiter courier2
+  const std::string sid = std::to_string (id);
+  EXPECT_FALSE (Process ("poster", R"({"s":)" + sid + R"(,"w":"courier2"})"));
+  EXPECT_TRUE (Process ("poster", R"({"s":)" + sid + R"(,"w":"courier"})"));
+}
+
+TEST_F (DealTests, DisputeTimeAndWindowInJson)
+{
+  /* reactionwindow rides on the live row; disputetime appears only after a
+     dispute, on both the live row and the settled history snapshot.  */
+  const auto id = PostAcceptDeal ();
+  EXPECT_EQ (LiveJson (id)["reactionwindow"].asInt64 (), 30);
+  EXPECT_FALSE (LiveJson (id).isMember ("disputetime"));
+  ctx.SetTimestamp (BASE_TS + 100);
+  EXPECT_TRUE (Dispute ("poster", id));
+  EXPECT_EQ (LiveJson (id)["disputetime"].asInt64 (), BASE_TS + 100);
+  EXPECT_TRUE (Rule ("courier2", id, 50));
+}
+
+/* -- admission-cap clamps + retention overlay (§4/§5/§6) ------------------- */
+
+TEST_F (DealTests, ReactionWindowClampedAtPost)
+{
+  /* An over-ceiling deal-reaction-window override clamps to CAP (30 days) in
+     the snapshot exactly as getjobsparams reports it -- RPC == consensus.  */
+  params.Set ("deal-reaction-window", CAP_DEAL_REACTION_WINDOW + 1000);
+  CHECK (Process ("poster",
+      R"({"t":"deal","d":2592000,"r":5000,"co":0,"terms":"long"})"));
+  const auto id = LatestJobId ();
+  EXPECT_EQ (Rwindow (id), CAP_DEAL_REACTION_WINDOW);
+  GameStateJson gsj(db, ctx);
+  EXPECT_EQ (gsj.JobsParams ()["deal-reaction-window"].asInt64 (),
+             CAP_DEAL_REACTION_WINDOW);
+}
+
+TEST_F (DealTests, JobsParamsClampsOverridesToCeilingsAndFloors)
+{
+  /* getjobsparams returns the POST-CLAMP effective value consensus uses: a
+     ceiling caps an over-ceiling override and a negative override floors
+     to 0.  */
+  params.Set ("max-live-jobs", CAP_MAX_LIVE_JOBS + 5);
+  params.Set ("max-jobs-per-poster", -7);
+  GameStateJson gsj(db, ctx);
+  const Json::Value p = gsj.JobsParams ();
+  EXPECT_EQ (p["max-live-jobs"].asInt64 (), CAP_MAX_LIVE_JOBS);
+  EXPECT_EQ (p["max-jobs-per-poster"].asInt64 (), 0);
+  /* A self-bounding param reports the raw overlay (no clamp).  */
+  params.Set ("deal-tax-bps", 4321);
+  EXPECT_EQ (gsj.JobsParams ()["deal-tax-bps"].asInt64 (), 4321);
+}
+
+TEST_F (DealTests, ProBonoArbiterSettlesWithZeroFee)
+{
+  /* L4: a pro-bono arbiter (bound, fee_bps 0) carries the deal to a
+     both-confirm settle and receives nothing -- the fee schedule is honoured
+     by moving zero coins, and the parties are paid as if no arbiter existed. */
+  CHECK (Process ("poster",
+      R"({"t":"deal","d":86400,"r":5000,"co":5000,"arbiter":"courier2"})"));
+  const auto id = LatestJobId ();
+  CHECK (Process ("courier", R"({"a":)" + std::to_string (id) + "}"));
+  EXPECT_TRUE (Confirm ("poster", id));
+  EXPECT_TRUE (Confirm ("courier", id));
+  EXPECT_FALSE (JobExists (id));
+  /* p=100, fee 0: worker <- 5000 - 150(tax) + 5000(collateral) = 9850; the
+     arbiter is bound but paid nothing.  */
+  EXPECT_EQ (Balance ("courier"), 1000000 - 5000 + 9850);
+  EXPECT_EQ (Balance ("courier2"), 1000000);   // pro-bono: zero coins move
+}
+
+TEST_F (DealTests, OpenDealExpiresRefundingThePoster)
+{
+  /* L6a: an OPEN deal that is never accepted expires through the void hook,
+     which refunds the poster's reward and touches no deal proto -- the deal
+     settlement path (RefundBothDeal / SettleDeal) never runs.  */
+  const auto id = PostDeal ();   // arbiter named, but never accepted
+  Expire ();
+  EXPECT_FALSE (JobExists (id));
+  EXPECT_EQ (Balance ("poster"), 1000000 - 50);   // reward refunded, fee burned
+}
+
+} // anonymous namespace
+} // namespace pxd

--- a/src/logic.cpp
+++ b/src/logic.cpp
@@ -21,6 +21,7 @@
 #include "buildings.hpp"
 #include "combat.hpp"
 #include "dynobstacles.hpp"
+#include "jobs.hpp"
 #include "mining.hpp"
 #include "movement.hpp"
 #include "moveprocessor.hpp"
@@ -136,6 +137,7 @@ PXLogic::UpdateState (Database& db, FameUpdater& fame, xaya::Random& rnd,
 
       AllHpUpdates (db, dyn, fame, rnd, ctx);
       ProcessAllOngoings (db, rnd, ctx);
+      ExpireJobs (db, ctx);
 
       ProcessAllMining (db, rnd, ctx);
       ProcessAllMovement (db, dyn, ctx);
@@ -610,6 +612,7 @@ PXLogic::ValidateStateSlow (Database& db, const Context& ctx)
   ValidateBuildingInventories (db);
   ValidateOngoingsLinks (db);
   ValidateOrderLinks (db);
+  ValidateJobs (db);
 }
 
 } // namespace pxd

--- a/src/logic_tests.cpp
+++ b/src/logic_tests.cpp
@@ -32,6 +32,7 @@
 #include "database/dex.hpp"
 #include "database/faction.hpp"
 #include "database/inventory.hpp"
+#include "database/jobs.hpp"
 #include "database/ongoing.hpp"
 #include "database/region.hpp"
 #include "hexagonal/coord.hpp"
@@ -160,14 +161,24 @@ protected:
 
   /**
    * Calls PXLogic::UpdateState with the given moves and superblock height.
+   * superBlock defaults to true; pass it explicitly to drive ORDINARY blocks
+   * (moves processed, no superblock phases) as the real dispatch does.
    */
   void
-  UpdateStateWithHeight (const Json::Value& moves, const unsigned sbHeight)
+  UpdateStateWithHeight (const Json::Value& moves, const unsigned sbHeight,
+                         const bool superBlock = true)
   {
     Context newCtx(ctx.Chain (), ctx.Map (),
                    sbHeight, ctx.BlockHeight (), ctx.Timestamp ());
     FameUpdater fame(db, newCtx);
-    PXLogic::UpdateState (db, fame, rnd, newCtx, true, BuildBlockData (moves));
+    PXLogic::UpdateState (db, fame, rnd, newCtx, superBlock,
+                          BuildBlockData (moves));
+  }
+
+  void
+  UpdateStateBlock (const std::string& movesStr, const bool superBlock)
+  {
+    UpdateStateWithHeight (ParseJson (movesStr), ctx.Height (), superBlock);
   }
 
   /**
@@ -608,6 +619,79 @@ TEST_F (PXLogicTests, PickUpDeadDrop)
   ASSERT_TRUE (c != nullptr);
   EXPECT_EQ (c->GetInventory ().GetFungibleCount ("foo"), 3);
   c.reset ();
+}
+
+/* ************************************************************************** */
+
+TEST_F (PXLogicTests, JobsExpireOnlyOnSuperblocks)
+{
+  /* ExpireJobs is gated inside the superblock branch while moves run on
+     every block:  a deadline passing on an ordinary block must NOT settle
+     the job -- it stays on the board until the next superblock sweep.  */
+  for (const auto* name : {"poster", "courier"})
+    {
+      auto a = accounts.CreateNew (name);
+      a->SetFaction (Faction::RED);
+      a->AddBalance (1'000'000);
+    }
+
+  UpdateStateBlock (R"([
+    {"name": "poster", "move": {"j": [{
+      "t": "deal", "d": 86400, "r": 2000, "co": 0, "terms": "x"
+    }]}}
+  ])", true);
+
+  JobsTable jobs(db);
+  Database::IdT jobId;
+  {
+    auto res = jobs.QueryAll ();
+    ASSERT_TRUE (res.Step ());
+    jobId = jobs.GetFromResult (res)->GetId ();
+    ASSERT_FALSE (res.Step ());
+  }
+  ASSERT_EQ (accounts.GetByName ("poster")->GetBalance (),
+             1'000'000 - 2'000 - 20);
+
+  /* The deadline passes, but the block is ordinary:  the overdue job must
+     survive it untouched -- and an accept landing in this move-before-sweep
+     window (otherwise perfectly valid) must not resurrect a listing whose
+     void at the sweep is already determined.  */
+  ctx.SetTimestamp (ctx.Timestamp () + 86401);
+  UpdateStateBlock (R"([
+    {"name": "courier", "move": {"j": [{"a": )"
+      + std::to_string (jobId) + R"(}]}}
+  ])", false);
+  {
+    auto j = jobs.GetById (jobId);
+    ASSERT_NE (j, nullptr);
+    EXPECT_EQ (j->GetStatus (), Job::Status::OPEN);
+  }
+  EXPECT_EQ (accounts.GetByName ("poster")->GetBalance (),
+             1'000'000 - 2'000 - 20);
+
+  /* Likewise the poster's own assign and cancel in the same gap:  a due
+     job is the sweep's alone -- a gap-assign would write dead designation
+     data, and a gap-cancel would record CANCELLED history for a job that
+     expired.  */
+  UpdateStateBlock (R"([
+    {"name": "poster", "move": {"j": [
+      {"s": )" + std::to_string (jobId) + R"(, "w": "courier"},
+      {"c": )" + std::to_string (jobId) + R"(}
+    ]}}
+  ])", false);
+  {
+    auto j = jobs.GetById (jobId);
+    ASSERT_NE (j, nullptr);
+    EXPECT_EQ (j->GetStatus (), Job::Status::OPEN);
+    EXPECT_EQ (j->GetProto ().designated_worker (), "");
+  }
+  EXPECT_EQ (accounts.GetByName ("poster")->GetBalance (),
+             1'000'000 - 2'000 - 20);
+
+  /* The next superblock sweeps it:  the OPEN job voids and refunds.  */
+  UpdateStateBlock ("[]", true);
+  EXPECT_EQ (jobs.GetById (jobId), nullptr);
+  EXPECT_EQ (accounts.GetByName ("poster")->GetBalance (), 1'000'000 - 20);
 }
 
 TEST_F (PXLogicTests, DamageLists)

--- a/src/moveprocessor.cpp
+++ b/src/moveprocessor.cpp
@@ -66,7 +66,7 @@ BaseMoveProcessor::BaseMoveProcessor (Database& d, DynObstacles& o,
     groundLoot(db), buildingInv(db),
     orders(db), dexHistory(db),
     itemCounts(db), moneySupply(db),
-    ongoings(db), regions(db, ctx.BlockHeight ())
+    ongoings(db), jobs(db), regions(db, ctx.BlockHeight ())
 {}
 
 bool
@@ -463,6 +463,32 @@ BaseMoveProcessor::TryDexOperations (const std::string& name,
         }
       if (parsed->IsValid ())
         PerformDexOperation (*parsed);
+    }
+}
+
+void
+BaseMoveProcessor::TryJobOperations (const std::string& name,
+                                     const Json::Value& mv)
+{
+  const auto& cmds = mv["j"];
+  if (!cmds.isArray ())
+    return;
+
+  const auto a = accounts.GetByName (name);
+  CHECK (a != nullptr);
+
+  const ParamsTable params(db);
+  const JobContext jc{ctx, accounts, jobs, params};
+  for (const auto& op : cmds)
+    {
+      auto parsed = JobOperation::Parse (*a, op, jc);
+      if (parsed == nullptr)
+        {
+          LOG (WARNING) << "Malformed job operation:\n" << op;
+          continue;
+        }
+      if (parsed->IsValid ())
+        PerformJobOperation (*parsed);
     }
 }
 
@@ -1361,6 +1387,12 @@ MoveProcessor::ProcessOne (const Json::Value& moveObj)
   TryBuildingUpdates (name, mv);
   TryServiceOperations (name, mv);
 
+  /* Job-board operations run last so a move can bundle character/building
+     updates (e.g. a hull swap-back or a cargo drop) that must settle before
+     the job op is checked (design section 3.3, normative order).  Like
+     the other post-init operations, they require an initialised account.  */
+  TryJobOperations (name, mv);
+
   /* If any burnt or paid-to-dev coins are left, it means probably something
      has gone wrong and the user overpaid due to a frontend bug.  */
   LOG_IF (WARNING, paidToDev > 0 || burnt > 0)
@@ -1948,6 +1980,12 @@ MoveProcessor::PerformServiceOperation (ServiceOperation& op)
 
 void
 MoveProcessor::PerformDexOperation (DexOperation& op)
+{
+  op.Execute ();
+}
+
+void
+MoveProcessor::PerformJobOperation (JobOperation& op)
 {
   op.Execute ();
 }

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -21,6 +21,7 @@
 
 #include "context.hpp"
 #include "dynobstacles.hpp"
+#include "jobs.hpp"
 #include "services.hpp"
 #include "trading.hpp"
 
@@ -155,6 +156,9 @@ protected:
 
   /** Ongoing operations table.  */
   OngoingsTable ongoings;
+
+  /** Access handle for the jobs board table.  */
+  JobsTable jobs;
 
   /** Access to the regions table.  */
   RegionsTable regions;
@@ -305,6 +309,14 @@ protected:
   void TryDexOperations (const std::string& name, const Json::Value& mv);
 
   /**
+   * Parses and handles a potential move with requested job-board operations.
+   * Each valid operation will be passed to PerformJobOperation for execution.
+   * Jobs are confirmed-only: the pending path never dispatches the "j" key
+   * (see the timestamp note in jobs.hpp).
+   */
+  void TryJobOperations (const std::string& name, const Json::Value& mv);
+
+  /**
    * This function is called when TryCharacterCreation found a creation that
    * is valid and should be performed.
    */
@@ -353,6 +365,14 @@ protected:
   PerformDexOperation (DexOperation& op)
   {}
 
+  /**
+   * This function is called when TryJobOperations has found a valid
+   * job-board operation.
+   */
+  virtual void
+  PerformJobOperation (JobOperation& op)
+  {}
+
 public:
 
   virtual ~BaseMoveProcessor () = default;
@@ -392,10 +412,11 @@ private:
 
   /**
    * Handles a "param" admin command, if any: runtime tuning of named
-   * parameters, in the exact admin shape of the soccerverse GSP.  Unlike
-   * god mode this is a legitimate mainnet operation -- admin commands only
-   * ever come from the game account's owner -- so tunable values can be
-   * adjusted without a redeploy.
+   * parameters (currently the jobs-board admission caps), in the exact
+   * admin shape of the soccerverse GSP.  Unlike god mode this is a
+   * legitimate mainnet operation -- admin commands only ever come from the
+   * game account's owner -- so the caps can be adjusted, or posting frozen
+   * with 0, without a redeploy.
    */
   void HandleParams (const Json::Value& cmd);
 
@@ -493,6 +514,7 @@ protected:
 
   void PerformServiceOperation (ServiceOperation& op) override;
   void PerformDexOperation (DexOperation& op) override;
+  void PerformJobOperation (JobOperation& op) override;
 
 public:
 

--- a/src/pxrpcserver.cpp
+++ b/src/pxrpcserver.cpp
@@ -523,6 +523,28 @@ PXRpcServer::getbuildings ()
 }
 
 Json::Value
+PXRpcServer::getjobs ()
+{
+  LOG (INFO) << "RPC method called: getjobs";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.Jobs ();
+      });
+}
+
+Json::Value
+PXRpcServer::getjobsparams ()
+{
+  LOG (INFO) << "RPC method called: getjobsparams";
+  return logic.GetCustomStateData (game,
+    [] (GameStateJson& gsj)
+      {
+        return gsj.JobsParams ();
+      });
+}
+
+Json::Value
 PXRpcServer::getcharacters ()
 {
   LOG (INFO) << "RPC method called: getcharacters";

--- a/src/pxrpcserver.hpp
+++ b/src/pxrpcserver.hpp
@@ -201,6 +201,8 @@ public:
 
   Json::Value getaccounts () override;
   Json::Value getbuildings () override;
+  Json::Value getjobs () override;
+  Json::Value getjobsparams () override;
   Json::Value getcharacters () override;
   Json::Value getgroundloot () override;
   Json::Value getongoings () override;

--- a/src/rpc-stubs/pxd.json
+++ b/src/rpc-stubs/pxd.json
@@ -40,6 +40,16 @@
     "returns": {}
   },
   {
+    "name": "getjobs",
+    "params": {},
+    "returns": {}
+  },
+  {
+    "name": "getjobsparams",
+    "params": {},
+    "returns": {}
+  },
+  {
     "name": "getcharacters",
     "params": {},
     "returns": {}


### PR DESCRIPTION
**Based on #202** (the runtime parameters table) — review that one first; this
PR's diff shows only the second commit. Retarget to `master` once #202 lands.

A player-driven contracts board: a job is an escrowed reward plus a worker
collateral plus a deadline, optionally exclusive to one designated worker,
settled by a completion percentage that a bound arbiter dials on a dispute, or
by the end-date sweep when nobody rules.

### Why this shape

The obvious design is a catalogue of verified types — transport this cargo,
escort that vehicle, rent me a slot — each with a consensus rule that watches
the world and decides whether the term was met. That was built, and abandoned:
most of what players want to contract about is **not observable to consensus**.
The chain can see a vehicle reached a tile; it cannot see whether the cargo was
the agreed cargo, or whether a service satisfied the buyer. Every type that
pretends otherwise is an approximation, and each approximation is an exploit
surface.

So the chain does the one thing it can do perfectly — hold value and release it
by a rule the parties agreed in advance — and the job "category" survives only
as a cosmetic integer tag that consensus never reads.

`docs/escrow-deals.md` (new) carries the full design notes: data model, move
surface, the five settlement modes, the settlement algebra and its invariants,
the sweep, and what is deliberately out of scope.

### Settlement properties, all test-pinned

- Each party bears the protocol tax and the arbiter fee on its **own transacted
  share**, so fee incidence tracks payout share.
- Escrow is conserved exactly: every path either pays out or refunds the full
  pot, with division dust burned, never redistributed.
- `tax_bps`, `fee_bps` and the reaction window are snapshot at post, so a
  governance retune can never change an in-flight deal.
- A late confirm, or an arbiter-bound dispute, inside the reaction window pushes
  the deadline to `now + W` — at most twice — so the successor move always keeps
  a full window to answer.

Bounding is by **admission control at the door** (global and per-poster caps,
runtime-tunable through #202, `0` freezes posting) rather than a sweep cap: a
sweep bound would change settlement semantics for rows already on the board,
whereas a rejected post never existed.

### What it deliberately does not have

- **No settled-jobs history.** A terminal transition deletes the row. Per-deal
  retention belongs to one general archival mechanism, not a table bespoke to
  this feature; `docs/escrow-deals.md` §10 records exactly what a settled record
  needs to carry so it can be added without re-deriving it. The aggregate
  reputation counters in `account.proto` survive the deletion.
- **No pagination.** `getjobs` returns the board like `getbuildings` does; the
  board is bounded by the admission caps, not a response limit.
- **No per-type abstraction.** The board carries escrow deals and nothing else,
  so the code names the deal directly.

Reputation counters are display-only — no consensus rule reads them back. They
are raw tallies, not trust scores: a colluding ring can wash-trade its own deals
for the price of the burn, which is why value-weighted counters sit alongside
the counts. Ghosting an arbiter is deliberately **not** counted: a post binds an
arbiter unilaterally with no consent step, so a permanent per-account mark would
be inflictable on a non-consenting third party.

### Testing

- 682/682 unit, 158/158 database, 51/51 gametests.
- Four gametest suites cover the end-to-end move wiring, the admission caps, the
  RPC surface and reorg unwinding.
- Additionally exercised end-to-end against a **forked Polygon chain**: the
  reaction-window extension on a late confirm and on an arbiter-bound dispute, a
  ruling inside the extension, a private deal rejecting a sniper then admitting
  its designee, a no-arbiter dispute leaving the deadline unmoved, the sweep
  ghost-splitting at it, cancel refunding the reward less the burned fee, and
  every settlement shape against the poster/worker/arbiter counters.
