### PR TITLE
Evaluate forks on the chain height, not the superblock height

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -42,7 +42,11 @@ Context::RefreshInstances ()
 {
   params = std::make_unique<pxd::Params> (chain);
   cfg = std::make_unique<pxd::RoConfig> (chain);
-  forks = std::make_unique<ForkHandler> (chain, height);
+  /* Forks are activated at *chain* heights (GameStart at 76'690'000), so they
+     must be evaluated against the real block height and not against the
+     superblock counter, which starts near zero at genesis and would leave
+     every fork inactive forever.  */
+  forks = std::make_unique<ForkHandler> (chain, blockHeight);
 }
 
 unsigned

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -73,6 +73,9 @@ private:
    * The real block height corresponding to the Context.  This tracks the
    * actual chain block height, in contrast to the modified "height" field
    * which tracks the game's virtual pacing (superblocks).
+   *
+   * This is what fork activation is evaluated against, since fork heights
+   * are heights of the underlying chain.
    */
   unsigned blockHeight;
 

--- a/src/forks_tests.cpp
+++ b/src/forks_tests.cpp
@@ -42,16 +42,33 @@ protected:
 TEST_F (ForksTests, IsActive)
 {
   ctx.SetChain (xaya::Chain::REGTEST);
-  ctx.SetHeight (99);
+  ctx.SetBlockHeight (99);
   EXPECT_FALSE (ctx.Forks ().IsActive (Fork::Dummy));
-  ctx.SetHeight (100);
+  ctx.SetBlockHeight (100);
   EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
-  ctx.SetHeight (101);
+  ctx.SetBlockHeight (101);
   EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
 
   ctx.SetChain (xaya::Chain::MAIN);
   EXPECT_FALSE (ctx.Forks ().IsActive (Fork::Dummy));
-  ctx.SetHeight (3'000'000);
+  ctx.SetBlockHeight (3'000'000);
+  EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
+}
+
+/* Forks are keyed to heights of the underlying chain, while Context::Height ()
+   is the superblock counter and starts back at one for every game.  Activation
+   must therefore follow the block height alone, no matter how far the two have
+   drifted apart.  */
+TEST_F (ForksTests, FollowsChainHeightNotSuperblockHeight)
+{
+  ctx.SetChain (xaya::Chain::REGTEST);
+
+  ctx.SetHeight (1'000'000);
+  ctx.SetBlockHeight (99);
+  EXPECT_FALSE (ctx.Forks ().IsActive (Fork::Dummy));
+
+  ctx.SetHeight (1);
+  ctx.SetBlockHeight (100);
   EXPECT_TRUE (ctx.Forks ().IsActive (Fork::Dummy));
 }
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -467,7 +467,7 @@ protected:
 
 TEST_F (GameStartTests, Before)
 {
-  ctx.SetHeight (99);
+  ctx.SetBlockHeight (99);
   accounts.CreateNew ("domob")->AddBalance (100);
 
   ProcessWithBurn (R"([
@@ -490,12 +490,32 @@ TEST_F (GameStartTests, Before)
 
 TEST_F (GameStartTests, After)
 {
-  ctx.SetHeight (100);
+  ctx.SetBlockHeight (100);
   Process (R"([
     {"name": "domob", "move": {"a": {"init": {"faction": "r"}}}}
   ])");
 
   auto a = accounts.GetByName ("domob");
+  EXPECT_TRUE (a->IsInitialised ());
+  EXPECT_EQ (a->GetFaction (), Faction::RED);
+}
+
+/* This is the production situation with superblocks:  the fork height is a
+   height of the underlying chain, which is long past, while ctx.Height () is
+   the superblock counter and is still tiny.  Gating gameplay on the latter
+   silently swallowed every move but coin operations - accounts were created
+   uninitialised and faction registration never completed.  */
+TEST_F (GameStartTests, ActiveWhileTheSuperblockCounterIsStillLow)
+{
+  ctx.SetBlockHeight (1'000);
+  ctx.SetHeight (1);
+
+  Process (R"([
+    {"name": "domob", "move": {"a": {"init": {"faction": "r"}}}}
+  ])");
+
+  auto a = accounts.GetByName ("domob");
+  ASSERT_NE (a, nullptr);
   EXPECT_TRUE (a->IsInitialised ());
   EXPECT_EQ (a->GetFaction (), Faction::RED);
 }


### PR DESCRIPTION
## The problem

Since superblocks landed (`2a43af5`), `Context::Height ()` is the **superblock counter**, which starts at one for a fresh game state. `Context::RefreshInstances ()` still builds the `ForkHandler` from it:

```cpp
forks = std::make_unique<ForkHandler> (chain, height);
```

But fork activation heights are heights of the **underlying chain** — `Fork::GameStart` is `76'690'000` on main. So on a fresh sync the superblock counter is in the hundreds while the fork wants tens of millions, `IsActive (GameStart)` is false on every block, and `MoveProcessor::ProcessOne` returns at:

```cpp
  TryCoinOperation (name, mv, burnt);

  /* At this point, we terminate if the game-play itself has not started. */
  if (!ctx.Forks ().IsActive (Fork::GameStart))
    return;
```

Coin operations keep working. Account initialisation, character creation, buildings, services and the DEX are all silently discarded — no error, no warning, valid moves simply have no effect.

## How it showed up

Registration hangs on a downstream deployment carrying these commits. The client submits `{"a": {"init": {"faction": "r"}}}` and polls for the faction until it gives up. The GSP log shows the move arriving and being half-processed:

```
moveprocessor.cpp:1274] Processing 1 moves...
moveprocessor.cpp:1316] Creating uninitialised account for kostike
```

and no `Initialised account …` line ever follows. That pair — account created, never initialised — is the fingerprint.

Anyone hit by this can unblock a node immediately with `--fork_height_gamestart=0`, but the state it produces is not what a corrected sync produces, so a resync is still needed.

## The fix

Evaluate forks against `blockHeight`. Forks are activations on the underlying chain; only pace-based durations (movement, combat, ongoings, service times) belong to `Height ()`.

## Why the tests did not catch it

`ForksTests` and `GameStartTests` drive fork activation through `ContextForTesting::SetHeight` — the field whose meaning changed — and never set the two heights to different values, so no test could tell them apart. Both now use `SetBlockHeight`, and two added tests pin the case where the counters have drifted:

- `ForksTests.FollowsChainHeightNotSuperblockHeight`
- `GameStartTests.ActiveWhileTheSuperblockCounterIsStillLow`

## Verification

Verified on a downstream branch that carries `bf09e4f`/`e251f63`/`7bacc45` (this repo's superblock commits, cherry-picked) built against libxayagame 1.0.2:

- with the fix: **628 tests, 622 passed** — the failures are a pre-existing set unrelated to this change
- with only `context.cpp` reverted and the tests kept: **4 of 5** of the fork tests fail

I was not able to build `master` itself in that environment: `mapdata` needs the `data/*.dat.xz` blobs, which are not in the repo, and `master` expects the newer CMake-built libxayagame. Both are unrelated to this change, but it means the numbers above come from the downstream branch rather than from `master`.
